### PR TITLE
Attempt to fix System limit for number of file watchers reached

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          start: CHOKIDAR_USEPOLLING=true yarn dev
+          start: CI=true yarn dev
           wait-on: 'http://localhost:3000'
           project: ./packages/app
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          start: yarn dev
+          start: CHOKIDAR_USEPOLLING=true yarn dev
           wait-on: 'http://localhost:3000'
           project: ./packages/app
         env:


### PR DESCRIPTION
The e2e are failing often with the error System limit for number of file watchers reached.

This is an attempt to fix it.