### PR TITLE
chore(bump): bump package versions

### DIFF
--- a/plugins/backstage-plugin-aws-lambda/package.json
+++ b/plugins/backstage-plugin-aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-aws-lambda",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-plugin-datadog/package.json
+++ b/plugins/backstage-plugin-datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-datadog",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-plugin-github-insights/package.json
+++ b/plugins/backstage-plugin-github-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-github-insights",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/backstage-plugin-github-pull-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-github-pull-requests",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-plugin-jira/package.json
+++ b/plugins/backstage-plugin-jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-jira",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bumping package versions to release updates to plugins from this change: https://github.com/RoadieHQ/roadie-backstage-plugins/commit/e56b75d9a131c353695e8e561c48f52dda8aee2a