### PR TITLE
Modify severity levels in app config

### DIFF
--- a/plugins/backstage-plugin-security-insights/README.md
+++ b/plugins/backstage-plugin-security-insights/README.md
@@ -113,13 +113,12 @@ const overviewContent = (
 );
 
 ```
-4. Per default, all severity level alerts will be included and shown on the widget. However, severity level for dependabot alerts shown in Dependabot alerts widget is configurable via app-config. For example, if you want to show only high severity alerts, you can do it in the following way.
+4. Per default, all severity level alerts will be included and shown on the widget. However, severity level for dependabot alerts shown in Dependabot alerts widget is configurable via app-config. For example, if you want to show only high and medium severity alerts, you can do it in the following way.
 
 ```yaml
 // app-config.yaml
 dependabotAlertsConfiguration: 
-   alerts:
-    - severity: high
+  severity: [ high, medium]
 ``` 
 
 ## Features

--- a/plugins/backstage-plugin-security-insights/config.d.ts
+++ b/plugins/backstage-plugin-security-insights/config.d.ts
@@ -21,12 +21,10 @@ export interface Config {
          *
          * @visibility frontend
          */
-        alerts?: Array<{
-            /**
-             * 
-             * @visibility frontend
-             */
-            severity: string;
-        }>;
+        /**
+         *
+         * @items.visibility frontend
+         */
+        severity: string[]
     };
 }

--- a/plugins/backstage-plugin-security-insights/package.json
+++ b/plugins/backstage-plugin-security-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-security-insights",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
+++ b/plugins/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
@@ -89,8 +89,7 @@ type DependabotAlertsProps = {
 export const DependabotAlertInformations: FC<DependabotAlertsProps> = ({ repository, detailsUrl }) => {
   const classes = useStyles();
   const configApi = useApi(configApiRef);
-  const configSeverityLevel = configApi.getOptionalConfigArray('dependabotAlertsConfiguration.alerts') ?? [];
-  const minimumConfiguredSeverities = configSeverityLevel.map(c => c?.getOptionalString('severity')) ?? ['all'];
+  const minimumConfiguredSeverities = configApi?.getOptionalStringArray('dependabotAlertsConfiguration.severity') ?? ['all'];
 
   // Filter issues so only open issues are taken into cosideration
   const all = repository.vulnerabilityAlerts.nodes.filter((entry) => entry.dismissedAt === null) || null;


### PR DESCRIPTION
I introduced a change in the way we store severity level in app-config. I think it makes more sense to store severity levels as an array, than create separate object in an array of alerts for every severity level