### PR TITLE
per cluster argo support

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -136,4 +136,8 @@ catalog:
       rules:
         - allow: [Template]
 argocd:
-  baseUrl: https://localhost:8080
+  # baseUrl: https://localhost:8080
+  username: ${ARGOCD_USERNAME}
+  password: ${ARGOCD_PASSWORD}
+  perCluster:
+    enabled: true

--- a/plugins/backstage-plugin-argo-cd/.eslintrc.js
+++ b/plugins/backstage-plugin-argo-cd/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
     // causing this issue but one of them is. Eventually the @backstage eslint config will
     // be updated to support V3 of @typescript-eslint and this rule can be defaulted.
     '@typescript-eslint/camelcase': 0,
+    'no-console': [0],
   },
 };

--- a/plugins/backstage-plugin-argo-cd/README.md
+++ b/plugins/backstage-plugin-argo-cd/README.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-- 
+-
 
 ## How to add argo-cd project dependency to Backstage app
 
@@ -53,7 +53,7 @@ export { argocdPlugin } from '@roadiehq/backstage-plugin-argo-cd';
 // packages/app/src/components/catalog/EntityPage.tsx
 import {
   EntityArgoCDHistoryCard,
-  isArgocdAvailable
+  isArgocdAvailable,
 } from '@roadiehq/backstage-plugin-argo-cd';
 
 const overviewContent = (
@@ -63,8 +63,8 @@ const overviewContent = (
       <EntitySwitch.Case if={e => Boolean(isArgocdAvailable(e))}>
         <Grid item sm={6}>
           <EntityArgoCDHistoryCard />
-        </Grid> 
-      </EntitySwitch.Case> 
+        </Grid>
+      </EntitySwitch.Case>
     </EntitySwitch>
     ...
   </Grid>
@@ -76,20 +76,25 @@ const overviewContent = (
 The Argo CD plugin is a part of the Backstage sample app. To start using it for your component, you have to:
 
 1. Add an annotation to the YAML config file of a component. If there is only a single Argo CD application for the component, you can use
-    ```yml
-    argocd/app-name: <app-name>
-    ```
-    You can also use labels to select multiple Argo CD applications for a component:
-    ```yml
-    argocd/app-selector: <app-selector>
-    ```
-    **Note:** You can only use one of the options per component.
+
+   ```yml
+   argocd/app-name: <app-name>
+   ```
+
+   You can also use labels to select multiple Argo CD applications for a component:
+
+   ```yml
+   argocd/app-selector: <app-selector>
+   ```
+
+   **Note:** You can only use one of the options per component.
 
 2. Add your auth key to the environmental variables for your backstage backend server (you can acquire it by sending a GET HTTP request to Argo CD's `/session` endpoint with username and password):
-    ```
-    ARGOCD_AUTH_TOKEN="argocd.token=<auth-token>"
-    ```
-## Support for multiple ArgoCD instances
+   ```
+   ARGOCD_AUTH_TOKEN="argocd.token=<auth-token>"
+   ```
+
+## Support for multiple ArgoCD instances - Option 1
 
 If you want to create multiple components that fetch data from different argoCD instances, you have to add a proxy config for each instance:
 
@@ -113,13 +118,49 @@ proxy:
       Cookie:
         $env: ARGOCD_AUTH_TOKEN2
 ```
+
 Add all required auth tokens to environmental variables, in this example, `ARGOCD_AUTH_TOKEN2`.
 
 And then in the following component definition annotations add a line with the url to the desired proxy path:
+
 ```yml
 argocd/proxy-url: '/argocd/api2'
 ```
+
 `argocd/proxy-url` annotation defaults to '/argocd/api' so it's not needed if there is only one proxy config.
+
+## Support for multiple ArgoCD instances - Option 2 - Kubernetes Plugin
+
+If you want to create multiple components that fetch data from different argoCD instances, you can dynamically set the ArgoCD instance url by adding the following to your app-config.yaml files.
+
+Ensure you are using the Kubernetes backstage plugins. The Argo plugin will fetch the clusters an app is deployed to and use the argocd-backend plugin to reach out to each Argo instance based on the mapping mentioned below.
+
+```yml
+argocd:
+  username: ${ARGOCD_USERNAME}
+  password: ${ARGOCD_PASSWORD}
+  perCluster:
+    enabled: true
+```
+
+Add the required auth tokens to environmental variables, `ARGOCD_USERNAME` and `ARGOCD_PASSWORD`.
+
+You can also use an argo session token as mentioned above in the Kubernetes cluster object as shown below. If omitted, we will use the argo username and password from the code block above.
+
+You must set the argoUrl
+
+```yaml
+kubernetes:
+  serviceLocatorMethod:
+    type: 'multiTenant'
+  clusterLocatorMethods:
+    - type: 'config'
+      clusters:
+        - url: https://testCluster.test.com
+          name: lab-cluster
+          argoUrl: https://argocd-server.test.com
+          argoToken: ${ARGOCD_AUTH_TOKEN} # OPTIONAL
+```
 
 ## Develop plugin locally
 

--- a/plugins/backstage-plugin-argo-cd/README.md
+++ b/plugins/backstage-plugin-argo-cd/README.md
@@ -94,9 +94,9 @@ The Argo CD plugin is a part of the Backstage sample app. To start using it for 
    ARGOCD_AUTH_TOKEN="argocd.token=<auth-token>"
    ```
 
-## Support for multiple ArgoCD instances - Option 1
+## Support for multiple Argo CD instances - Option 1
 
-If you want to create multiple components that fetch data from different argoCD instances, you have to add a proxy config for each instance:
+If you want to create multiple components that fetch data from different Argo CD instances, you have to add a proxy config for each instance:
 
 ```yml
 proxy:
@@ -129,11 +129,11 @@ argocd/proxy-url: '/argocd/api2'
 
 `argocd/proxy-url` annotation defaults to '/argocd/api' so it's not needed if there is only one proxy config.
 
-## Support for multiple ArgoCD instances - Option 2 - Kubernetes Plugin
+## Support for multiple Argo CD instances - Option 2 - Kubernetes Plugin
 
-If you want to create multiple components that fetch data from different argoCD instances, you can dynamically set the ArgoCD instance url by adding the following to your app-config.yaml files.
+If you want to create multiple components that fetch data from different Argo CD instances, you can dynamically set the Argo CD instance url by adding the following to your app-config.yaml files.
 
-Ensure you are using the Kubernetes backstage plugins. The Argo plugin will fetch the clusters an app is deployed to and use the argocd-backend plugin to reach out to each Argo instance based on the mapping mentioned below.
+Ensure you are using the Kubernetes backstage plugins. The Argo CD plugin will fetch the clusters an app is deployed to and use the argocd-backend plugin to reach out to each Argo CD instance based on the mapping mentioned below.
 
 ```yml
 argocd:
@@ -145,9 +145,9 @@ argocd:
 
 Add the required auth tokens to environmental variables, `ARGOCD_USERNAME` and `ARGOCD_PASSWORD`.
 
-You can also use an argo session token as mentioned above in the Kubernetes cluster object as shown below. If omitted, we will use the argo username and password from the code block above.
+You can also use an Argo CD session token as mentioned above in the Kubernetes cluster object as shown below. If omitted, we will use the argo username and password from the code block above.
 
-You must set the argoUrl
+You must set the argoUrl.
 
 ```yaml
 kubernetes:

--- a/plugins/backstage-plugin-argo-cd/config.d.ts
+++ b/plugins/backstage-plugin-argo-cd/config.d.ts
@@ -16,11 +16,6 @@ export interface Config {
        * @visibility frontend
        */
       enabled?: boolean;
-      /**
-       * The base url of the ArgoCD instance.
-       * @visibility frontend
-       */
-      pattern?: string;
     };
   };
 }

--- a/plugins/backstage-plugin-argo-cd/config.d.ts
+++ b/plugins/backstage-plugin-argo-cd/config.d.ts
@@ -6,5 +6,21 @@ export interface Config {
      * @visibility frontend
      */
     baseUrl?: string;
+    /**
+     * The base url of the ArgoCD instance.
+     * @visibility frontend
+     */
+    perCluster?: {
+      /**
+       * The base url of the ArgoCD instance.
+       * @visibility frontend
+       */
+      enabled?: boolean;
+      /**
+       * The base url of the ArgoCD instance.
+       * @visibility frontend
+       */
+      pattern?: string;
+    };
   };
 }

--- a/plugins/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
+++ b/plugins/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
@@ -27,16 +27,13 @@ import {
   Table,
   TableColumn,
 } from '@backstage/core-components';
-import {
-  configApiRef,
-  useApi,
-} from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import ErrorBoundary from './ErrorBoundary';
 import { isArgocdAvailable } from '../Router';
 import { ArgoCDAppDetails, ArgoCDAppList } from '../types';
 import { useAppDetails } from './useAppDetails';
 import SyncIcon from '@material-ui/icons/Sync';
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 const getElapsedTime = (start: string) => {
   return moment(start).fromNow();
@@ -73,17 +70,34 @@ type OverviewComponentProps = {
   retry: () => void;
 };
 
-const OverviewComponent = ({ data, extraColumns, retry }: OverviewComponentProps) => {
+const OverviewComponent = ({
+  data,
+  extraColumns,
+  retry,
+}: OverviewComponentProps) => {
   const configApi = useApi(configApiRef);
-  const baseUrl = configApi.getOptionalString('argocd.baseUrl')
+  const baseUrl = configApi.getOptionalString('argocd.baseUrl');
 
   const columns: TableColumn[] = [
     {
       title: 'Name',
       highlight: true,
-      render: (row: any): React.ReactNode => (
-        baseUrl ? <Link href={`${baseUrl}/applications/${row.metadata.name}`} target="_blank" rel="noopener">{row.metadata.name}</Link> : row.metadata.name
-      ),
+      render: (row: any): React.ReactNode =>
+        baseUrl ? (
+          <Link
+            href={`${baseUrl}/applications/${row.metadata.name}`}
+            target="_blank"
+            rel="noopener"
+          >
+            {row.metadata.name}
+          </Link>
+        ) : (
+          row.metadata.name
+        ),
+    },
+    {
+      title: 'Cluster',
+      render: (row: any): React.ReactNode => row.metadata.cluster,
     },
     {
       title: 'Sync Status',
@@ -128,7 +142,13 @@ const OverviewComponent = ({ data, extraColumns, retry }: OverviewComponentProps
   );
 };
 
-const ArgoCDDetails = ({ entity, extraColumns }: { entity: Entity, extraColumns: TableColumn[] }) => {
+const ArgoCDDetails = ({
+  entity,
+  extraColumns,
+}: {
+  entity: Entity;
+  extraColumns: TableColumn[];
+}) => {
   const { url, appName, appSelector, projectName } = useArgoCDAppData({
     entity,
   });
@@ -154,12 +174,36 @@ const ArgoCDDetails = ({ entity, extraColumns }: { entity: Entity, extraColumns:
   }
   if (value) {
     if ((value as ArgoCDAppList).items !== undefined) {
-      return <OverviewComponent data={value as ArgoCDAppList} retry={retry} extraColumns={extraColumns} />;
+      return (
+        <OverviewComponent
+          data={value as ArgoCDAppList}
+          retry={retry}
+          extraColumns={extraColumns}
+        />
+      );
+    }
+    if (value as Array<ArgoCDAppDetails>) {
+      const wrapped: ArgoCDAppList = {
+        items: value as Array<ArgoCDAppDetails>,
+      };
+      return (
+        <OverviewComponent
+          data={wrapped}
+          retry={retry}
+          extraColumns={extraColumns}
+        />
+      );
     }
     const wrapped: ArgoCDAppList = {
       items: [value as ArgoCDAppDetails],
     };
-    return <OverviewComponent data={wrapped} retry={retry} extraColumns={extraColumns} />;
+    return (
+      <OverviewComponent
+        data={wrapped}
+        retry={retry}
+        extraColumns={extraColumns}
+      />
+    );
   }
   return null;
 };
@@ -167,7 +211,7 @@ const ArgoCDDetails = ({ entity, extraColumns }: { entity: Entity, extraColumns:
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
-  extraColumns?: TableColumn[]
+  extraColumns?: TableColumn[];
 };
 
 export const ArgoCDDetailsCard = (props: Props) => {

--- a/plugins/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
+++ b/plugins/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
@@ -52,6 +52,7 @@ const HistoryTable = ({
           return app.status.history.map(entry => {
             return {
               app: app.metadata.name,
+              cluster: app.metadata.cluster,
               ...entry,
             };
           });
@@ -78,8 +79,13 @@ const HistoryTable = ({
       highlight: true,
     },
     {
+      title: 'Cluster',
+      render: (row: any): React.ReactNode => row.cluster,
+    },
+    {
       title: 'Deploy Started',
       field: 'deployStartedAt',
+      defaultSort: 'desc',
       render: (row: any) => (
         <Tooltip
           title={
@@ -125,6 +131,7 @@ const HistoryTable = ({
         search: false,
         draggable: false,
         padding: 'dense',
+        sorting: true,
       }}
       data={history}
       columns={columns}
@@ -168,6 +175,12 @@ const ArgoCDHistory = ({ entity }: { entity: Entity }) => {
   if (value) {
     if ((value as ArgoCDAppList).items !== undefined) {
       return <HistoryTable data={value as ArgoCDAppList} retry={retry} />;
+    }
+    if (value as Array<ArgoCDAppDetails>) {
+      const wrapped: ArgoCDAppList = {
+        items: value as Array<ArgoCDAppDetails>,
+      };
+      return <HistoryTable data={wrapped} retry={retry} />;
     }
     const wrapped: ArgoCDAppList = {
       items: [value as ArgoCDAppDetails],

--- a/plugins/backstage-plugin-argo-cd/src/mocks/mocks.ts
+++ b/plugins/backstage-plugin-argo-cd/src/mocks/mocks.ts
@@ -83,6 +83,7 @@ export const getResponseStubMissingData = {
 export const getResponseStub = {
   metadata: {
     name: 'guestbook',
+    cluster: 'testCluster',
     namespace: 'argocd',
     selfLink:
       '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
@@ -219,10 +220,10 @@ export const getResponseStub = {
 
 export const getEmptyResponseStub = {
   metadata: {
-    resourceVersion: '7277391'
+    resourceVersion: '7277391',
   },
-  items: null
-}
+  items: null,
+};
 
 export class ArgoCDApiMock implements ArgoCDApi {
   // @ts-ignore

--- a/plugins/backstage-plugin-argo-cd/src/plugin.test.tsx
+++ b/plugins/backstage-plugin-argo-cd/src/plugin.test.tsx
@@ -49,7 +49,6 @@ const apis = ApiRegistry.from([
       argocd: {
         perCluster: {
           enabled: true,
-          pattern: 'https://argocd-CLUSTER.test.com',
         },
       },
       kubernetes: {
@@ -152,7 +151,6 @@ describe('argo-cd', () => {
             baseUrl: 'www.example-argocd-url.com',
             perCluster: {
               enabled: true,
-              pattern: 'https://argocd-CLUSTER.test.com',
             },
           },
           kubernetes: {

--- a/plugins/backstage-plugin-argo-cd/src/plugin.ts
+++ b/plugins/backstage-plugin-argo-cd/src/plugin.ts
@@ -1,4 +1,5 @@
 import {
+  configApiRef,
   createApiFactory,
   createComponentExtension,
   createPlugin,
@@ -17,8 +18,16 @@ export const argocdPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: argoCDApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new ArgoCDApiClient({ discoveryApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+      },
+      factory: ({ discoveryApi, configApi }) =>
+        new ArgoCDApiClient({
+          discoveryApi: discoveryApi,
+          backendBaseUrl: configApi.getString('backend.baseUrl'),
+          perCluster: configApi.getBoolean('argo.perCluster.enabled'),
+        }),
     }),
   ],
   routes: {
@@ -28,29 +37,25 @@ export const argocdPlugin = createPlugin({
 
 export const EntityArgoCDContent = argocdPlugin.provide(
   createRoutableExtension({
-    component: () => import('./Router').then((m) => m.Router),
+    component: () => import('./Router').then(m => m.Router),
     mountPoint: entityContentRouteRef,
-  })
+  }),
 );
 
 export const EntityArgoCDOverviewCard = argocdPlugin.provide(
   createComponentExtension({
     component: {
       lazy: () =>
-        import('./components/ArgoCDDetailsCard').then(
-          (m) => m.ArgoCDDetailsCard
-        ),
+        import('./components/ArgoCDDetailsCard').then(m => m.ArgoCDDetailsCard),
     },
-  })
+  }),
 );
 
 export const EntityArgoCDHistoryCard = argocdPlugin.provide(
   createComponentExtension({
     component: {
       lazy: () =>
-        import('./components/ArgoCDHistoryCard').then(
-          (m) => m.ArgoCDHistoryCard
-        ),
+        import('./components/ArgoCDHistoryCard').then(m => m.ArgoCDHistoryCard),
     },
-  })
+  }),
 );

--- a/plugins/backstage-plugin-argo-cd/src/types.ts
+++ b/plugins/backstage-plugin-argo-cd/src/types.ts
@@ -1,7 +1,10 @@
 import * as t from 'io-ts';
 
 export const argoCDAppDetails = t.type({
-  metadata: t.type({ name: t.string }),
+  metadata: t.type({
+    name: t.string,
+    cluster: t.union([t.string, t.undefined]),
+  }),
   status: t.type({
     sync: t.type({
       status: t.string,
@@ -12,12 +15,14 @@ export const argoCDAppDetails = t.type({
     operationState: t.type({
       finishedAt: t.string,
     }),
-    history: t.array(t.type({
-      id: t.number,
-      revision: t.string,
-      deployStartedAt: t.union([t.string, t.undefined]),
-      deployedAt: t.union([t.string, t.undefined]),
-    })),
+    history: t.array(
+      t.type({
+        id: t.number,
+        revision: t.string,
+        deployStartedAt: t.union([t.string, t.undefined]),
+        deployedAt: t.union([t.string, t.undefined]),
+      }),
+    ),
   }),
 });
 


### PR DESCRIPTION
This is to continue the discussion that I had with @Xantier . This is only the frontend. Once we agree on a approach, if it's something willing to be accepted or continued to be worked on, then we can continue to the backend that we built, but have not yet published as open source.

We install Argo CD on every cluster. We chose the approach of using the existing kubernetes block in the app-config.yaml files so that we did not duplicate information. Since each argo cd instance uses different tokens, we're using a username and password across all clusters and generating the token using the backend we created (to be discussed). That user can be synced with LDAP or something similar using argocd native functionality, but we did not want to keep track of many different tokens per cluster. This makes it dynamic and when we rotate credentials we can update in a single spot.

This solution unfortunately tightly couples this plugin to the kubernetes plugins from backstage, but it makes the finding of an application dynamic. There is a little extra work to be done if using selectors, as we don't use that internally but probably should.

We are running this code internally at this time, but this is the initial approach to get us over the problems we faced when additional clusters were enabled.

Resolves #193

