### PR TITLE
Add Github templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,38 @@
+---
+name: 'Bug Report'
+about: 'Create Bug Report'
+labels: kind/bug
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+
+<!--- Tell us what should happen -->
+
+## Current Behavior
+
+<!--- Tell us what happens instead of the expected behavior -->
+
+
+## Steps to Reproduce
+
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code or configuration to reproduce, if relevant -->
+
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas as to the implementation of the addition or change -->
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context (e.g. links to configuration settings, -->
+<!--- stack trace or log data) helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+
+- `@backstage/catalog-react` version:
+- `@backstage/integrations` version:

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -1,0 +1,21 @@
+---
+name: 'Feature Request'
+about: 'Suggest new features and changes'
+labels: kind/enhancement
+---
+
+<!--- Provide a general summary of the feature request in the Title above -->
+
+## Feature Suggestion
+
+<!--- Tell us how we could improve your experience -->
+
+## Possible Implementation
+
+<!--- Not obligatory, but ideas as to the implementation of the addition or change -->
+
+## Context
+
+<!--- What are you trying to accomplish? -->
+<!--- Providing context (e.g. links to configuration settings, stack trace or log data) -->
+<!--- helps us come up with a solution that is most useful in the real world -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!-- Please describe what these changes achieve -->
+
+#### :heavy_check_mark: Checklist
+
+- [ ] Added tests for new functionality and regression tests for bug fixes
+- [ ] Screenshots of before and after attached (for UI changes)
+- [ ] Added or updated documentation (if applicable)


### PR DESCRIPTION
This PR adds basic templates for Github issues and pull requests to
guide users in what information we need from them from the start.

This hopefully avoids having us asking for more information in issues so
oftern.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)