### PR TITLE
Export PRTable as Component and grab Entity from EntityContext

### DIFF
--- a/plugins/backstage-plugin-github-pull-requests/src/components/PullRequestsPage/PullRequestsPage.tsx
+++ b/plugins/backstage-plugin-github-pull-requests/src/components/PullRequestsPage/PullRequestsPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import { Grid } from '@material-ui/core';
 import {
   Page,
@@ -25,7 +25,12 @@ import {
 import { PullRequestsTable } from '../PullRequestsTable';
 import { Entity } from '@backstage/catalog-model';
 
-const PullRequestsPage: FC<{ entity: Entity }> = ({ entity }) => (
+type Props = {
+  /** @deprecated The entity is now grabbed from context instead */
+  entity?: Entity;
+};
+
+const PullRequestsPage = (__props: Props) => (
   <Page themeId="tool">
     <Content>
       <ContentHeader title="Pull requests plugin">
@@ -35,7 +40,7 @@ const PullRequestsPage: FC<{ entity: Entity }> = ({ entity }) => (
       </ContentHeader>
       <Grid container spacing={3} direction="column">
         <Grid item>
-          <PullRequestsTable entity={entity} />
+          <PullRequestsTable />
         </Grid>
       </Grid>
     </Content>

--- a/plugins/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.test.tsx
+++ b/plugins/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.test.tsx
@@ -16,14 +16,8 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import {
-  configApiRef,
-  githubAuthApiRef,
-} from '@backstage/core-plugin-api';
-import {
-  ApiRegistry,
-  ApiProvider
-} from '@backstage/core-app-api';
+import { configApiRef, githubAuthApiRef } from '@backstage/core-plugin-api';
+import { ApiRegistry, ApiProvider } from '@backstage/core-app-api';
 import { rest } from 'msw';
 import { msw } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
@@ -31,6 +25,7 @@ import { githubPullRequestsApiRef } from '../..';
 import { GithubPullRequestsClient } from '../../api';
 import { entityMock, openPullsRequestMock } from '../../mocks/mocks';
 import { PullRequestsTable } from './PullRequestsTable';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
 
 const mockGithubAuth = {
   getAccessToken: async (_: string[]) => 'test-token',
@@ -64,7 +59,9 @@ describe('PullRequestsTable', () => {
   it('should display a table with data from requests', async () => {
     const rendered = render(
       <ApiProvider apis={apis}>
-        <PullRequestsTable entity={entityMock} />
+        <EntityProvider entity={entityMock}>
+          <PullRequestsTable />
+        </EntityProvider>
       </ApiProvider>,
     );
     expect(

--- a/plugins/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
+++ b/plugins/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
@@ -22,6 +22,7 @@ import { usePullRequests, PullRequest } from '../usePullRequests';
 import { PullRequestState } from '../../types';
 import { Entity } from '@backstage/catalog-model';
 import { getStatusIconType } from '../Icons';
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 const generatedColumns: TableColumn[] = [
   {
@@ -139,12 +140,14 @@ export const PullRequestsTableView: FC<Props> = ({
   );
 };
 
-export const PullRequestsTable = ({
-  entity,
-}: {
-  entity: Entity;
+type TableProps = {
+  /** @deprecated The entity is now grabbed from context instead */
+  entity?: Entity;
   branch?: string;
-}) => {
+};
+
+export const PullRequestsTable = (__props: TableProps) => {
+  const { entity } = useEntity();
   const [PRStatusFilter, setPRStatusFilter] = useState<PullRequestState>(
     'open',
   );

--- a/plugins/backstage-plugin-github-pull-requests/src/components/Router.tsx
+++ b/plugins/backstage-plugin-github-pull-requests/src/components/Router.tsx
@@ -37,7 +37,7 @@ export const Router = (_props: Props) =>{
     <MissingAnnotationEmptyState annotation={GITHUB_PULL_REQUESTS_ANNOTATION} />
   ) : (
     <FlatRoutes>
-      <Route path="/" element={<PullRequestsPage entity={entity} />} />
+      <Route path="/" element={<PullRequestsPage />} />
     </FlatRoutes>
   );
 }

--- a/plugins/backstage-plugin-github-pull-requests/src/plugin.ts
+++ b/plugins/backstage-plugin-github-pull-requests/src/plugin.ts
@@ -55,3 +55,14 @@ export const EntityGithubPullRequestsOverviewCard = githubPullRequestsPlugin.pro
     },
   }),
 );
+
+export const EntityGithubPullRequestsTable = githubPullRequestsPlugin.provide(
+  createComponentExtension({
+    component: {
+      lazy: () =>
+        import('./components/PullRequestsTable').then(
+          m => m.PullRequestsTable,
+        ),
+    },
+  }),
+);


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
- Export PullRequestsTable as `ComponentExtension`
- Use useEntity()` to fetch entity data for `PullRequestsTable`
- Update PullRequestTable test file
#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
