### PR TITLE
Update token used in Update Dependancies workflow so checks run on PR

### DIFF
--- a/.github/workflows/weekly-check-versions.yml
+++ b/.github/workflows/weekly-check-versions.yml
@@ -24,7 +24,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN  }}
+          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN  }}
           commit-message: Update dependencies
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Updates the token used to create a PR to the roadie-bot PAT so that checks can run on the resulting PR, as otherwise they will not be triggered when using the standard Github token. 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
