### PR TITLE
Deprecation: `description` will no longer be supported in `createApiRef`

### DIFF
--- a/.changeset/shaggy-ties-invent.md
+++ b/.changeset/shaggy-ties-invent.md
@@ -1,0 +1,13 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+'@roadiehq/backstage-plugin-aws-lambda': patch
+'@roadiehq/backstage-plugin-bugsnag': patch
+'@roadiehq/backstage-plugin-buildkite': patch
+'@roadiehq/backstage-plugin-datadog': patch
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+'@roadiehq/backstage-plugin-jira': patch
+'@roadiehq/backstage-plugin-prometheus': patch
+'@roadiehq/backstage-plugin-travis-ci': patch
+---
+
+Removed deprecated `description` option from `ApiRefConfig` for all plugins

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -30,7 +30,6 @@ export interface ArgoCDApi {
 
 export const argoCDApiRef = createApiRef<ArgoCDApi>({
   id: 'plugin.argocd.service',
-  description: 'Used by the ArgoCD plugin to make requests',
 });
 
 export type Options = {

--- a/plugins/frontend/backstage-plugin-aws-lambda/src/api/AWSLambdaApi.ts
+++ b/plugins/frontend/backstage-plugin-aws-lambda/src/api/AWSLambdaApi.ts
@@ -19,7 +19,6 @@ import { LambdaData } from '../types';
 
 export const awsLambdaApiRef = createApiRef<AwsLambdaApi>({
   id: 'plugin.awslambda.service',
-  description: 'Used by the AWS lambda plugin to make requests',
 });
 
 export type AwsLambdaApi = {

--- a/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagApi.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagApi.ts
@@ -19,7 +19,6 @@ import { BugsnagError, Organisation, Project } from './types';
 
 export const bugsnagApiRef = createApiRef<BugsnagApi>({
   id: 'plugin.bugsnag.service',
-  description: 'Used by the Bugsnag plugin to make requests',
 });
 
 export interface BugsnagApi {

--- a/plugins/frontend/backstage-plugin-buildkite/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/api/index.ts
@@ -18,7 +18,6 @@ import { createApiRef, DiscoveryApi } from '@backstage/core-plugin-api';
 
 export const buildKiteApiRef = createApiRef<BuildkiteApi>({
   id: 'plugin.buildkite.service',
-  description: 'Used by the Buildkite plugin to make requests',
 });
 
 const DEFAULT_PROXY_PATH = '/buildkite/api';

--- a/plugins/frontend/backstage-plugin-datadog/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-datadog/src/api/index.ts
@@ -4,7 +4,6 @@ export interface DatadogApi {}
 
 export const datadogApiRef = createApiRef<DatadogApi>({
   id: 'plugin.datadog.service',
-  description: 'Used by the Datadog plugin to make requests',
 });
 
 export type Options = {

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsApi.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsApi.ts
@@ -20,7 +20,6 @@ import { PullRequestState } from '../types';
 
 export const githubPullRequestsApiRef = createApiRef<GithubPullRequestsApi>({
   id: 'plugin.githubpullrequests.service',
-  description: 'Used by the Github Pull Requests plugin to make requests',
 });
 
 export type GithubPullRequestsApi = {

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.ts
@@ -20,7 +20,6 @@ import fetch from 'cross-fetch';
 
 export const jiraApiRef = createApiRef<JiraAPI>({
   id: 'plugin.jira.service',
-  description: 'Used by the Jira plugin to make requests',
 });
 
 const DEFAULT_PROXY_PATH = '/jira/api';

--- a/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
@@ -25,7 +25,6 @@ const DEFAULT_PROXY_PATH = '/prometheus/api';
 
 export const prometheusApiRef = createApiRef<PrometheusApi>({
   id: 'plugin.prometheus.service',
-  description: 'Used by the Prometheus plugin to make requests',
 });
 
 type Options = {

--- a/plugins/frontend/backstage-plugin-travis-ci/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-travis-ci/src/api/index.ts
@@ -82,7 +82,6 @@ export interface TravisCIApi {
 
 export const travisCIApiRef = createApiRef<TravisCIApi>({
   id: 'plugin.travisci.service',
-  description: 'Used by the TravisCI plugin to make requests',
 });
 
 export class TravisCIApiClient implements TravisCIApi {


### PR DESCRIPTION
Hello!

I wanted to bring to your attention that in a future release, the `description` option will no longer be supported in the `createApiRef` method. A list of all deprecations that will soon be removed can be found here: https://github.com/backstage/backstage/issues/8312.

Thanks!

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
