### PR TITLE
Deprecation: core-app-api#createApp to app-defaults#createApp

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "bundled": true,
   "dependencies": {
+    "@backstage/app-defaults": "^0.1.2",
     "@backstage/catalog-model": "^0.9.7",
     "@backstage/core-app-api": "^0.2.0",
     "@backstage/core-components": "^0.8.0",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -36,7 +36,8 @@ import { entityPage } from './components/catalog/EntityPage';
 import { Root } from './components/Root';
 
 import { AlertDisplay, OAuthRequestDialog } from '@backstage/core-components';
-import { createApp, FlatRoutes } from '@backstage/core-app-api';
+import { FlatRoutes } from '@backstage/core-app-api';
+import { createApp } from '@backstage/app-defaults';
 
 const app = createApp({
   apis,


### PR DESCRIPTION
In a future release, the deprecated `createApp` method found in `core-app-api` will be removed and replaced by the version found in `app-defaults`.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
