### PR TITLE
#215:  Enable-multiple-GitHub-integrations-by-extracting-source-location-annotation

### DIFF
--- a/.changeset/ninety-beers-smile.md
+++ b/.changeset/ninety-beers-smile.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': patch
+---
+
+Enable multiple GitHub integrations and extract source location from entity managed annotations backstage.io/managed-by-origin-location or backstage.io/managed-by-location.

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.tsx
@@ -151,7 +151,7 @@ export const DenseTable: FC<DenseTableProps> = ({ repository, detailsUrl }) => {
 
 export const DependabotAlertsTable: FC<{}> = () => {
   const { entity } = useEntity();
-  const { hostname } = useUrl();
+  const { hostname } = useUrl(entity);
   const { owner, repo } = useProjectEntity(entity);
   const auth = useApi(githubAuthApiRef);
 

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
@@ -145,7 +145,7 @@ export const DependabotAlertsWidget = () => {
   const { entity } = useEntity();
   const { owner, repo } = useProjectEntity(entity);
   const auth = useApi(githubAuthApiRef);
-  const { hostname } = useUrl();
+  const { hostname } = useUrl(entity);
 
   const query = `
   query GetDependabotAlertsWidget($name: String!, $owner: String!) {

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
@@ -46,7 +46,7 @@ export const SecurityInsightsTable: FC<SecurityInsightsTabProps> = ({ entity }) 
   const {owner, repo} = useProjectEntity(entity);
   const projectName = useProjectName(entity);
   const auth = useApi(githubAuthApiRef);
-  const { baseUrl } = useUrl();
+  const { baseUrl } = useUrl(entity);
 
   const { value, loading, error } = useAsync(async (): Promise<SecurityInsight[]> => {
     const token = await auth.getAccessToken(['repo']);
@@ -112,6 +112,7 @@ export const SecurityInsightsTable: FC<SecurityInsightsTabProps> = ({ entity }) 
             id={row.number}
             tableData={tableData}
             setTableData={setTableData}
+            entity={entity}
           />
         )
       ),

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsWidget/SecurityInsightsWidget.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsWidget/SecurityInsightsWidget.tsx
@@ -85,7 +85,7 @@ export const SecurityInsightsWidget = (_props: Props) => {
   const { owner, repo } = useProjectEntity(entity);
   const classes = useStyles();
   const auth = useApi(githubAuthApiRef);
-  const { baseUrl, hostname } = useUrl();
+  const { baseUrl, hostname } = useUrl(entity);
 
   const { value, loading, error } = useAsync(async (): Promise<
     SecurityInsight[]

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/UpdateSeverityStatusModal/UpdateSeverityStatusModal.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/UpdateSeverityStatusModal/UpdateSeverityStatusModal.tsx
@@ -60,14 +60,14 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 export const UpdateSeverityStatusModal: FC<UpdateSeverityStatusProps> = ({
-  owner, repo, severityData, id, tableData, setTableData
+  owner, repo, severityData, id, tableData, setTableData, entity
 }) => {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
   const [dismissedReason, setDismissedReason] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const auth = useApi(githubAuthApiRef);
-  const { baseUrl } = useUrl();
+  const { baseUrl } = useUrl(entity);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -96,12 +96,12 @@ export const UpdateSeverityStatusModal: FC<UpdateSeverityStatusProps> = ({
     setTableData(tableData.map(element => (element.number === id ? {...element, state: 'dismissed'} : element)));
     return data;
   }, []);
-  
+
   const getSeverityState = useCallback(
     (severityState: SecurityInsightFilterState) => {
     switch(severityState) {
       case 'open':
-        return (          
+        return (
           <Chip
             label="Open"
             color="primary"
@@ -114,7 +114,7 @@ export const UpdateSeverityStatusModal: FC<UpdateSeverityStatusProps> = ({
           />
         );
       case 'dismissed':
-        return (          
+        return (
           <Chip
             label="Dismissed"
             color="secondary"
@@ -126,7 +126,7 @@ export const UpdateSeverityStatusModal: FC<UpdateSeverityStatusProps> = ({
           />
         );
       case 'fixed':
-        return (          
+        return (
           <Chip
             label="Fixed"
             color="primary"
@@ -136,7 +136,7 @@ export const UpdateSeverityStatusModal: FC<UpdateSeverityStatusProps> = ({
               label: classes.label,
             }}
           />
-        )  ; 
+        )  ;
       default: return 'Unknown';
     }
   }, []);

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/useGitHubConfig.test.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/useGitHubConfig.test.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useGitHubConfig } from "./useGitHubConfig";
+import { GitHubIntegrationConfig } from "../types";
+
+const createGitHubEntity = (originHost: string) => {
+  return {
+    entity: {
+      metadata: {
+        namespace: 'default',
+        annotations: {
+          'github.com/project-slug': 'company/sample-service',
+          'backstage.io/managed-by-location': `url:https://${originHost}/sample-service/blob/master/catalog-info.yaml`
+        },
+        name: 'sample-service',
+        description: 'Sample service'
+      },
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      spec: {
+        type: 'service',
+        lifecycle: 'experimental',
+      },
+      relations: [],
+    },
+  };
+}
+
+const enterpriseGithub: GitHubIntegrationConfig = {
+  host: "git.company.com",
+  apiBaseUrl: "https://git.company.com/api/v3",
+  rawBaseUrl: "https://raw.git.company.com"
+};
+
+const github: GitHubIntegrationConfig = {
+  host: "github.com",
+  apiBaseUrl: "https://api.github.com",
+  rawBaseUrl: "https://raw.github.com"
+};
+
+const getValueFromConfig = (config: GitHubIntegrationConfig, key: string) => {
+  // @ts-ignore
+  return config[ key ]
+}
+
+const config = {
+  getOptionalConfigArray: (_: string) => [
+    {getOptionalString: (key: string) => getValueFromConfig(github, key)},
+    {getOptionalString: (key: string) => getValueFromConfig(enterpriseGithub, key)}
+  ],
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => {
+    return config;
+  }
+}));
+
+describe('useGitHubConfig', () => {
+
+  it('should match github enterprise config based on the catalog entity location', () => {
+
+    const githubEnterpriseEntity = createGitHubEntity('git.company.com');
+    const matchedConfig = useGitHubConfig(githubEnterpriseEntity.entity);
+
+    expect(matchedConfig).toBeDefined();
+    expect(matchedConfig?.getOptionalString('host')).toBe(enterpriseGithub.host);
+    expect(matchedConfig?.getOptionalString('apiBaseUrl')).toBe(enterpriseGithub.apiBaseUrl);
+    expect(matchedConfig?.getOptionalString('rawBaseUrl')).toBe(enterpriseGithub.rawBaseUrl);
+  });
+
+  it('should match github config based on the catalog entity location', () => {
+
+    const gitHubEntity = createGitHubEntity('github.com');
+    const matchedConfig = useGitHubConfig(gitHubEntity.entity);
+
+    expect(matchedConfig).toBeDefined();
+    expect(matchedConfig?.getOptionalString('host')).toBe(github.host);
+    expect(matchedConfig?.getOptionalString('apiBaseUrl')).toBe(github.apiBaseUrl);
+    expect(matchedConfig?.getOptionalString('rawBaseUrl')).toBe(github.rawBaseUrl);
+  });
+
+  it('should not match config based on the catalog entity location', () => {
+
+    const gitLabEntity = createGitHubEntity('gitlab.com');
+    const matchedConfig = useGitHubConfig(gitLabEntity.entity);
+
+    expect(matchedConfig).toBeUndefined();
+  });
+});

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/useGitHubConfig.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/useGitHubConfig.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 RoadieHQ
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { Entity, getEntitySourceLocation } from "@backstage/catalog-model";
+
+export const useGitHubConfig = (entity: Entity) => {
+    const config = useApi(configApiRef);
+    const providerConfigs = config.getOptionalConfigArray('integrations.github') ?? [];
+
+    const location = getEntitySourceLocation(entity);
+
+    if (location.type === 'url' && location.target.length > 0) {
+        // Try to match a provider config with catalog location (being a github.com or github enterprise domain)
+        const locationHost = new URL(location.target).host;
+        return providerConfigs.find(providerConfig => providerConfig?.getOptionalString("host") === locationHost);
+    }
+    return providerConfigs[0];
+}

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/useUrl.test.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/useUrl.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { useUrl } from "./useUrl";
+import { GitHubIntegrationConfig } from "../types";
+
+const createGitHubEntity = (originHost: string) => {
+  return {
+    entity: {
+      metadata: {
+        namespace: 'default',
+        annotations: {
+          'github.com/project-slug': 'company/sample-service',
+          'backstage.io/managed-by-location': `url:https://${originHost}/sample-service/blob/master/catalog-info.yaml`
+        },
+        name: 'sample-service',
+        description: 'Sample service'
+      },
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      spec: {
+        type: 'service',
+        lifecycle: 'experimental',
+      },
+      relations: [],
+    },
+  };
+}
+
+const enterpriseGithub = {
+  host: "git.company.com",
+  apiBaseUrl: "https://git.company.com/api/v3",
+  rawBaseUrl: "https://raw.git.company.com"
+};
+
+const github = {
+  host: "github.com",
+  apiBaseUrl: "https://api.github.com",
+  rawBaseUrl: "https://raw.github.com"
+};
+
+const getValueFromConfig = (config: GitHubIntegrationConfig, key: string) => {
+  // @ts-ignore
+  return config[ key ]
+}
+
+const config = {
+  getOptionalConfigArray: (_: string) => [
+    {getOptionalString: (key: string) => getValueFromConfig(github, key)},
+    {getOptionalString: (key: string) => getValueFromConfig(enterpriseGithub, key)}
+  ],
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: () => {
+    return config;
+  }
+}));
+
+describe('useUrl', () => {
+
+  it('should get github enterprise URL based on the catalog entity location', () => {
+
+    const githubEnterpriseEntity = createGitHubEntity('git.company.com');
+    const urlInfo = useUrl(githubEnterpriseEntity.entity);
+
+    expect(urlInfo).toBeDefined();
+    expect(urlInfo?.hostname).toBe(enterpriseGithub.host);
+    expect(urlInfo?.baseUrl).toBe(enterpriseGithub.apiBaseUrl);
+  });
+
+  it('should get github URL based on the catalog entity location', () => {
+
+    const gitHubEntity = createGitHubEntity('github.com');
+    const urlInfo = useUrl(gitHubEntity.entity);
+
+    expect(urlInfo).toBeDefined();
+    expect(urlInfo?.hostname).toBe(github.host);
+    expect(urlInfo?.baseUrl).toBe(github.apiBaseUrl);
+  });
+
+  it('should get default github URL', () => {
+
+    const gitLabEntity = createGitHubEntity('gitlab.com');
+    const urlInfo = useUrl(gitLabEntity.entity);
+
+    expect(urlInfo).toBeDefined();
+    expect(urlInfo?.hostname).toBe(github.host);
+    expect(urlInfo?.baseUrl).toBe(github.apiBaseUrl);
+  });
+});

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/useUrl.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/useUrl.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { useApi, configApiRef } from '@backstage/core-plugin-api';
+import { Entity } from "@backstage/catalog-model";
+import { useGitHubConfig } from "./useGitHubConfig";
 
-export const useUrl = () => {
-    const config = useApi(configApiRef);
-    const providerConfigs = config.getOptionalConfigArray('integrations.github') ?? [];
-    const targetProviderConfig = providerConfigs[0];
+export const useUrl = (entity: Entity) => {
+
+    const targetProviderConfig = useGitHubConfig(entity);
     const baseUrl = targetProviderConfig?.getOptionalString('apiBaseUrl') || 'https://api.github.com';
     const hostname = targetProviderConfig?.getOptionalString('host') || 'github.com';
 
     return {
-      hostname,
-      baseUrl,
+        hostname,
+        baseUrl,
     };
 }

--- a/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
@@ -248,6 +248,7 @@ export const entityStub: { entity: Entity } = {
       namespace: 'default',
       annotations: {
         'github.com/project-slug': 'roadiehq/sample-service',
+        'backstage.io/managed-by-location': 'url:http://roadiehq/sample-service/blob/master/catalog-info.yaml'
       },
       name: 'sample-service',
       description: 'Sample service'

--- a/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
@@ -248,7 +248,6 @@ export const entityStub: { entity: Entity } = {
       namespace: 'default',
       annotations: {
         'github.com/project-slug': 'roadiehq/sample-service',
-        'backstage.io/managed-by-location': 'url:http://roadiehq/sample-service/blob/master/catalog-info.yaml'
       },
       name: 'sample-service',
       description: 'Sample service'

--- a/plugins/frontend/backstage-plugin-security-insights/src/types.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/types.ts
@@ -37,9 +37,16 @@ export type UpdateSeverityStatusProps = {
   id: number;
   tableData: SecurityInsight[];
   setTableData: Dispatch<SetStateAction<SecurityInsight[]>>;
+  entity: Entity;
 };
 
 export type IssuesCounterProps = {
   issues: SecurityInsight[];
   issueStatus?: SecurityInsightFilterState;
+};
+
+export type GitHubIntegrationConfig = {
+  host: string;
+  apiBaseUrl: string;
+  rawBaseUrl: string;
 };


### PR DESCRIPTION
Signed-off-by: manusant <ney.br.santos@gmail.com>

Enable multiple GitHub integrations by extracting source location from entity managed annotations

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
