### PR TITLE
fix: ignore null items from Argo and revert to correct url for the appName single instance pattern

### DIFF
--- a/.changeset/proud-guests-flash.md
+++ b/.changeset/proud-guests-flash.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Fix bug where an instance with no items would crash the card

--- a/packages/app/cypress/integration/ArgoCD.ts
+++ b/packages/app/cypress/integration/ArgoCD.ts
@@ -22,7 +22,7 @@ describe('Travis CI', () => {
     cy.saveGithubToken();
     cy.intercept(
       'GET',
-      'http://localhost:7007/api/proxy/argocd/api/applications/name/test-app',
+      'http://localhost:7007/api/proxy/argocd/api/applications/test-app',
       { fixture: 'ArgoCD/applications-test-app.json' },
     );
     cy.visit('/catalog/default/component/sample-service');

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -133,7 +133,7 @@ export class ArgoCDApiClient implements ArgoCDApi {
       );
     }
     return this.fetchDecode(
-      `${proxyUrl}${options.url}/applications/name/${options.appName}`,
+      `${proxyUrl}${options.url}/applications/${options.appName}`,
       argoCDAppDetails,
     );
   }

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -80,7 +80,7 @@ export const useAppDetails = ({
         });
         const output = await Promise.all(promises);
         const items = {
-          items: output.flatMap(argoCdAppList => argoCdAppList.items)
+          items: output.flatMap(argoCdAppList => argoCdAppList.items).filter(item => item !== null),
         };
         return items;
       }


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
The card was exploding when the table was trying to load for an app not present in one of the configured instances, while using the argocd-backend-plugin & app-selector pattern. Filtering out null item responses from instances fixes this.

I also added a fix for [issue 355](https://github.com/RoadieHQ/roadie-backstage-plugins/issues/355), by removing the `name` part of the URL for the single-instance/appName pattern.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
