### PR TITLE
Add system, domain and resource kind support to validate

### DIFF
--- a/.changeset/giant-colts-pull.md
+++ b/.changeset/giant-colts-pull.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': patch
+---
+
+Add system, domain and resource validators

--- a/utils/roadie-backstage-entity-validator/sample/invalid-domain-entity.yml
+++ b/utils/roadie-backstage-entity-validator/sample/invalid-domain-entity.yml
@@ -1,0 +1,6 @@
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: sample-service-5
+spec:
+  domain: something

--- a/utils/roadie-backstage-entity-validator/sample/invalid-resource-entity.yml
+++ b/utils/roadie-backstage-entity-validator/sample/invalid-resource-entity.yml
@@ -1,0 +1,6 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: sample-service-5
+spec:
+  type: test

--- a/utils/roadie-backstage-entity-validator/sample/invalid-system-entity.yml
+++ b/utils/roadie-backstage-entity-validator/sample/invalid-system-entity.yml
@@ -1,0 +1,6 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: sample-service-5
+spec:
+  domain: something

--- a/utils/roadie-backstage-entity-validator/src/schemas/annotations.schema.json
+++ b/utils/roadie-backstage-entity-validator/src/schemas/annotations.schema.json
@@ -13,7 +13,6 @@
           "type": "object",
           "description": "Key/value pairs of non-identifying auxiliary information attached to the entity.",
           "additionalProperties": false,
-          "uniqueItems": true,
           "patternProperties": {
             "^.+$": {
               "type": "string"

--- a/utils/roadie-backstage-entity-validator/src/validator.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.js
@@ -12,13 +12,17 @@ import {
   locationEntityV1alpha1Validator,
   templateEntityV1beta2Validator,
   userEntityV1alpha1Validator,
+  systemEntityV1alpha1Validator,
+  domainEntityV1alpha1Validator,
+  resourceEntityV1alpha1Validator
 } from '@backstage/catalog-model';
 import annotationSchema from './schemas/annotations.schema.json';
 import Ajv from 'ajv';
+import ajvFormats from 'ajv-formats'
+import path from 'path'
 
 const ajv = new Ajv({ verbose: true });
-require('ajv-formats')(ajv);
-const path = require('path');
+ajvFormats(ajv);
 
 const VALIDATORS = {
   api: apiEntityV1alpha1Validator,
@@ -27,6 +31,9 @@ const VALIDATORS = {
   location: locationEntityV1alpha1Validator,
   template: templateEntityV1beta2Validator,
   user: userEntityV1alpha1Validator,
+  system: systemEntityV1alpha1Validator,
+  domain: domainEntityV1alpha1Validator,
+  resource: resourceEntityV1alpha1Validator
 };
 
 function modifyPlaceholders(obj) {

--- a/utils/roadie-backstage-entity-validator/src/validator.test.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.test.js
@@ -16,9 +16,17 @@ describe('validator',  () => {
   it('Should fail to validate with incorrect catalog-info that has an empty label', async () => {
     await expect(validator.validateFromFile('./sample/catalog-info-with-empty-label.yml')).rejects.toThrow("Error: Placeholder with name 'definition' is empty. Please remove it or populate it.");
   });
-
   it('Should fail to validate with bad techdocs path', async () => {
     await expect(validator.validateFromFile('./sample/catalog-info-with-bad-techdocs-dir.yml')).rejects.toThrow('Techdocs annotation specifies "dir" but file under');
   });
+  it('Should throw validation error for system entity', async ()=> {
+    await expect(validator.validateFromFile('./sample/invalid-system-entity.yml')).rejects.toThrow()
+  })
+  it('Should throw validation error for domain entity', async ()=> {
+    await expect(validator.validateFromFile('./sample/invalid-domain-entity.yml')).rejects.toThrow()
+  })
+  it('Should throw validation error for resource entity', async ()=> {
+    await expect(validator.validateFromFile('./sample/invalid-resource-entity.yml')).rejects.toThrow()
+  })
 })
 


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
Added the system, domain, and resource validators from the @backstage/catalog-model. It means the validator will be able to validate this kind of entity file from now on.
https://github.com/RoadieHQ/backstage-entity-validator/issues/8

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
