### PR TITLE
remove uniqueItems array only prop

### DIFF
--- a/utils/roadie-backstage-entity-validator/src/schemas/annotations.schema.json
+++ b/utils/roadie-backstage-entity-validator/src/schemas/annotations.schema.json
@@ -13,7 +13,6 @@
           "type": "object",
           "description": "Key/value pairs of non-identifying auxiliary information attached to the entity.",
           "additionalProperties": false,
-          "uniqueItems": true,
           "patternProperties": {
             "^.+$": {
               "type": "string"


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
Removes the uniqueItems prop from the annotations schema to not show a warning message. The uniqueItems is only useable on arrays.
https://github.com/RoadieHQ/backstage-entity-validator/issues/21

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
