### PR TITLE
Fix readme image of Bugsnag plugin

### DIFF
--- a/plugins/frontend/backstage-plugin-bugsnag/README.md
+++ b/plugins/frontend/backstage-plugin-bugsnag/README.md
@@ -1,6 +1,6 @@
 # Bugsnag Plugin for Backstage
 
-![a preview of the Bugsnag plugin](https://raw.githubusercontent.com/RoadieHQ/roadie-backstage-plugins/main/plugins/backstage-plugin-bugsnag/docs/backstage-bugsnag-plugin.png)
+![a preview of the Bugsnag plugin](./docs/backstage-bugsnag-plugin.png?raw=true)
 
 Since Bugsnag has a policy around API rate limits (https://bugsnagapiv2.docs.apiary.io/#introduction/rate-limiting), we are not displaying error trends in the table. However, you can visit error details page in Bugsnag for more details, including error trend.
 


### PR DESCRIPTION
Fixes a broken image on the Bugsnag plugin readme.
