### PR TITLE
Sc 5454/bugsnag plugin should fetch all projects

### DIFF
--- a/.changeset/honest-poets-behave.md
+++ b/.changeset/honest-poets-behave.md
@@ -1,5 +1,5 @@
 ---
-'@roadiehq/backstage-plugin-bugsnag': patch
+'@roadiehq/backstage-plugin-bugsnag': minor
 ---
 
 Introduce new annotations in order to fix the limit with pagination and default of fetching 30 requests per page.

--- a/.changeset/honest-poets-behave.md
+++ b/.changeset/honest-poets-behave.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-bugsnag': patch
+---
+
+Introduce new annotations in order to fix the limit with pagination and default of fetching 30 requests per page.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -163,3 +163,6 @@ argocd:
 
 prometheus:
   proxyPath: /prometheus/api
+
+bugsnag:
+  resultsPerPage: 50

--- a/packages/app/cypress/integration/bugsnag.ts
+++ b/packages/app/cypress/integration/bugsnag.ts
@@ -20,11 +20,11 @@ import 'os';
 describe('Bugsnag', () => {
     beforeEach(() => {
         cy.saveGithubToken();
-        cy.intercept('GET', ' http://localhost:7007/api/proxy/bugsnag/api/user/organizations', { fixture: 'Bugsnag/organisations.json' })
-        cy.intercept('GET', 'http://localhost:7007/api/proxy/bugsnag/api/organizations/129876sdfgh/projects', { fixture: 'Bugsnag/projects.json' })
+        cy.intercept('GET', 'http://localhost:7007/api/proxy/bugsnag/api/user/organizations', { fixture: 'Bugsnag/organisations.json' })
+        cy.intercept('GET', 'http://localhost:7007/api/proxy/bugsnag/api/organizations/129876sdfgh/projects?per_page=50', { fixture: 'Bugsnag/projects.json' })
         cy.intercept('GET', 'http://localhost:7007/api/proxy/bugsnag/api/projects/0987qwert!!/errors', { fixture: 'Bugsnag/errors.json' })
-        cy.intercept('GET', 'localhost:7007/api/proxy/bugsnag/api/projects/0987qwert!!/errors/123456qwerty!!/trend?&buckets_count=10', { fixture: 'Bugsnag/trends.json' })
-        cy.intercept('GET', 'localhost:7007/api/proxy/bugsnag/api/projects/0987qwert!!/errors/123456qwerty2!!/trend?&buckets_count=10', { fixture: 'Bugsnag/trends.json' })
+        cy.intercept('GET', 'http://localhost:7007/api/proxy/bugsnag/api/projects/0987qwert!!/errors/123456qwerty!!/trend?&buckets_count=10', { fixture: 'Bugsnag/trends.json' })
+        cy.intercept('GET', 'http://localhost:7007/api/proxy/bugsnag/api/projects/0987qwert!!/errors/123456qwerty2!!/trend?&buckets_count=10', { fixture: 'Bugsnag/trends.json' })
         cy.visit('/catalog/default/component/sample-service')
     })
 

--- a/plugins/frontend/backstage-plugin-bugsnag/README.md
+++ b/plugins/frontend/backstage-plugin-bugsnag/README.md
@@ -31,6 +31,13 @@ proxy:
         X-version: '2'
 ```
 
+ Define number of results fetched per request (this is optional and if ommited it will be set to default value of 30). This will be used as a 'per_page' parameter (https://bugsnagapiv2.docs.apiary.io/#introduction/rate-limiting).
+
+ ```yml
+bugsnag:
+  resultsPerPage: <number>
+```
+
 3. Add plugin to your Backstage instance:
 
 ```ts
@@ -61,7 +68,7 @@ const serviceEntityPage = (
 bugsnag.com/project-key: <organization-name>/<project-notifier-api-key>
 ```
 
-Please note that if your organisation has more than 100 projects you need to provide additional annotations where you will provide the name of the project:
+Please note that if your organisation has more projects than results returned by page and defined under 'bugsnag.resultsPerPage' you need to provide additional annotations where you will provide the name of the project:
 
 ```yml
 bugsnag.com/project-name: <project-name>

--- a/plugins/frontend/backstage-plugin-bugsnag/README.md
+++ b/plugins/frontend/backstage-plugin-bugsnag/README.md
@@ -55,13 +55,19 @@ const serviceEntityPage = (
 
 ## How to use Bugsnag plugin in Backstage:
 
-1. Add an annotation to the yaml config file of a component:
+1. Add annotations to the yaml config file of a component:
 
 ```yml
 bugsnag.com/project-key: <organization-name>/<project-notifier-api-key>
 ```
 
-Both values can be found in Bugsnag settings dashboard, under organization and project settings.
+Please note that if your organisation has more than 100 projects you need to provide additional annotations where you will provide the name of the project:
+
+```yml
+bugsnag.com/project-name: <project-name>
+```
+
+These values can be found in Bugsnag settings dashboard, under organization and project settings.
 
 2. Add your Bugsnag personal auth token to the environment variables of your backstage backend server (you can find it in https://app.bugsnag.com/settings/{organizationaname}/my-account/auth-tokens), in the form of the word 'token' followed by your token. So it should look like this:
 

--- a/plugins/frontend/backstage-plugin-bugsnag/config.d.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Larder Software Limited
+ * Copyright 2022 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/core-plugin-api';
-import { BugsnagError, Organisation, Project } from './types';
-
-export const bugsnagApiRef = createApiRef<BugsnagApi>({
-  id: 'plugin.bugsnag.service',
-});
-
-export interface BugsnagApi {
-  fetchErrors(projectId:string): Promise<BugsnagError[]>;
-  fetchOrganisations(): Promise<Organisation[]>;
-  fetchProjects(organisationId?: string, projectName?:string, perPage?: number): Promise<Project[]>;
+export interface Config {
+  /** Results per page for bugsnag plugin */
+  bugsnag?: {
+    /**
+     *
+     * @visibility frontend
+     */
+    resultsPerPage: number;
+  };
 }

--- a/plugins/frontend/backstage-plugin-bugsnag/config.d.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/config.d.ts
@@ -21,6 +21,6 @@ export interface Config {
      *
      * @visibility frontend
      */
-    resultsPerPage: number;
+    resultsPerPage?: number;
   };
 }

--- a/plugins/frontend/backstage-plugin-bugsnag/package.json
+++ b/plugins/frontend/backstage-plugin-bugsnag/package.json
@@ -56,6 +56,8 @@
     "cross-fetch": "^3.0.6"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagApi.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagApi.ts
@@ -22,7 +22,15 @@ export const bugsnagApiRef = createApiRef<BugsnagApi>({
 });
 
 export interface BugsnagApi {
-  fetchErrors(projectId:string): Promise<BugsnagError[]>;
+  fetchErrors(projectId: string): Promise<BugsnagError[]>;
   fetchOrganisations(): Promise<Organisation[]>;
-  fetchProjects(organisationId?: string, projectName?:string, perPage?: number): Promise<Project[]>;
+  fetchProjects({
+    organisationId,
+    projectName,
+    perPage,
+  }: {
+    organisationId?: string;
+    projectName?: string;
+    perPage?: number;
+  }): Promise<Project[]>;
 }

--- a/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagApi.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagApi.ts
@@ -24,5 +24,5 @@ export const bugsnagApiRef = createApiRef<BugsnagApi>({
 export interface BugsnagApi {
   fetchErrors(projectId:string): Promise<BugsnagError[]>;
   fetchOrganisations(): Promise<Organisation[]>;
-  fetchProjects(organisationId: string): Promise<Project[]>;
+  fetchProjects(organisationId?: string, projectName?:string): Promise<Project[]>;
 }

--- a/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagClient.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagClient.ts
@@ -49,11 +49,15 @@ export class BugsnagClient implements BugsnagApi {
     return payload;
   }
 
-  async fetchProjects(
-    organisationId?: string,
-    projectName?: string,
-    perPage?: number
-  ): Promise<Project[]> {
+  async fetchProjects({
+    organisationId,
+    projectName,
+    perPage = 30,
+  }: {
+    organisationId?: string;
+    projectName?: string;
+    perPage?: number;
+  }): Promise<Project[]> {
     const query = projectName ? `q=${projectName}&` : '';
     const response = await fetch(
       `${await this.getApiUrl()}/organizations/${organisationId}/projects?${query}per_page=${perPage}`,

--- a/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagClient.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagClient.ts
@@ -52,10 +52,11 @@ export class BugsnagClient implements BugsnagApi {
   async fetchProjects(
     organisationId?: string,
     projectName?: string,
+    perPage?: number
   ): Promise<Project[]> {
     const query = projectName ? `q=${projectName}&` : '';
     const response = await fetch(
-      `${await this.getApiUrl()}/organizations/${organisationId}/projects?${query}per_page=100`,
+      `${await this.getApiUrl()}/organizations/${organisationId}/projects?${query}per_page=${perPage}`,
     );
     const payload = await response.json();
     if (!response.ok) {

--- a/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagClient.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/api/BugsnagClient.ts
@@ -49,9 +49,13 @@ export class BugsnagClient implements BugsnagApi {
     return payload;
   }
 
-  async fetchProjects(organisationId: string): Promise<Project[]> {
+  async fetchProjects(
+    organisationId?: string,
+    projectName?: string,
+  ): Promise<Project[]> {
+    const query = projectName ? `q=${projectName}&` : '';
     const response = await fetch(
-      `${await this.getApiUrl()}/organizations/${organisationId}/projects`,
+      `${await this.getApiUrl()}/organizations/${organisationId}/projects?${query}per_page=100`,
     );
     const payload = await response.json();
     if (!response.ok) {

--- a/plugins/frontend/backstage-plugin-bugsnag/src/components/ErrorsOverviewComponent/ErrorsOverview.tsx
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/components/ErrorsOverviewComponent/ErrorsOverview.tsx
@@ -49,7 +49,7 @@ export const ErrorsOverview = () => {
   const api = useApi(bugsnagApiRef);
   const configApi = useApi(configApiRef);
   const [slug, setOrganisationSlug] = useState('');
-  const resultsPerPage = configApi?.getOptionalNumber('bugsnag.resultsPerPage');
+  const perPage = configApi?.getOptionalNumber('bugsnag.resultsPerPage');
 
   const { value, loading, error } = useAsync(async () => {
     const organisations = await api.fetchOrganisations();
@@ -57,11 +57,13 @@ export const ErrorsOverview = () => {
       org.name.includes(organisationName),
     );
     setOrganisationSlug(organisation?.slug || '');
-    const projects = await api.fetchProjects(
-      organisation?.id,
-      projectName ? projectName : undefined,
-      resultsPerPage ? resultsPerPage : 30,
-    );
+
+    const projects = await api.fetchProjects({
+      organisationId: organisation ? organisation.id : undefined,
+      projectName: projectName ? projectName : undefined,
+      perPage,
+    });
+
     const filteredProject = projects.find(proj =>
       proj.api_key.includes(projectApiKey),
     );

--- a/plugins/frontend/backstage-plugin-bugsnag/src/components/ErrorsOverviewComponent/ErrorsOverview.tsx
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/components/ErrorsOverviewComponent/ErrorsOverview.tsx
@@ -28,7 +28,7 @@ import {
   MissingAnnotationEmptyState,
   Progress,
 } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { bugsnagApiRef } from '../..';
 import { ErrorsTable } from '../ErrorsTableComponent';
 import {
@@ -47,7 +47,9 @@ export const ErrorsOverview = () => {
   const projectApiKey = useBugsnagData()[1];
   const projectName = useProjectName();
   const api = useApi(bugsnagApiRef);
+  const configApi = useApi(configApiRef);
   const [slug, setOrganisationSlug] = useState('');
+  const resultsPerPage = configApi?.getOptionalNumber('bugsnag.resultsPerPage');
 
   const { value, loading, error } = useAsync(async () => {
     const organisations = await api.fetchOrganisations();
@@ -58,6 +60,7 @@ export const ErrorsOverview = () => {
     const projects = await api.fetchProjects(
       organisation?.id,
       projectName ? projectName : undefined,
+      resultsPerPage ? resultsPerPage : 30,
     );
     const filteredProject = projects.find(proj =>
       proj.api_key.includes(projectApiKey),

--- a/plugins/frontend/backstage-plugin-bugsnag/src/hooks/useBugsnagData.ts
+++ b/plugins/frontend/backstage-plugin-bugsnag/src/hooks/useBugsnagData.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 export const BUGSNAG_ANNOTATION = 'bugsnag.com/project-key';
+export const PROJECT_ANNOTATION = 'bugsnag.com/project-name';
 
 export const useBugsnagData = () => {
   const { entity } = useEntity();
@@ -29,4 +30,10 @@ export const useBugsnagData = () => {
     throw new Error("'bugsnag.com/project-key' annotation is missing");
   }
   return slugElements;
+};
+
+export const useProjectName = () => {
+  const { entity } = useEntity();
+  const projectNameSlug = entity?.metadata.annotations?.[PROJECT_ANNOTATION] ?? '';
+  return projectNameSlug;
 };


### PR DESCRIPTION
There have been some limitations due the fact Bugsnag retruns only 30 results per page (by default).
Currently Bugsnag supports query by project name so I figured out having 100 items (which I believe is maximum for per_request optional parameter) is enough, in addition of having project name annotation which narrow search a bit more.