### PR TITLE
Move React dependencies to peerDependencies and allow both v16 and v17

### DIFF
--- a/.changeset/five-lemons-agree.md
+++ b/.changeset/five-lemons-agree.md
@@ -1,0 +1,15 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+'@roadiehq/backstage-plugin-aws-lambda': patch
+'@roadiehq/backstage-plugin-bugsnag': patch
+'@roadiehq/backstage-plugin-buildkite': patch
+'@roadiehq/backstage-plugin-datadog': patch
+'@roadiehq/backstage-plugin-github-insights': patch
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+'@roadiehq/backstage-plugin-jira': patch
+'@roadiehq/backstage-plugin-prometheus': patch
+'@roadiehq/backstage-plugin-security-insights': patch
+'@roadiehq/backstage-plugin-travis-ci': patch
+---
+
+Moved React dependencies to `peerDependencies` and allow both React v16 and v17 to be used.

--- a/.changeset/soft-flowers-crash.md
+++ b/.changeset/soft-flowers-crash.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-travis-ci': patch
+---
+
+Removed unused dependency on `@backstage/core-app-api`.

--- a/plugins/frontend/backstage-plugin-argo-cd/package.json
+++ b/plugins/frontend/backstage-plugin-argo-cd/package.json
@@ -46,11 +46,13 @@
     "io-ts-promise": "^2.0.2",
     "io-ts-reporters": "^1.2.2",
     "moment": "^2.29.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-aws-lambda/package.json
+++ b/plugins/frontend/backstage-plugin-aws-lambda/package.json
@@ -41,9 +41,11 @@
     "cross-fetch": "^3.1.4",
     "history": "^5.0.0",
     "moment": "^2.29.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.0",

--- a/plugins/frontend/backstage-plugin-bugsnag/package.json
+++ b/plugins/frontend/backstage-plugin-bugsnag/package.json
@@ -37,10 +37,12 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-use": "^17.2.4",
     "luxon": "^2.0.1"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-buildkite/package.json
+++ b/plugins/frontend/backstage-plugin-buildkite/package.json
@@ -40,11 +40,13 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "history": "^5.0.0",
     "moment": "^2.29.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-datadog/package.json
+++ b/plugins/frontend/backstage-plugin-datadog/package.json
@@ -41,11 +41,13 @@
     "history": "^5.0.0",
     "moment": "^2.29.1",
     "re-resizable": "^6.9.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-github-insights/package.json
+++ b/plugins/frontend/backstage-plugin-github-insights/package.json
@@ -44,10 +44,12 @@
     "@octokit/rest": "^18.5.3",
     "@octokit/types": "^6.14.2",
     "history": "^5.0.0",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
     "react-router": "^6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -44,10 +44,12 @@
     "history": "^5.0.0",
     "moment": "^2.27.0",
     "node-fetch": "^2.6.1",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
     "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-jira/package.json
+++ b/plugins/frontend/backstage-plugin-jira/package.json
@@ -43,12 +43,14 @@
     "history": "^5.0.0",
     "html-react-parser": "^0.14.1",
     "moment": "^2.29.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-use": "^17.2.4",
     "sanitize-html": "^2.3.3",
     "uuid": "8.3.2",
     "xml-js": "^1.6.11"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-prometheus/package.json
+++ b/plugins/frontend/backstage-plugin-prometheus/package.json
@@ -43,11 +43,13 @@
     "history": "^5.0.0",
     "lodash": "^4.17.21",
     "luxon": "^2.0.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-use": "^17.2.4",
     "react-use-dimensions": "^1.2.1",
     "recharts": "^1.8.5"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-security-insights/package.json
+++ b/plugins/frontend/backstage-plugin-security-insights/package.json
@@ -45,11 +45,13 @@
     "history": "^5.0.0",
     "luxon": "^2.0.1",
     "moment": "^2.27.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-minimal-pie-chart": "^8.2.0",
     "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-travis-ci/package.json
+++ b/plugins/frontend/backstage-plugin-travis-ci/package.json
@@ -43,11 +43,13 @@
     "date-fns": "^2.18.0",
     "history": "^5.0.0",
     "moment": "^2.29.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "react-router": "6.0.0-beta.0",
     "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",

--- a/plugins/frontend/backstage-plugin-travis-ci/package.json
+++ b/plugins/frontend/backstage-plugin-travis-ci/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "^0.9.7",
-    "@backstage/core-app-api": "^0.3.0",
     "@backstage/core-components": "^0.8.0",
     "@backstage/core-plugin-api": "^0.4.0",
     "@backstage/plugin-catalog-react": "^0.6.5",
@@ -53,6 +52,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.10.1",
+    "@backstage/core-app-api": "^0.3.0",
     "@backstage/dev-utils": "^0.2.14",
     "@backstage/test-utils": "^0.2.1",
     "@testing-library/jest-dom": "^5.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17721,7 +17721,7 @@ react-dev-utils@^12.0.0-next.47:
     strip-ansi "^6.0.0"
     text-table "^0.2.0"
 
-react-dom@^16.12.0, react-dom@^16.13.1:
+react-dom@^16.13.1:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -18018,7 +18018,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.12.0, react@^16.13.1:
+react@^16.13.1:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
Looking to get backstage/backstage#6910 through, and this is the missing piece :grin:

Also moved over one last `@backstage/core-app-api` dependency to devDeps 🧹 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
