### PR TITLE
Make check for repo access optional

### DIFF
--- a/.changeset/three-apricots-judge.md
+++ b/.changeset/three-apricots-judge.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-github-insights': minor
+'@roadiehq/backstage-plugin-github-pull-requests': minor
+---
+
+Check if repository is public before retrieving information and checking access rights.

--- a/plugins/frontend/backstage-plugin-github-insights/.eslintrc.js
+++ b/plugins/frontend/backstage-plugin-github-insights/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: [require.resolve('@backstage/cli/config/eslint')],
+  rules: {
+    'notice/notice': 'off',
+  },
 };

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
@@ -69,7 +69,7 @@ const ComplianceCard = (_props: Props) => {
   } else if (error || licenseError) {
     return error?.message.includes('API Rate Limit') ||
       licenseError?.message.includes('API Rate Limit') ? (
-      <Alert severity="error">
+        <InfoCard title="Compliance report">
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be
         higher. You can read more in official
@@ -81,7 +81,7 @@ const ComplianceCard = (_props: Props) => {
         >
           documentation
         </Link>
-      </Alert>
+      </InfoCard>
     ) : (
       <Alert severity="error">{error?.message}</Alert>
     );

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
@@ -31,6 +31,7 @@ import {
 import WarningIcon from '@material-ui/icons/ErrorOutline';
 import { styles as useStyles } from '../../utils/styles';
 import { useEntity } from "@backstage/plugin-catalog-react";
+import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */
@@ -39,14 +40,15 @@ type Props = {
 
 const ComplianceCard = (_props: Props) => {
   const { entity } = useEntity();
-  const { branches, loading, error } = useProtectedBranches(entity);
+  const classes = useStyles();
+  const { owner, repo } = useProjectEntity(entity);
+  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { branches, loading, error } = useProtectedBranches({entity, isPrivate});
   const {
     license,
     loading: licenseLoading,
     error: licenseError,
-  } = useRepoLicence(entity);
-  const classes = useStyles();
-  const { owner, repo } = useProjectEntity(entity);
+  } = useRepoLicence({entity, isPrivate});
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
     return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
@@ -15,9 +15,14 @@
  */
 
 import React from 'react';
-import { Box, List, ListItem } from '@material-ui/core';
+import { Box, Link, List, ListItem } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, StructuredMetadataTable, MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  InfoCard,
+  Progress,
+  StructuredMetadataTable,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import {
   useProtectedBranches,
@@ -26,11 +31,11 @@ import {
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import WarningIcon from '@material-ui/icons/ErrorOutline';
 import { styles as useStyles } from '../../utils/styles';
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
 type Props = {
@@ -42,26 +47,43 @@ const ComplianceCard = (_props: Props) => {
   const { entity } = useEntity();
   const classes = useStyles();
   const { owner, repo } = useProjectEntity(entity);
-  const { value: isPrivate } = useGithubRepository({owner, repo});
-  const { branches, loading, error } = useProtectedBranches({entity, isPrivate});
+  const { value: isPrivate } = useGithubRepository({ owner, repo });
+  const { branches, loading, error } = useProtectedBranches({
+    entity,
+    isPrivate,
+  });
   const {
     license,
     loading: licenseLoading,
     error: licenseError,
-  } = useRepoLicence({entity, isPrivate});
+  } = useRepoLicence({ entity, isPrivate });
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading || licenseLoading) {
     return <Progress />;
   } else if (error || licenseError) {
-    return (
+    return error?.message.includes('API Rate Limit') ||
+      licenseError?.message.includes('API Rate Limit') ? (
       <Alert severity="error">
-        Error occured while fetching data for the compliance card:{' '}
-        {error?.message}
+        API Rate Limit exceeded. Authenticated requests get a higher rate limit
+        so after you log in and set up GitHub provider, this rate will be
+        higher. You can read more in official
+        <Link
+          href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting"
+          target="_blank"
+          rel="noopener"
+          style={{ paddingLeft: '0.3rem' }}
+        >
+          documentation
+        </Link>
       </Alert>
+    ) : (
+      <Alert severity="error">{error?.message}</Alert>
     );
   }
 

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
@@ -17,7 +17,11 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  InfoCard,
+  Progress,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import ContributorsList from './components/ContributorsList';
 import { useRequest } from '../../../hooks/useRequest';
@@ -25,9 +29,10 @@ import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScm
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -46,12 +51,22 @@ type Props = {
 const ContributorsCard = (_props: Props) => {
   const { entity } = useEntity();
   const classes = useStyles();
-  const { value, loading, error } = useRequest(entity, 'contributors', 10);
   const { hostname } = useEntityGithubScmIntegration(entity);
   const projectAlert = isGithubInsightsAvailable(entity);
   const { owner, repo } = useProjectEntity(entity);
+  const { value: isPrivate } = useGithubRepository({ owner, repo });
+  const { value, loading, error } = useRequest({
+    entity,
+    requestName: 'contributors',
+    perPage: 10,
+    maxResults: 0,
+    showTotal: false,
+    isPrivate,
+  });
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useGithubRepository } from '../../../hooks/useGithubRepository';
+import { Link } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -72,7 +73,21 @@ const ContributorsCard = (_props: Props) => {
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
+    return error.message.includes('API rate limit') ? (
+      <Alert severity="error" className={classes.infoCard}>
+        API Rate Limit exceeded. Authenticated requests get a higher rate limit
+        so after you log in and set up GitHub provider, this rate will be
+        higher. You can read more in official
+        <Link
+          href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting"
+          target="_blank"
+          rel="noopener"
+          style={{ paddingLeft: '0.3rem' }}
+        >
+          documentation
+        </Link>
+      </Alert>
+    ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}
       </Alert>

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
@@ -74,7 +74,8 @@ const ContributorsCard = (_props: Props) => {
     return <Progress />;
   } else if (error) {
     return error.message.includes('API rate limit') ? (
-      <Alert severity="error" className={classes.infoCard}>
+      <InfoCard title="Contributors" className={classes.infoCard}>
+        {' '}
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be
         higher. You can read more in official
@@ -86,7 +87,7 @@ const ContributorsCard = (_props: Props) => {
         >
           documentation
         </Link>
-      </Alert>
+      </InfoCard>
     ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/components/ContributorTooltipContent/ContributorTooltipContent.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/components/ContributorTooltipContent/ContributorTooltipContent.tsx
@@ -30,6 +30,8 @@ import LocationOnIcon from '@material-ui/icons/LocationOn';
 import { useEntityGithubScmIntegration } from '../../../../../hooks/useEntityGithubScmIntegration';
 import { useContributor } from '../../../../../hooks/useContributor';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { useGithubRepository } from '../../../../../hooks/useGithubRepository';
+import { useProjectEntity } from '../../../../../hooks/useProjectEntity';
 
 const useStyles = makeStyles(theme => ({
   contributorsTooltipContainer: {
@@ -44,7 +46,9 @@ const ContributorTooltipContent = ({ contributorLogin }: Props) => {
   const classes = useStyles();
   const { entity } = useEntity();
   const { hostname } = useEntityGithubScmIntegration(entity);
-  const { contributor, loading } = useContributor(contributorLogin);
+  const { owner, repo } = useProjectEntity(entity);
+  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { contributor, loading } = useContributor({username:contributorLogin, isPrivate});
 
   if (loading) {
     return <Progress />;

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -27,6 +27,7 @@ import {
   GITHUB_INSIGHTS_ANNOTATION
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from "@backstage/plugin-catalog-react";
+import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
 const useStyles = makeStyles((theme) => ({
   infoCard: {
@@ -72,7 +73,15 @@ const LanguagesCard = (_props: Props) => {
   let barWidth = 0;
   const classes = useStyles();
   const { owner, repo } = useProjectEntity(entity);
-  const { value, loading, error } = useRequest(entity, 'languages', 0, 0, true);
+  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { value, loading, error } = useRequest({
+    entity,
+    requestName: 'languages',
+    perPage: 0,
+    maxResults: 0,
+    showTotal: true,
+    isPrivate,
+  });
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
     return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -15,21 +15,25 @@
  */
 
 import React from 'react';
-import { Chip, makeStyles, Tooltip } from '@material-ui/core';
+import { Chip, Link, makeStyles, Tooltip } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  InfoCard,
+  Progress,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
 import { colors } from './colors';
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   infoCard: {
     marginBottom: theme.spacing(3),
     '& + .MuiAlert-root': {
@@ -73,7 +77,7 @@ const LanguagesCard = (_props: Props) => {
   let barWidth = 0;
   const classes = useStyles();
   const { owner, repo } = useProjectEntity(entity);
-  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { value: isPrivate } = useGithubRepository({ owner, repo });
   const { value, loading, error } = useRequest({
     entity,
     requestName: 'languages',
@@ -84,13 +88,29 @@ const LanguagesCard = (_props: Props) => {
   });
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
+    return error.message.includes('API rate limit') ? (
+      <Alert severity="error" className={classes.infoCard}>
+        API Rate Limit exceeded. Authenticated requests get a higher rate limit
+        so after you log in and set up GitHub provider, this rate will be
+        higher. You can read more in official
+        <Link
+          href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting"
+          target="_blank"
+          rel="noopener"
+          style={{ paddingLeft: '0.3rem' }}
+        >
+          documentation
+        </Link>
+      </Alert>
+    ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}
       </Alert>
@@ -120,10 +140,10 @@ const LanguagesCard = (_props: Props) => {
                 />
               </Tooltip>
             );
-          }
+          },
         )}
       </div>
-      {Object.entries(value.data as Language).map((language) => (
+      {Object.entries(value.data as Language).map(language => (
         <Chip
           classes={{
             label: classes.label,

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -97,7 +97,11 @@ const LanguagesCard = (_props: Props) => {
     return <Progress />;
   } else if (error) {
     return error.message.includes('API rate limit') ? (
-      <Alert severity="error" className={classes.infoCard}>
+      <InfoCard
+        title="Languages"
+        className={classes.infoCard}
+        vclassName={classes.infoCard}
+      >
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be
         higher. You can read more in official
@@ -109,7 +113,7 @@ const LanguagesCard = (_props: Props) => {
         >
           documentation
         </Link>
-      </Alert>
+      </InfoCard>
     ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -100,7 +100,6 @@ const LanguagesCard = (_props: Props) => {
       <InfoCard
         title="Languages"
         className={classes.infoCard}
-        vclassName={classes.infoCard}
       >
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -32,6 +32,7 @@ import {
   GITHUB_INSIGHTS_ANNOTATION
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -92,8 +93,15 @@ const ReadMeCard = (props: Props) => {
   const { owner, repo, readmePath } = useProjectEntity(entity);
   const request = readmePath ? `contents/${readmePath}` : 'readme';
   const path = readmePath || 'README.md';
-
-  const { value, loading, error } = useRequest(entity, request);
+  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { value, loading, error } = useRequest({
+    entity,
+    requestName: request,
+    perPage: 0,
+    maxResults: 0,
+    showTotal: false,
+    isPrivate,
+  });
   const { hostname } = useEntityGithubScmIntegration(entity);
 
   const projectAlert = isGithubInsightsAvailable(entity);

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -15,13 +15,13 @@
  */
 
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
+import { Link, makeStyles } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import {
   InfoCard,
   Progress,
   MarkdownContent,
-  MissingAnnotationEmptyState
+  MissingAnnotationEmptyState,
 } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
@@ -29,7 +29,7 @@ import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScm
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useGithubRepository } from '../../../hooks/useGithubRepository';
@@ -93,7 +93,7 @@ const ReadMeCard = (props: Props) => {
   const { owner, repo, readmePath } = useProjectEntity(entity);
   const request = readmePath ? `contents/${readmePath}` : 'readme';
   const path = readmePath || 'README.md';
-  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { value: isPrivate } = useGithubRepository({ owner, repo });
   const { value, loading, error } = useRequest({
     entity,
     requestName: request,
@@ -106,15 +106,31 @@ const ReadMeCard = (props: Props) => {
 
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
+    return error.message.includes('API rate limit') ? (
       <Alert severity="error" className={classes.infoCard}>
-        {error.message}
+        API Rate Limit exceeded. Authenticated requests get a higher rate limit
+        so after you log in and set up GitHub provider, this rate will be
+        higher. You can read more in official
+        <Link
+          href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting"
+          target="_blank"
+          rel="noopener"
+          style={{ paddingLeft: '0.3rem' }}
+        >
+          documentation
+        </Link>
+      </Alert>
+    ) : (
+      <Alert severity="error" className={classes.infoCard}>
+        {error.message}{' '}
       </Alert>
     );
   }

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -115,7 +115,10 @@ const ReadMeCard = (props: Props) => {
     return <Progress />;
   } else if (error) {
     return error.message.includes('API rate limit') ? (
-      <Alert severity="error" className={classes.infoCard}>
+      <InfoCard
+        title="Read me"
+        className={classes.infoCard}
+      >
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be
         higher. You can read more in official
@@ -127,7 +130,7 @@ const ReadMeCard = (props: Props) => {
         >
           documentation
         </Link>
-      </Alert>
+      </InfoCard>
     ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}{' '}
@@ -139,20 +142,6 @@ const ReadMeCard = (props: Props) => {
     <InfoCard
       title="Read me"
       className={classes.infoCard}
-      deepLink={{
-        link: `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
-          value.url,
-        )}/${path}`,
-        title: 'Read me',
-        onClick: e => {
-          e.preventDefault();
-          window.open(
-            `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
-              value.url,
-            )}/${path}`,
-          );
-        },
-      }}
     >
       <div
         className={classes.readMe}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -115,10 +115,7 @@ const ReadMeCard = (props: Props) => {
     return <Progress />;
   } else if (error) {
     return error.message.includes('API rate limit') ? (
-      <InfoCard
-        title="Read me"
-        className={classes.infoCard}
-      >
+      <InfoCard title="Read me" className={classes.infoCard}>
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be
         higher. You can read more in official
@@ -142,6 +139,20 @@ const ReadMeCard = (props: Props) => {
     <InfoCard
       title="Read me"
       className={classes.infoCard}
+      deepLink={{
+        link: `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
+          value.url,
+        )}/${path}`,
+        title: 'Read me',
+        onClick: e => {
+          e.preventDefault();
+          window.open(
+            `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
+              value.url,
+            )}/${path}`,
+          );
+        },
+      }}
     >
       <div
         className={classes.readMe}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
@@ -75,7 +75,11 @@ const ReleasesCard = (_props: Props) => {
     return <Progress />;
   } else if (error) {
     return error.message.includes('API rate limit') ? (
-      <Alert severity="error" className={classes.infoCard}>
+      <InfoCard
+        title="Releases"
+        className={classes.infoCard}
+      >
+        {' '}
         API Rate Limit exceeded. Authenticated requests get a higher rate limit
         so after you log in and set up GitHub provider, this rate will be
         higher. You can read more in official
@@ -87,7 +91,7 @@ const ReleasesCard = (_props: Props) => {
         >
           documentation
         </Link>
-      </Alert>
+      </InfoCard>
     ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { styles as useStyles } from '../../utils/styles';
+import { useGithubRepository } from '../../../hooks/useGithubRepository';
 
 type Release = {
   id: number;
@@ -48,7 +49,15 @@ const ReleasesCard = (_props: Props) => {
   const { entity } = useEntity();
 
   const { owner, repo } = useProjectEntity(entity);
-  const { value, loading, error } = useRequest(entity, 'releases', 0, 5);
+  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { value, loading, error } = useRequest({
+    entity,
+    requestName: 'releases',
+    perPage: 0,
+    maxResults: 5,
+    showTotal: false,
+    isPrivate,
+  });
   const { hostname } = useEntityGithubScmIntegration(entity);
 
   const projectAlert = isGithubInsightsAvailable(entity);

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
@@ -18,14 +18,18 @@ import React from 'react';
 import { Link, List, ListItem, Chip } from '@material-ui/core';
 import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
 import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, MissingAnnotationEmptyState } from '@backstage/core-components';
+import {
+  InfoCard,
+  Progress,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
 import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScmIntegration';
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { styles as useStyles } from '../../utils/styles';
@@ -49,7 +53,7 @@ const ReleasesCard = (_props: Props) => {
   const { entity } = useEntity();
 
   const { owner, repo } = useProjectEntity(entity);
-  const { value: isPrivate } = useGithubRepository({owner, repo});
+  const { value: isPrivate } = useGithubRepository({ owner, repo });
   const { value, loading, error } = useRequest({
     entity,
     requestName: 'releases',
@@ -62,13 +66,29 @@ const ReleasesCard = (_props: Props) => {
 
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
+    return error.message.includes('API rate limit') ? (
+      <Alert severity="error" className={classes.infoCard}>
+        API Rate Limit exceeded. Authenticated requests get a higher rate limit
+        so after you log in and set up GitHub provider, this rate will be
+        higher. You can read more in official
+        <Link
+          href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting"
+          target="_blank"
+          rel="noopener"
+          style={{ paddingLeft: '0.3rem' }}
+        >
+          documentation
+        </Link>
+      </Alert>
+    ) : (
       <Alert severity="error" className={classes.infoCard}>
         {error.message}
       </Alert>

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useComplianceHooks.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useComplianceHooks.ts
@@ -21,13 +21,20 @@ import { useAsync } from 'react-use';
 import { useProjectEntity } from './useProjectEntity';
 import { useEntityGithubScmIntegration } from './useEntityGithubScmIntegration';
 
-export const useProtectedBranches = (entity: Entity) => {
+export const useProtectedBranches = ({
+  entity,
+  isPrivate = false,
+}: {
+  entity: Entity;
+  isPrivate?: boolean;
+}) => {
   const auth = useApi(githubAuthApiRef);
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo']);
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({
+      auth: isPrivate ? await auth.getAccessToken(['repo']) : undefined,
+    });
 
     const response = await octokit.request(
       'GET /repos/{owner}/{repo}/branches',
@@ -48,13 +55,20 @@ export const useProtectedBranches = (entity: Entity) => {
   };
 };
 
-export const useRepoLicence = (entity: Entity) => {
+export const useRepoLicence = ({
+  entity,
+  isPrivate = false,
+}: {
+  entity: Entity;
+  isPrivate?: boolean;
+}) => {
   const auth = useApi(githubAuthApiRef);
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo']);
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({
+      auth: isPrivate ? await auth.getAccessToken(['repo']) : undefined,
+    });
 
     let license: string = '';
     try {

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useContributor.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useContributor.ts
@@ -21,7 +21,13 @@ import { useEntityGithubScmIntegration } from './useEntityGithubScmIntegration';
 import { ContributorData } from '../components/types';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-export const useContributor = (username: string) => {
+export const useContributor = ({
+  username,
+  isPrivate = false,
+}: {
+  username: string;
+  isPrivate?: boolean;
+}) => {
   const auth = useApi(githubAuthApiRef);
   const { entity } = useEntity();
   const { baseUrl } = useEntityGithubScmIntegration(entity);
@@ -29,7 +35,7 @@ export const useContributor = (username: string) => {
   const { value, loading, error } = useAsync(async (): Promise<
     ContributorData
   > => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = isPrivate ? await auth.getAccessToken(['repo']) : undefined;
     const octokit = new Octokit({ auth: token });
 
     const response = await octokit.request(`GET /users/${username}`, {

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
@@ -28,8 +28,11 @@ export const useGithubRepository = ({
   const auth = useApi(githubAuthApiRef);
   const { value, loading, error } = useAsync(
     async (): Promise<boolean> => {
-      const token = await auth.getAccessToken(['repo'], { optional: true });
+      const token = await auth.getAccessToken(['repo'], { optional: false });
       const octokit = new Octokit({ auth: token });
+      if(token) {
+        return true;
+      }
       const githubRepositoryResponse = await octokit.rest.repos.get({
         owner,
         repo,

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
@@ -31,7 +31,7 @@ export const useGithubRepository = ({
       const token = await auth.getAccessToken(['repo'], { optional: true });
       const octokit = new Octokit({ auth: token });
       if(token) {
-        return true;
+        return false;
       }
       const githubRepositoryResponse = await octokit.rest.repos.get({
         owner,

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
@@ -16,6 +16,7 @@
 
 import { useAsync } from 'react-use';
 import { Octokit } from '@octokit/rest';
+import { githubAuthApiRef, useApi } from '@backstage/core-plugin-api';
 
 export const useGithubRepository = ({
   owner,
@@ -24,9 +25,11 @@ export const useGithubRepository = ({
   owner: string;
   repo: string;
 }) => {
+  const auth = useApi(githubAuthApiRef);
   const { value, loading, error } = useAsync(
     async (): Promise<boolean> => {
-      const octokit = new Octokit();
+      const token = await auth.getAccessToken(['repo'], { optional: true });
+      const octokit = new Octokit({ auth: token });
       const githubRepositoryResponse = await octokit.rest.repos.get({
         owner,
         repo,
@@ -34,10 +37,9 @@ export const useGithubRepository = ({
       return githubRepositoryResponse.data.private;
     },
   );
-
   return {
     value,
     loading,
-    error
+    error,
   };
 };

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
@@ -13,5 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { PullRequestsTable, PullRequestsTableView } from './PullRequestsTable';
-export type { PullRequest } from '../../hooks/usePullRequests';
+
+import { useAsync } from 'react-use';
+import { Octokit } from '@octokit/rest';
+
+export const useGithubRepository = ({
+  owner,
+  repo,
+}: {
+  owner: string;
+  repo: string;
+}) => {
+  const { value, loading, error } = useAsync(
+    async (): Promise<boolean> => {
+      const octokit = new Octokit();
+      const githubRepositoryResponse = await octokit.rest.repos.get({
+        owner,
+        repo,
+      });
+      return githubRepositoryResponse.data.private;
+    },
+  );
+
+  return {
+    value,
+    loading,
+    error
+  };
+};

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useGithubRepository.ts
@@ -28,7 +28,7 @@ export const useGithubRepository = ({
   const auth = useApi(githubAuthApiRef);
   const { value, loading, error } = useAsync(
     async (): Promise<boolean> => {
-      const token = await auth.getAccessToken(['repo'], { optional: false });
+      const token = await auth.getAccessToken(['repo'], { optional: true });
       const octokit = new Octokit({ auth: token });
       if(token) {
         return true;

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts
@@ -21,18 +21,26 @@ import { useApi, githubAuthApiRef } from '@backstage/core-plugin-api';
 import { useProjectEntity } from './useProjectEntity';
 import { useEntityGithubScmIntegration } from './useEntityGithubScmIntegration';
 
-export const useRequest = (
-  entity: Entity,
-  requestName: string,
-  perPage: number = 0,
-  maxResults: number = 0,
-  showTotal: boolean = false,
-) => {
+export const useRequest = ({
+  entity,
+  requestName,
+  perPage = 0,
+  maxResults = 0,
+  showTotal,
+  isPrivate = false,
+}: {
+  entity: Entity;
+  requestName: string;
+  perPage: number;
+  maxResults: number;
+  showTotal?: boolean;
+  isPrivate?: boolean;
+}) => {
   const auth = useApi(githubAuthApiRef);
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = isPrivate ? await auth.getAccessToken(['repo']) : undefined;
     const octokit = new Octokit({ auth: token });
 
     const response = await octokit.request(

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsApi.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsApi.ts
@@ -33,7 +33,7 @@ export type GithubPullRequestsApi = {
     state,
     baseUrl,
   }: {
-    token: string;
+    token?: string;
     owner: string;
     repo: string;
     pageSize?: number;

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsClient.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsClient.ts
@@ -16,7 +16,7 @@
 
 import { GithubPullRequestsApi } from './GithubPullRequestsApi';
 import { Octokit } from '@octokit/rest';
-import { PullsListResponseData } from '@octokit/types';
+import { PullsListResponseData} from '@octokit/types';
 import { PullRequestState } from '../types';
 
 export class GithubPullRequestsClient implements GithubPullRequestsApi {
@@ -29,7 +29,7 @@ export class GithubPullRequestsClient implements GithubPullRequestsApi {
     state = 'all',
     baseUrl,
   }: {
-    token: string;
+    token?: string;
     owner: string;
     repo: string;
     pageSize?: number;

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Icons.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Icons.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { makeStyles, Tooltip } from '@material-ui/core';
-import { PullRequest } from './usePullRequests';
+import { PullRequest } from '../hooks/usePullRequests';
 
 const useStyles = makeStyles(() => ({
   open: {

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
@@ -22,7 +22,7 @@ import {
   MissingAnnotationEmptyState
 } from '@backstage/core-components';
 import { isGithubSlugSet, GITHUB_PULL_REQUESTS_ANNOTATION } from '../../utils/isGithubSlugSet';
-import { usePullRequestsStatistics } from '../usePullRequestsStatistics';
+import { usePullRequestsStatistics } from '../../hooks/usePullRequestsStatistics';
 import {
   Box,
   CircularProgress,
@@ -34,6 +34,7 @@ import {
 } from '@material-ui/core';
 import { Entity } from '@backstage/catalog-model';
 import { useEntity } from "@backstage/plugin-catalog-react";
+import { useGithubRepository } from '../../hooks/useGithubRepository';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -62,12 +63,15 @@ const StatsCard = (props: Props) => {
   const [pageSize, setPageSize] = useState<number>(20);
   const projectName = isGithubSlugSet(entity);
   const [owner, repo] = (projectName ?? '/').split('/');
+  const { value: isPrivate } = useGithubRepository({owner, repo});
+
   const [{ statsData, loading: loadingStatistics }] = usePullRequestsStatistics(
     {
       owner,
       repo,
       pageSize,
       state: 'closed',
+      isPrivate
     },
   );
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
@@ -18,11 +18,12 @@ import { Typography, Box, ButtonGroup, Button } from '@material-ui/core';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import { Table, TableColumn, MissingAnnotationEmptyState } from '@backstage/core-components';
 import { isGithubSlugSet, GITHUB_PULL_REQUESTS_ANNOTATION } from '../../utils/isGithubSlugSet';
-import { usePullRequests, PullRequest } from '../usePullRequests';
+import { usePullRequests, PullRequest } from '../../hooks/usePullRequests';
 import { PullRequestState } from '../../types';
 import { Entity } from '@backstage/catalog-model';
 import { getStatusIconType } from '../Icons';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { useGithubRepository } from '../../hooks/useGithubRepository';
 
 const generatedColumns: TableColumn[] = [
   {
@@ -153,10 +154,12 @@ const PullRequests = (__props: TableProps) => {
   const [PRStatusFilter, setPRStatusFilter] = useState<PullRequestState>(
     'open',
   );
+  const { value: isPrivate } = useGithubRepository({owner, repo});
   const [tableProps, { retry, setPage, setPageSize }] = usePullRequests({
     state: PRStatusFilter,
     owner,
     repo,
+    isPrivate,
   });
 
   const StateFilterComponent = () => (

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
@@ -28,8 +28,11 @@ export const useGithubRepository = ({
   const auth = useApi(githubAuthApiRef);
   const { value, loading, error } = useAsync(
     async (): Promise<boolean> => {
-      const token = await auth.getAccessToken(['repo'], { optional: true });
+      const token = await auth.getAccessToken(['repo'], { optional: false });
       const octokit = new Octokit({ auth: token });
+      if(token) {
+        return true;
+      }
       const githubRepositoryResponse = await octokit.rest.repos.get({
         owner,
         repo,

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
@@ -31,7 +31,7 @@ export const useGithubRepository = ({
       const token = await auth.getAccessToken(['repo'], { optional: true });
       const octokit = new Octokit({ auth: token });
       if(token) {
-        return true;
+        return false;
       }
       const githubRepositoryResponse = await octokit.rest.repos.get({
         owner,

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
@@ -16,6 +16,7 @@
 
 import { useAsync } from 'react-use';
 import { Octokit } from '@octokit/rest';
+import { githubAuthApiRef, useApi } from '@backstage/core-plugin-api';
 
 export const useGithubRepository = ({
   owner,
@@ -24,9 +25,11 @@ export const useGithubRepository = ({
   owner: string;
   repo: string;
 }) => {
+  const auth = useApi(githubAuthApiRef);
   const { value, loading, error } = useAsync(
     async (): Promise<boolean> => {
-      const octokit = new Octokit();
+      const token = await auth.getAccessToken(['repo'], { optional: true });
+      const octokit = new Octokit({ auth: token });
       const githubRepositoryResponse = await octokit.rest.repos.get({
         owner,
         repo,
@@ -34,10 +37,9 @@ export const useGithubRepository = ({
       return githubRepositoryResponse.data.private;
     },
   );
-
   return {
     value,
     loading,
-    error
+    error,
   };
 };

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
@@ -13,5 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { PullRequestsTable, PullRequestsTableView } from './PullRequestsTable';
-export type { PullRequest } from '../../hooks/usePullRequests';
+
+import { useAsync } from 'react-use';
+import { Octokit } from '@octokit/rest';
+
+export const useGithubRepository = ({
+  owner,
+  repo,
+}: {
+  owner: string;
+  repo: string;
+}) => {
+  const { value, loading, error } = useAsync(
+    async (): Promise<boolean> => {
+      const octokit = new Octokit();
+      const githubRepositoryResponse = await octokit.rest.repos.get({
+        owner,
+        repo,
+      });
+      return githubRepositoryResponse.data.private;
+    },
+  );
+
+  return {
+    value,
+    loading,
+    error
+  };
+};

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/useGithubRepository.ts
@@ -28,7 +28,7 @@ export const useGithubRepository = ({
   const auth = useApi(githubAuthApiRef);
   const { value, loading, error } = useAsync(
     async (): Promise<boolean> => {
-      const token = await auth.getAccessToken(['repo'], { optional: false });
+      const token = await auth.getAccessToken(['repo'], { optional: true });
       const octokit = new Octokit({ auth: token });
       if(token) {
         return true;

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/usePullRequests.ts
@@ -120,8 +120,7 @@ export function usePullRequests({
 
   useEffect(() => {
     setPage(0);
-    retry();
-  }, [state, retry]);
+  }, [state]);
 
   return [
     {

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/usePullRequests.ts
@@ -121,7 +121,7 @@ export function usePullRequests({
   useEffect(() => {
     setPage(0);
     retry();
-  }, [state]);
+  }, [state, retry]);
 
   return [
     {

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/hooks/usePullRequests.ts
@@ -59,11 +59,6 @@ export function usePullRequests({
     return moment(start).fromNow();
   };
 
-  useEffect(() => {
-    setPage(0);
-    retry();
-  }, [state]);
-
   const { loading, value: prData, retry, error } = useAsyncRetry<
     PullRequest[]
   >(async () => {
@@ -122,6 +117,11 @@ export function usePullRequests({
         },
       );
   }, [page, pageSize, repo, owner]);
+
+  useEffect(() => {
+    setPage(0);
+    retry();
+  }, [state]);
 
   return [
     {


### PR DESCRIPTION
`getAccessToken` method from @backstage/core-plugin-api' verifies scope of the rights for the repo. However if rejected, this will block fetching even for public repositories. I think we need to decide if there is a need to check for scope in first place, and if not we don't have to show login screen for Github

I introduced new hook (useGithubRepository) in both GH requests and GH insights plugins and idea around it would be to decide on the repo privacy based on data from fetching the repo there. 