### PR TITLE
Make access token calls optional

### DIFF
--- a/.changeset/nine-bats-divide.md
+++ b/.changeset/nine-bats-divide.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-github-insights': minor
+'@roadiehq/backstage-plugin-github-pull-requests': minor
+---
+
+Make getAccessToken calls optional in order to fetch data for public repositories.

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ComplianceCard/ComplianceCard.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { Box, List, ListItem } from '@material-ui/core';
-import Alert from '@material-ui/lab/Alert';
+import { Alert } from '@material-ui/lab';
 import { InfoCard, Progress, StructuredMetadataTable, MissingAnnotationEmptyState } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import {
@@ -55,11 +55,12 @@ const ComplianceCard = (_props: Props) => {
   if (loading || licenseLoading) {
     return <Progress />;
   } else if (error || licenseError) {
-    return (
+    return error?.message.includes('Not Found')? (
       <Alert severity="error">
-        Error occured while fetching data for the compliance card:{' '}
-        {error?.message}
+        There was an issue with fetching this information. Check that you are logged into GitHub if this is a private repository.
       </Alert>
+    ) : (
+      <Alert severity="error">{error?.message}</Alert>
     );
   }
 

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
@@ -16,8 +16,12 @@
 
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, MissingAnnotationEmptyState } from '@backstage/core-components';
+import { Alert } from '@material-ui/lab';
+import {
+  InfoCard,
+  Progress,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import ContributorsList from './components/ContributorsList';
 import { useRequest } from '../../../hooks/useRequest';
@@ -25,7 +29,7 @@ import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScm
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
@@ -51,16 +55,21 @@ const ContributorsCard = (_props: Props) => {
   const projectAlert = isGithubInsightsAvailable(entity);
   const { owner, repo } = useProjectEntity(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
-      <Alert severity="error" className={classes.infoCard}>
-        {error.message}
+    return error?.message.includes('Not Found') ? (
+      <Alert severity="error">
+        There was an issue with fetching this information. Check that you are
+        logged into GitHub if this is a private repository.
       </Alert>
+    ) : (
+      <Alert severity="error">{error?.message}</Alert>
     );
   }
 

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -16,19 +16,23 @@
 
 import React from 'react';
 import { Chip, makeStyles, Tooltip } from '@material-ui/core';
-import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, MissingAnnotationEmptyState } from '@backstage/core-components';
+import { Alert } from '@material-ui/lab';
+import {
+  InfoCard,
+  Progress,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
 import { colors } from './colors';
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { useEntity } from '@backstage/plugin-catalog-react';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   infoCard: {
     marginBottom: theme.spacing(3),
     '& + .MuiAlert-root': {
@@ -75,16 +79,21 @@ const LanguagesCard = (_props: Props) => {
   const { value, loading, error } = useRequest(entity, 'languages', 0, 0, true);
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
-      <Alert severity="error" className={classes.infoCard}>
-        {error.message}
+    return error?.message.includes('Not Found') ? (
+      <Alert severity="error">
+        There was an issue with fetching this information. Check that you are
+        logged into GitHub if this is a private repository.
       </Alert>
+    ) : (
+      <Alert severity="error">{error?.message}</Alert>
     );
   }
   return value && owner && repo ? (
@@ -111,10 +120,10 @@ const LanguagesCard = (_props: Props) => {
                 />
               </Tooltip>
             );
-          }
+          },
         )}
       </div>
-      {Object.entries(value.data as Language).map((language) => (
+      {Object.entries(value.data as Language).map(language => (
         <Chip
           classes={{
             label: classes.label,

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -16,12 +16,12 @@
 
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
-import Alert from '@material-ui/lab/Alert';
+import { Alert } from '@material-ui/lab';
 import {
   InfoCard,
   Progress,
   MarkdownContent,
-  MissingAnnotationEmptyState
+  MissingAnnotationEmptyState,
 } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
@@ -29,7 +29,7 @@ import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScm
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
@@ -98,16 +98,21 @@ const ReadMeCard = (props: Props) => {
 
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
-      <Alert severity="error" className={classes.infoCard}>
-        {error.message}
+    return error?.message.includes('Not Found') ? (
+      <Alert severity="error">
+        There was an issue with fetching this information. Check that you are
+        logged into GitHub if this is a private repository.
       </Alert>
+    ) : (
+      <Alert severity="error">{error?.message}</Alert>
     );
   }
 

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
@@ -17,15 +17,19 @@
 import React from 'react';
 import { Link, List, ListItem, Chip } from '@material-ui/core';
 import LocalOfferOutlinedIcon from '@material-ui/icons/LocalOfferOutlined';
-import Alert from '@material-ui/lab/Alert';
-import { InfoCard, Progress, MissingAnnotationEmptyState } from '@backstage/core-components';
+import { Alert } from '@material-ui/lab';
+import {
+  InfoCard,
+  Progress,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
 import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScmIntegration';
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { styles as useStyles } from '../../utils/styles';
@@ -53,16 +57,21 @@ const ReleasesCard = (_props: Props) => {
 
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return (
-      <Alert severity="error" className={classes.infoCard}>
-        {error.message}
+    return error?.message.includes('Not Found') ? (
+      <Alert severity="error">
+        There was an issue with fetching this information. Check that you are
+        logged into GitHub if this is a private repository.
       </Alert>
+    ) : (
+      <Alert severity="error">{error?.message}</Alert>
     );
   }
 

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useComplianceHooks.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useComplianceHooks.ts
@@ -26,7 +26,7 @@ export const useProtectedBranches = (entity: Entity) => {
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = await auth.getAccessToken(['repo'], { optional: true });
     const octokit = new Octokit({ auth: token });
 
     const response = await octokit.request(
@@ -53,7 +53,7 @@ export const useRepoLicence = (entity: Entity) => {
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = await auth.getAccessToken(['repo'],{optional: true})
     const octokit = new Octokit({ auth: token });
 
     let license: string = '';

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useContributor.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useContributor.ts
@@ -29,7 +29,7 @@ export const useContributor = (username: string) => {
   const { value, loading, error } = useAsync(async (): Promise<
     ContributorData
   > => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = await auth.getAccessToken(['repo'],{optional: true})
     const octokit = new Octokit({ auth: token });
 
     const response = await octokit.request(`GET /users/${username}`, {

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts
@@ -32,7 +32,7 @@ export const useRequest = (
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = await auth.getAccessToken(['repo'],{optional: true})
     const octokit = new Octokit({ auth: token });
 
     const response = await octokit.request(

--- a/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts
@@ -32,7 +32,7 @@ export const useRequest = (
   const { baseUrl } = useEntityGithubScmIntegration(entity);
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useAsync(async (): Promise<any> => {
-    const token = await auth.getAccessToken(['repo'],{optional: true})
+    const token = await auth.getAccessToken(['repo'], { optional: true });
     const octokit = new Octokit({ auth: token });
 
     const response = await octokit.request(

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -45,7 +45,8 @@
     "moment": "^2.27.0",
     "node-fetch": "^2.6.1",
     "react-router": "6.0.0-beta.0",
-    "react-use": "^17.2.4"
+    "react-use": "^17.2.4",
+    "@material-ui/lab": "4.0.0-alpha.45"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
@@ -60,7 +60,7 @@ export function usePullRequests({
   const { loading, value: prData, retry, error } = useAsyncRetry<
     PullRequest[]
   >(async () => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = await auth.getAccessToken(['repo'],{optional: true})
     if (!repo) {
       return [];
     }

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
@@ -69,7 +69,7 @@ export function usePullRequestsStatistics({
   const { loading, value: statsData, error } = useAsyncRetry<
     PullRequestStats
   >(async () => {
-    const token = await auth.getAccessToken(['repo']);
+    const token = await auth.getAccessToken(['repo'],{optional: true})
     if (!repo) {
       return {
         avgTimeUntilMerge: 'Never',


### PR DESCRIPTION
Pass optional parameter to getAccessToken method

From documentation ->

   * If this is set to true, the user will not be prompted to log in,
   * and an empty response will be returned if there is no existing session.
   *
   * This can be used to perform a check whether the user is logged in, or if you don’t
   * want to force a user to be logged in, but provide functionality if they already are.
   * 
 This means users won’t get annoying Log-in screen. but error message will need to let them know they have to log in. It is still change in a way plugin works, since it won't look for your sign in but at least it won't be causing additional api hit rates to decide if it is public or not.