### PR TITLE
Add timeout to http requests

### DIFF
--- a/.changeset/funny-pillows-grab.md
+++ b/.changeset/funny-pillows-grab.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Adds a timeout to the http request scaffolder actions

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
@@ -182,6 +182,17 @@ describe('http', () => {
           );
         });
       });
+
+      describe("when the request timesout", () => {
+        it('fails with an error', async () => {
+          ((fetch as unknown) as jest.Mock).mockResolvedValue(new AbortController().abort());
+          await expect(
+            async () => await http(options, logger),
+          ).rejects.toThrowError(
+            'There was an issue with the request: Error: Request was aborted as it took longer than 60 seconds',
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This here adds a timeout to the http requests of 60 seconds.

The resource was taken from here: https://github.com/node-fetch/node-fetch/blob/main/%40types/index.d.ts#L90

Signed-off-by: Nicolas Arnold <nic@roadie.io>

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
