### PR TITLE
@roadiehq/scaffolder-backend-module-http-request: Allow specifying absolute Urls in the Path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Installation instructions for each plugin can be found in their individual READM
 
 Backstage is an open platform for creating developer portals. To learn more about the problems it can help solve, please check out our [Ultimate Guide to Backstage by Spotify](https://roadie.io/backstage-spotify/).
 
-## 
+##  
 
 
 

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -96,8 +96,13 @@ export function createHttpBackstageAction(options: { config: Config }) {
       const { input } = ctx;
       const token = ctx.secrets?.backstageToken;
       const { method, params } = input;
-      const url = await generateBackstageUrl(config, input.path);
-
+      let url = input.path;
+      try {
+        new URL(input.path);
+      }
+      catch{
+        url = await generateBackstageUrl(config, input.path);
+      }
       ctx.logger.info(
         `Creating ${method} request with http:backstage:proxy scaffolder action against ${url}`,
       );


### PR DESCRIPTION
This will allow the callers to specify absolute paths as well as relative ones

#### :heavy_check_mark: Checklist

- [ x] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
