### PR TITLE
Rename cards in github plugins

### DIFF
--- a/.changeset/four-phones-pretend.md
+++ b/.changeset/four-phones-pretend.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-github-insights': patch
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Renamed card names in '@roadiehq/backstage-plugin-github-pull-requests', so instead of 'Pull requests plugin' it will show 'Github Pull Requests'. In '@roadiehq/backstage-plugin-github-insights' 'Read me' card is renamed to 'Readme'.

--- a/packages/app/cypress/integration/backstage-github-insights.ts
+++ b/packages/app/cypress/integration/backstage-github-insights.ts
@@ -18,38 +18,57 @@
 import 'os';
 
 describe('GithubInsights', () => {
-    beforeEach(() => {
-        cy.saveGithubToken();
-        cy.intercept('GET', 'https://api.github.com/repos/organisation/github-project-slug/languages', { fixture: 'githubInsights/languages.json' }).as('getLanguages')
-        cy.intercept('GET', 'https://api.github.com/repos/organisation/github-project-slug/releases', { fixture: 'githubInsights/releases.json' }).as('getReleases')
-        cy.intercept('GET', 'https://api.github.com/repos/organisation/github-project-slug/readme', { fixture: 'githubInsights/readme.json' }).as('getReadme')
-        cy.visit('/catalog/default/component/sample-service')
-        cy.wait(['@getLanguages', '@getReleases', '@getReadme'])
-    })
+  beforeEach(() => {
+    cy.saveGithubToken();
+    cy.intercept(
+      'GET',
+      'https://api.github.com/repos/organisation/github-project-slug/languages',
+      { fixture: 'githubInsights/languages.json' },
+    ).as('getLanguages');
+    cy.intercept(
+      'GET',
+      'https://api.github.com/repos/organisation/github-project-slug/releases',
+      { fixture: 'githubInsights/releases.json' },
+    ).as('getReleases');
+    cy.intercept(
+      'GET',
+      'https://api.github.com/repos/organisation/github-project-slug/readme',
+      { fixture: 'githubInsights/readme.json' },
+    ).as('getReadme');
+    cy.visit('/catalog/default/component/sample-service');
+    cy.wait(['@getLanguages', '@getReleases', '@getReadme']);
+  });
 
-    describe('Navigating to GitHub Insights', () => {
-        it('should show GitHub Insights Releases in Overview tab', () => {
-            cy.contains('Releases');
-        });
-
-        it('should show GitHub Insights Languages in Overview tab', () => {
-            cy.contains('Languages');
-        });
-
-        it('should show GitHub Insights Read me in Overview tab', () => {
-            cy.contains('Read me');
-        });
-
-        it('should show GitHub Insights when navigating to Code insights tab', () => {
-
-            cy.intercept('GET', 'https://api.github.com/repos/organisation/github-project-slug/branches?protected=true', { fixture: 'githubInsights/compliance.json' }).as('getBranches')
-            cy.intercept('GET', 'https://api.github.com/repos/organisation/github-project-slug/contributors?per_page=10', { fixture: 'githubInsights/contributors.json' }).as('getContributors')
-
-            cy.visit('/catalog/default/component/sample-service/code-insights')
-
-            cy.wait(['@getBranches', '@getContributors'])
-
-            cy.contains('GitHub Insights');
-        });
+  describe('Navigating to GitHub Insights', () => {
+    it('should show GitHub Insights Releases in Overview tab', () => {
+      cy.contains('Releases');
     });
+
+    it('should show GitHub Insights Languages in Overview tab', () => {
+      cy.contains('Languages');
+    });
+
+    it('should show GitHub Insights Readme in Overview tab', () => {
+      cy.contains('Readme');
+    });
+
+    it('should show GitHub Insights when navigating to Code insights tab', () => {
+      cy.intercept(
+        'GET',
+        'https://api.github.com/repos/organisation/github-project-slug/branches?protected=true',
+        { fixture: 'githubInsights/compliance.json' },
+      ).as('getBranches');
+      cy.intercept(
+        'GET',
+        'https://api.github.com/repos/organisation/github-project-slug/contributors?per_page=10',
+        { fixture: 'githubInsights/contributors.json' },
+      ).as('getContributors');
+
+      cy.visit('/catalog/default/component/sample-service/code-insights');
+
+      cy.wait(['@getBranches', '@getContributors']);
+
+      cy.contains('GitHub Insights');
+    });
+  });
 });

--- a/packages/app/cypress/integration/backstage-github-pr.ts
+++ b/packages/app/cypress/integration/backstage-github-pr.ts
@@ -18,30 +18,36 @@
 import 'os';
 
 describe('Github Pull Requests', () => {
-    beforeEach(() => {
-        cy.saveGithubToken();
+  beforeEach(() => {
+    cy.saveGithubToken();
+  });
 
-    })
+  describe('Navigating to GitHub Pull Requests', () => {
+    it('should show GitHub Pull Requests in Overview tab', () => {
+      cy.intercept(
+        'GET',
+        'https://api.github.com/search/issues?q=state%3Aclosed%20in%3Atitle%20type%3Apr%20repo%3Aorganisation%2Fgithub-project-slug&per_page=20&page=1',
+        { fixture: 'githubPRs/pull-requests.json' },
+      ).as('getPulls');
+      cy.visit('/catalog/default/component/sample-service');
 
-    describe('Navigating to GitHub Pull Requests', () => {
-        it('should show GitHub Pull Requests in Overview tab', () => {
+      cy.wait('@getPulls');
 
-            cy.intercept('GET', 'https://api.github.com/search/issues?q=state%3Aclosed%20in%3Atitle%20type%3Apr%20repo%3Aorganisation%2Fgithub-project-slug&per_page=20&page=1', { fixture: 'githubPRs/pull-requests.json' }).as('getPulls')
-            cy.visit('/catalog/default/component/sample-service')
-
-            cy.wait('@getPulls')
-
-            cy.contains('Pull requests statistics');
-        });
-
-        it('should show GitHub Pull Requests when navigating to Pull Requests tab', () => {
-            cy.intercept('GET', 'https://api.github.com/search/issues?q=state%3Aopen%20%20in%3Atitle%20type%3Apr%20repo%3Aorganisation%2Fgithub-project-slug&per_page=5&page=1', { fixture: 'githubPRs/pull-requests.json' }).as('getPulls')
-
-            cy.visit('/catalog/default/component/sample-service/pull-requests')
-
-            cy.wait('@getPulls')
-
-            cy.contains('Pull requests plugin');
-        });
+      cy.contains('GitHub Pull Requests Statistics');
     });
+
+    it('should show GitHub Pull Requests when navigating to Pull Requests tab', () => {
+      cy.intercept(
+        'GET',
+        'https://api.github.com/search/issues?q=state%3Aopen%20%20in%3Atitle%20type%3Apr%20repo%3Aorganisation%2Fgithub-project-slug&per_page=5&page=1',
+        { fixture: 'githubPRs/pull-requests.json' },
+      ).as('getPulls');
+
+      cy.visit('/catalog/default/component/sample-service/pull-requests');
+
+      cy.wait('@getPulls');
+
+      cy.contains('GitHub Pull Requests');
+    });
+  });
 });

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -16,12 +16,12 @@
 
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
-import Alert from '@material-ui/lab/Alert';
+import { Alert } from '@material-ui/lab';
 import {
   InfoCard,
   Progress,
   MarkdownContent,
-  MissingAnnotationEmptyState
+  MissingAnnotationEmptyState,
 } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import { useRequest } from '../../../hooks/useRequest';
@@ -29,7 +29,7 @@ import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScm
 import { useProjectEntity } from '../../../hooks/useProjectEntity';
 import {
   isGithubInsightsAvailable,
-  GITHUB_INSIGHTS_ANNOTATION
+  GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
@@ -78,7 +78,7 @@ function b64DecodeUnicode(str: string): string {
   return decodeURIComponent(
     Array.prototype.map
       // eslint-disable-next-line func-names
-      .call(atob(str), function(c) {
+      .call(atob(str), function (c) {
         // eslint-disable-next-line prefer-template
         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
       })
@@ -98,7 +98,9 @@ const ReadMeCard = (props: Props) => {
 
   const projectAlert = isGithubInsightsAvailable(entity);
   if (!projectAlert) {
-    return <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
+    );
   }
 
   if (loading) {
@@ -113,13 +115,13 @@ const ReadMeCard = (props: Props) => {
 
   return value?.content && owner && repo ? (
     <InfoCard
-      title="Read me"
+      title="Readme"
       className={classes.infoCard}
       deepLink={{
         link: `//${hostname}/${owner}/${repo}/blob/${getRepositoryDefaultBranch(
           value.url,
         )}/${path}`,
-        title: 'Read me',
+        title: 'Readme',
         onClick: e => {
           e.preventDefault();
           window.open(

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsPage/PullRequestsPage.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsPage/PullRequestsPage.tsx
@@ -33,7 +33,7 @@ type Props = {
 const PullRequestsPage = (__props: Props) => (
   <Page themeId="tool">
     <Content>
-      <ContentHeader title="Pull requests plugin">
+      <ContentHeader title="GitHub Pull Requests">
         <SupportButton>
           Plugin to show a project's pull requests on GitHub
         </SupportButton>

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
@@ -19,9 +19,12 @@ import {
   InfoCard,
   InfoCardVariants,
   StructuredMetadataTable,
-  MissingAnnotationEmptyState
+  MissingAnnotationEmptyState,
 } from '@backstage/core-components';
-import { isGithubSlugSet, GITHUB_PULL_REQUESTS_ANNOTATION } from '../../utils/isGithubSlugSet';
+import {
+  isGithubSlugSet,
+  GITHUB_PULL_REQUESTS_ANNOTATION,
+} from '../../utils/isGithubSlugSet';
 import { usePullRequestsStatistics } from '../usePullRequestsStatistics';
 import {
   Box,
@@ -33,7 +36,7 @@ import {
   makeStyles,
 } from '@material-ui/core';
 import { Entity } from '@backstage/catalog-model';
-import { useEntity } from "@backstage/plugin-catalog-react";
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -72,7 +75,11 @@ const StatsCard = (props: Props) => {
   );
 
   if (!projectName || projectName === '') {
-    return <MissingAnnotationEmptyState annotation={GITHUB_PULL_REQUESTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState
+        annotation={GITHUB_PULL_REQUESTS_ANNOTATION}
+      />
+    );
   }
 
   const metadata = {
@@ -82,7 +89,10 @@ const StatsCard = (props: Props) => {
 
   return (
     <InfoCard
-      title="Pull requests statistics" className={classes.infoCard} variant={props.variant}>
+      title="GitHub Pull Requests Statistic"
+      className={classes.infoCard}
+      variant={props.variant}
+    >
       {loadingStatistics ? (
         <CircularProgress />
       ) : (
@@ -112,9 +122,13 @@ const PullRequestsStatsCard = (props: Props) => {
   const { entity } = useEntity();
   const projectName = isGithubSlugSet(entity);
   if (!projectName || projectName === '') {
-    return <MissingAnnotationEmptyState annotation={GITHUB_PULL_REQUESTS_ANNOTATION} />
+    return (
+      <MissingAnnotationEmptyState
+        annotation={GITHUB_PULL_REQUESTS_ANNOTATION}
+      />
+    );
   }
-  return <StatsCard {...props}/>
+  return <StatsCard {...props} />;
 };
 
 export default PullRequestsStatsCard;

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
@@ -89,7 +89,7 @@ const StatsCard = (props: Props) => {
 
   return (
     <InfoCard
-      title="GitHub Pull Requests Statistic"
+      title="GitHub Pull Requests Statistics"
       className={classes.infoCard}
       variant={props.variant}
     >


### PR DESCRIPTION
Renamed 'Read me' to 'Readme' and 'Pull requests plugin' to 'GitHub Pull Requests', in addition I also renamed 'Pull requests statistics' to 'GitHub Pull Requests statistics'
