### PR TITLE
Fix release for home plugins

### DIFF
--- a/.changeset/soft-cooks-tap.md
+++ b/.changeset/soft-cooks-tap.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': patch
+---
+
+update readme

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -18,5 +18,6 @@ jobs:
         with:
           # Calls out to `changeset version`, but also runs prettier
           version: yarn release
+          title: Version Packages - plugins
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/weekly-check-versions.yml
+++ b/.github/workflows/weekly-check-versions.yml
@@ -31,7 +31,7 @@ jobs:
           signoff: false
           branch: update-dependencies-${{ steps.current-time.outputs.formattedTime }}
           delete-branch: true
-          title: 'Update dependencies'
+          title: 'Update Dependencies - plugins'
           base: main
           body: |
             Update backstage dependencies

--- a/plugins/home/backstage-plugin-home-markdown/README.md
+++ b/plugins/home/backstage-plugin-home-markdown/README.md
@@ -1,6 +1,7 @@
 # Markdown Home page plugin
 
-A react component that renders a markdown file from github as a homepage component. You can configure the plugin to point to a remote markdown file in github and it will fetch that markdown file and render it inside a card componenet.
+A react component that renders a markdown file from github as a homepage component. You'll need to log in to github to be able to fetch the markdown.
+You can configure the plugin to point to a remote markdown file in github and it will fetch that markdown file and render it inside a card componenet.
 It fetches on every render but it caches based on the etag that gets returned by the github api.
 
 For the resources (links & images) currently you should use absolute urls. For example:

--- a/scripts/check-if-release.js
+++ b/scripts/check-if-release.js
@@ -62,7 +62,11 @@ async function main() {
   );
   const packageList = diff
     .split('\n')
-    .filter(path => path.match(/^(packages|plugins\/backend|plugins\/frontend|plugins\/scaffolder-actions|utils)\/[^/]+\/package\.json$/));
+    .filter(path =>
+      path.match(
+        /^(packages|plugins\/backend|plugins\/frontend|plugins\/scaffolder-actions|utils|plugins\/home)\/[^/]+\/package\.json$/,
+      ),
+    );
 
   const packageVersions = await Promise.all(
     packageList.map(async path => {


### PR DESCRIPTION
This should fix the release of the home plugins if they are the only ones that are changed in a PR.
Tweaks some PR titles in the update dependencies and version packages jobs.
Updates the markdown plugin's readme to create a new release right away