### PR TITLE
Remove caching from markdown plugin

### DIFF
--- a/.changeset/six-ways-rhyme.md
+++ b/.changeset/six-ways-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': patch
+---
+
+Remove caching to avoid duplicate content

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -77,7 +77,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
       <SidebarSearch />
       <SidebarDivider />
       {/* Global nav, not org-specific */}
-      <SidebarItem icon={HomeIcon} to="/catalog" text="Home" />
+      <SidebarItem icon={HomeIcon} to="/" text="Home" />
       <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
       <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
       <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -41,6 +41,16 @@ export const HomePage = () => {
           path=".backstage/home-page.md"
         />
       </Grid>
+
+      <Grid item xs={12} md={6}>
+        <HomePageMarkdown
+          title="History"
+          owner="RoadieHQ"
+          repo="roadie-backstage-plugins"
+          path=".backstage/home-page-test.md"
+          branch="test-two-mdown"
+        />
+      </Grid>
     </Grid>
   );
 };

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
@@ -23,20 +23,8 @@ import {
   githubAuthApiRef,
   SessionState,
 } from '@backstage/core-plugin-api';
-
+import { MarkdownContentProps, GithubCache} from './types';
 import { Button, Grid, Typography, Tooltip } from '@material-ui/core';
-
-/**
- * Props for Markdown content component {@link Content}.
- *
- * @public
- */
-export type MarkdownContentProps = {
-  owner: string;
-  repo: string;
-  path: string;
-  branch?: string;
-};
 
 /**
  * A component to render a markdown file from github
@@ -65,14 +53,14 @@ export const Content = (props: MarkdownContentProps) => {
   );
 };
 
-function GithubFileContent(props: MarkdownContentProps) {
-  const { value, loading, error } = useGithubFile(props);
+const GithubFileContent = (props: MarkdownContentProps) => {
+  const { value, loading, error } = useGithubFile({...props});
+
   if (loading) {
     return <Progress />;
   } else if (error) {
     return <Alert severity="error">{error.message}</Alert>;
   }
-
   return (
     <MarkdownContent
       content={Buffer.from(value.content, 'base64').toString('utf8')}
@@ -80,7 +68,7 @@ function GithubFileContent(props: MarkdownContentProps) {
   );
 }
 
-function GithubNotAuthorized() {
+const GithubNotAuthorized = () => {
   const githubApi = useApi(githubAuthApiRef);
   return (
     <Grid container>

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
@@ -23,35 +23,9 @@ import {
   githubAuthApiRef,
   SessionState,
 } from '@backstage/core-plugin-api';
-import { MarkdownContentProps, GithubCache} from './types';
+import { MarkdownContentProps} from './types';
 import { Button, Grid, Typography, Tooltip } from '@material-ui/core';
 
-/**
- * A component to render a markdown file from github
- *
- * @public
- */
-export const Content = (props: MarkdownContentProps) => {
-  const githubApi = useApi(githubAuthApiRef);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    const authSubscription = githubApi.sessionState$().subscribe(state => {
-      if (state === SessionState.SignedIn) {
-        setIsLoggedIn(true);
-      }
-    });
-    return () => {
-      authSubscription.unsubscribe();
-    };
-  }, [githubApi]);
-
-  return isLoggedIn ? (
-    <GithubFileContent {...props} />
-  ) : (
-    <GithubNotAuthorized />
-  );
-};
 
 const GithubFileContent = (props: MarkdownContentProps) => {
   const { value, loading, error } = useGithubFile({...props});
@@ -93,3 +67,30 @@ const GithubNotAuthorized = () => {
     </Grid>
   );
 }
+
+/**
+ * A component to render a markdown file from github
+ *
+ * @public
+ */
+export const Content = (props: MarkdownContentProps) => {
+  const githubApi = useApi(githubAuthApiRef);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const authSubscription = githubApi.sessionState$().subscribe(state => {
+      if (state === SessionState.SignedIn) {
+        setIsLoggedIn(true);
+      }
+    });
+    return () => {
+      authSubscription.unsubscribe();
+    };
+  }, [githubApi]);
+
+  return isLoggedIn ? (
+    <GithubFileContent {...props} />
+  ) : (
+    <GithubNotAuthorized />
+  );
+};

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/types.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Props for Markdown content component {@link Content}.
+ *
+ * @public
+ */
+ export type MarkdownContentProps = {
+  owner: string;
+  repo: string;
+  path: string;
+  branch?: string;
+};
+
+export const BASE_URL = 'https://api.github.com';

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/types.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/types.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Props for Markdown content component {@link Content}.
  *

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/useGithubFile.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/useGithubFile.ts
@@ -44,7 +44,7 @@ export const useGithubFile = (options: MarkdownContentProps) => {
         data,
         etag: response.headers.etag ?? '',
       };
-    } catch (e) {
+    } catch (e: any) {
       throw new Error(`Unable to gather markdown contents: ${e.message}`)
     }
     return result;


### PR DESCRIPTION
The caching caused duplicate content on render. This happens when github send back no content.

This here removes the caching so that this edge case no longer happens

[sc7740]

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
