### PR TITLE
Updated documentation to include conditionals

### DIFF
--- a/.changeset/old-pillows-remain.md
+++ b/.changeset/old-pillows-remain.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+'@roadiehq/backstage-plugin-security-insights': patch
+---
+
+Changed documentation to include entity switches

--- a/plugins/frontend/backstage-plugin-github-pull-requests/README.md
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/README.md
@@ -28,13 +28,20 @@ yarn add @roadiehq/backstage-plugin-github-pull-requests
 
 ```ts
 // packages/app/src/components/catalog/EntityPage.tsx
-import { EntityGithubPullRequestsContent } from '@roadiehq/backstage-plugin-github-pull-requests';
+import {
+  EntityGithubPullRequestsContent,
+  isGithubPullRequestsAvailable,
+} from '@roadiehq/backstage-plugin-github-pull-requests';
 ...
 
 const serviceEntityPage = (
   <EntityLayout>
     ...
-    <EntityLayout.Route path="/pull-requests" title="Pull Requests">
+    <EntityLayout.Route
+      path="/pull-requests"
+      title="Pull Requests"
+      if={isGithubPullRequestsAvailable}
+    >
       <EntityGithubPullRequestsContent />
     </EntityLayout.Route>
     ...
@@ -53,16 +60,20 @@ const serviceEntityPage = (
 
 ```ts
 // packages/app/src/components/catalog/EntityPage.tsx
-import { EntityGithubPullRequestsOverviewCard } from '@roadiehq/backstage-plugin-github-pull-requests';
+import { EntityGithubPullRequestsOverviewCard, isGithubPullRequestsAvailable } from '@roadiehq/backstage-plugin-github-pull-requests';
 
 ...
 
 const overviewContent = (
   <Grid container spacing={3}>
     ...
-    <Grid item md={6}>
-      <EntityGithubPullRequestsOverviewCard />
-    </Grid>
+    <EntitySwitch>
+      <EntitySwitch.Case if={isGithubPullRequestsAvailable}>
+        <Grid item md={6}>
+          <EntityGithubPullRequestsOverviewCard />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
     ...
   </Grid>
 );

--- a/plugins/frontend/backstage-plugin-github-pull-requests/README.md
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/README.md
@@ -40,7 +40,8 @@ const serviceEntityPage = (
     <EntityLayout.Route
       path="/pull-requests"
       title="Pull Requests"
-      if={isGithubPullRequestsAvailable}
+      // Uncomment the line below if you'd like to only show the tab on entities with the correct annotations already set
+      // if={isGithubPullRequestsAvailable}
     >
       <EntityGithubPullRequestsContent />
     </EntityLayout.Route>

--- a/plugins/frontend/backstage-plugin-security-insights/README.md
+++ b/plugins/frontend/backstage-plugin-security-insights/README.md
@@ -30,7 +30,9 @@ const serviceEntityPage = (
     <EntityLayout.Route
       path="/security-insights"
       title="Security Insights"
-      if={isSecurityInsightsAvailable}>
+      // Uncomment the line below if you'd like to only show the tab on entities with the correct annotations already set
+      // if={isSecurityInsightsAvailable}
+      >
       <EntitySecurityInsightsContent />
     </EntityLayout.Route>
     ...
@@ -53,7 +55,9 @@ const serviceEntityPage = (
     <EntityLayout.Route 
       path="/dependabot" 
       title="Dependabot"
-      if={isSecurityInsightsAvailable}>
+      // Uncomment the line below if you'd like to only show the tab on entities with the correct annotations already set
+      // if={isSecurityInsightsAvailable}
+      >
       <EntityGithubDependabotContent/>
     </EntityLayout.Route>
     ...

--- a/plugins/frontend/backstage-plugin-security-insights/README.md
+++ b/plugins/frontend/backstage-plugin-security-insights/README.md
@@ -19,7 +19,8 @@ yarn add @roadiehq/backstage-plugin-security-insights
 
 ```tsx
 import {
-  EntitySecurityInsightsContent
+  EntitySecurityInsightsContent,
+  isSecurityInsightsAvailable
 } from '@roadiehq/backstage-plugin-security-insights';
 
 
@@ -28,7 +29,8 @@ const serviceEntityPage = (
     ...
     <EntityLayout.Route
       path="/security-insights"
-      title="Security Insights">
+      title="Security Insights"
+      if={isSecurityInsightsAvailable}>
       <EntitySecurityInsightsContent />
     </EntityLayout.Route>
     ...
@@ -40,14 +42,18 @@ const serviceEntityPage = (
 
 ```tsx
 import {
-  EntityGithubDependabotContent
+  EntityGithubDependabotContent,
+  isSecurityInsightsAvailable
 } from '@roadiehq/backstage-plugin-security-insights';
 
 
 const serviceEntityPage = (
   <EntityPageLayout>
     ...
-    <EntityLayout.Route path="/dependabot" title="Dependabot">
+    <EntityLayout.Route 
+      path="/dependabot" 
+      title="Dependabot"
+      if={isSecurityInsightsAvailable}>
       <EntityGithubDependabotContent/>
     </EntityLayout.Route>
     ...


### PR DESCRIPTION
When implementing the Github PR plugin and the Security Insights plugin, we found that the default documentation did not include entity switches on some of the resources, even though it's exposed by the plugin. This PR adds the switches to the example code in the documentation.

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation (if applicable)
