### PR TITLE
Fix borken Argo CD Dashboard button

### DIFF
--- a/.changeset/chilled-cycles-cry.md
+++ b/.changeset/chilled-cycles-cry.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Fix Argo CD Dashboard button

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
@@ -8,11 +8,11 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 import {
-  Button as BackstageButton,
   StructuredMetadataTable,
 } from '@backstage/core-components';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import CloseIcon from '@material-ui/icons/Close';
+import MaterialButton from '@material-ui/core/Button';
 
 interface TableContent {
   [key: string]: any;
@@ -64,19 +64,17 @@ export const DetailsDrawerComponent = (rowData: any, baseUrl: string | undefined
     images: rowData.status?.summary?.images,
     ...(baseUrl && {
       link: (
-        <BackstageButton
-          name="Open Argo CD Dashboard"
+        <MaterialButton
           variant="outlined"
           color="primary"
           size="small"
           title='Open Argo CD Dashboard'
           endIcon={<OpenInNewIcon />}
-          component={Button}
           target="_blank"
-          to={`${baseUrl}/applications/${rowData.metadata.name}`}
+          href={`${baseUrl}/applications/${rowData.metadata.name}`}
         >
           Open Argo CD Dashboard
-        </BackstageButton>
+        </MaterialButton>
       ),
     }),
   };

--- a/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
@@ -214,7 +214,7 @@ describe('argo-cd', () => {
       fireEvent.click(drawerButton)
       expect(await rendered.findByTitle('Open Argo CD Dashboard')).toBeInTheDocument()
       expect(await rendered.findByTitle('Open Argo CD Dashboard')).toHaveAttribute(
-        'to',
+        'href',
         'www.example-argocd-url.com/applications/guestbook',
       );
     });
@@ -440,7 +440,7 @@ describe('argo-cd', () => {
       fireEvent.click(drawerButton)
       expect(await rendered.findByTitle('Open Argo CD Dashboard')).toBeInTheDocument()
       expect(await rendered.findByTitle('Open Argo CD Dashboard')).toHaveAttribute(
-        'to',
+        'href',
         'www.example-argocd-url.com/applications/guestbook',
       );
     });


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)

Hey 👋 

I've just noticed a broken button that should link to the Argo Dashboard. Looks like the button was using the `to` property, but for external links it needs to be `href` as shown in [here](https://backstage.io/storybook/?path=/story/inputs-button--button-links)

![image](https://user-images.githubusercontent.com/1393946/163980276-4cece958-9054-4cb9-bac4-1c146c918aad.png)