### PR TITLE
update catalog-info.yaml files for libraries

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,11 +3,18 @@ kind: Component
 metadata:
   name: roadie-backstage-plugins
   description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-    # github.com/project-slug: backstage/backstage
-    # backstage.io/techdocs-ref: url:https://github.com/backstage/backstage
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: website 
+  owner: group:open-source
+  lifecycle: production
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: roadie-backstage-plugins
+spec:
+  type: file
+  targets:
+    - ./plugins/**/catalog-info.yaml
+    - ./utils/**/catalog-info.yaml

--- a/plugins/backend/backstage-plugin-argo-cd-backend/catalog-info.yaml
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/catalog-info.yaml
@@ -1,19 +1,19 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-plugin-argo-cd
+  name: backstage-plugin-argo-cd-backend
   description: |
-    Backstage plugin to view and interact with Argo CD.
+    Backstage plugin Argo CD backend
   annotations:
     github.com/project-slug: roadiehq/roadie-backstage-plugins
-    github.com/project-readme-path: plugins/frontend/backstage-plugin-argo-cd/README.md
+    github.com/project-readme-path: plugins/backend/backstage-plugin-argo-cd-backend/README.md
     backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backstage-plugin-argo-cd
   tags:
     - plugin
     - oss
-    - frontend
+    - backend
   links:
-    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd
+    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd-backend
       title: NPM
 spec:
   type: library

--- a/plugins/backend/backstage-plugin-argo-cd-backend/catalog-info.yaml
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/catalog-info.yaml
@@ -7,7 +7,10 @@ metadata:
   annotations:
     github.com/project-slug: roadiehq/roadie-backstage-plugins
     github.com/project-readme-path: plugins/backend/backstage-plugin-argo-cd-backend/README.md
-    backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backstage-plugin-argo-cd
+    backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backend/backstage-plugin-argo-cd
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/backend/backstage-plugin-argo-cd-backend/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/backend/backstage-plugin-argo-cd-backend/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backend/backstage-plugin-argo-cd
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-argo-cd/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-argo-cd/catalog-info.yaml
@@ -7,7 +7,10 @@ metadata:
   annotations:
     github.com/project-slug: roadiehq/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-argo-cd/README.md
-    backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backstage-plugin-argo-cd
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-argo-cd/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-argo-cd/catalog-info.yaml
+    backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-argo-cd
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-argo-cd
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-aws-lambda/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-aws-lambda/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-aws-lambda/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-aws-lambda/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-aws-lambda/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-aws-lambda
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-bugsnag/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-bugsnag/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-bugsnag/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-bugsnag/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-bugsnag/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-bugsnag
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-bugsnag/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-bugsnag/catalog-info.yaml
@@ -1,18 +1,18 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-plugin-aws-lambda
+  name: backstage-plugin-bugsnag
   description: |
-    Backstage plugin to show the latest releases to your AWS Lambda functions.
+    Backstage plugin bugsnag
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
-    github.com/project-readme-path: plugins/frontend/backstage-plugin-aws-lambda/README.md
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-bugsnag/README.md
   tags:
     - plugin
     - oss
     - frontend
   links:
-    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-aws-lambda
+    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-bugsnag
       title: NPM
 spec:
   type: library

--- a/plugins/frontend/backstage-plugin-buildkite/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-buildkite/catalog-info.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-buildkite/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-buildkite/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-buildkite/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-buildkite
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-buildkite/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-buildkite/catalog-info.yaml
@@ -5,13 +5,15 @@ metadata:
   name: backstage-plugin-buildkite
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-buildkite/README.md
   tags:
     - plugin
     - oss
+    - frontend
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-buildkite
       title: NPM
 spec:
   type: library
-  owner: group:engineering
+  owner: group:open-source
   lifecycle: production

--- a/plugins/frontend/backstage-plugin-datadog/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-datadog/catalog-info.yaml
@@ -2,18 +2,16 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-plugin-iframe
-  description: |
-    Backstage plugin to render iframes.
+  name: backstage-plugin-datadog
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
-    github.com/project-readme-path: plugins/frontend/backstage-plugin-iframe/README.md
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-datadog/README.md
   tags:
     - plugin
     - oss
     - frontend
   links:
-    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-iframe
+    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-datadog
       title: NPM
 spec:
   type: library

--- a/plugins/frontend/backstage-plugin-datadog/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-datadog/catalog-info.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-datadog/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-datadog/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-datadog/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-datadog
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-github-insights/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-github-insights/catalog-info.yaml
@@ -5,14 +5,16 @@ metadata:
   description: |
     Backstage plugin to provide Readmes, Top Contributors and other widgets.
   annotations:
-    github.com/project-slug: roadiehq/backstage-plugin-github-insights
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-github-insights/README.md
   tags:
     - plugin
     - oss
+    - frontend
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-github-insights
       title: NPM
 spec:
   type: library
-  owner: group:engineering
+  owner: group:open-source
   lifecycle: production

--- a/plugins/frontend/backstage-plugin-github-insights/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-github-insights/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-github-insights/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-github-insights/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-github-insights/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-github-insights
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-github-pull-requests/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/catalog-info.yaml
@@ -5,15 +5,17 @@ metadata:
   description: |
     Backstage plugin to view and interact with GitHub pull requests.
   annotations:
-    github.com/project-slug: roadiehq/backstage-plugin-github-pull-requests
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-github-pull-requests/README.md
     backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/backstage-plugin-github-pull-requests/tree/main
   tags:
     - plugin
     - oss
+    - frontend
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-github-pull-requests
       title: NPM
 spec:
   type: library
-  owner: group:engineering
+  owner: group:open-source
   lifecycle: production

--- a/plugins/frontend/backstage-plugin-github-pull-requests/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/catalog-info.yaml
@@ -8,6 +8,9 @@ metadata:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-github-pull-requests/README.md
     backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/backstage-plugin-github-pull-requests/tree/main
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-github-pull-requests/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-github-pull-requests/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-github-pull-requests
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-iframe/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-iframe/catalog-info.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-iframe/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-iframe/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-iframe/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-iframe
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-jira/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-jira/catalog-info.yaml
@@ -5,15 +5,17 @@ metadata:
   description: |
     Backstage plugin to view and interact with JIRA
   annotations:
-    github.com/project-slug: roadiehq/backstage-plugin-jira
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-jira/README.md
     backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/backstage-plugin-jira/tree/main
   tags:
     - plugin
     - oss
+    - frontend
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-jira
       title: NPM
 spec:
   type: library
-  owner: group:engineering
+  owner: group:open-source
   lifecycle: production

--- a/plugins/frontend/backstage-plugin-jira/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-jira/catalog-info.yaml
@@ -8,6 +8,9 @@ metadata:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-jira/README.md
     backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/backstage-plugin-jira/tree/main
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-jira/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-jira/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-jira
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-prometheus/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-prometheus/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-prometheus/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-prometheus/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-prometheus/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-prometheus
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-prometheus/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-prometheus/catalog-info.yaml
@@ -1,18 +1,18 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-plugin-aws-lambda
+  name: backstage-plugin-prometheus
   description: |
-    Backstage plugin to show the latest releases to your AWS Lambda functions.
+    Backstage plugin to view and interact with JIRA
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
-    github.com/project-readme-path: plugins/frontend/backstage-plugin-aws-lambda/README.md
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-prometheus/README.md
   tags:
     - plugin
     - oss
     - frontend
   links:
-    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-aws-lambda
+    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-prometheus
       title: NPM
 spec:
   type: library

--- a/plugins/frontend/backstage-plugin-security-insights/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-security-insights/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-security-insights/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-security-insights/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-security-insights/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-security-insights
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-security-insights/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-security-insights/catalog-info.yaml
@@ -5,14 +5,16 @@ metadata:
   description: |
     Backstage plugin to add security insights for GitHub repos.
   annotations:
-    github.com/project-slug: roadiehq/backstage-plugin-security-insights
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-security-insights/README.md
   tags:
     - plugin
     - oss
+    - frontend
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-security-insights
       title: NPM
 spec:
   type: library
-  owner: group:engineering
+  owner: group:open-source
   lifecycle: production

--- a/plugins/frontend/backstage-plugin-travis-ci/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-travis-ci/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/frontend/backstage-plugin-travis-ci/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-travis-ci/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/frontend/backstage-plugin-travis-ci/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-travis-ci
   tags:
     - plugin
     - oss

--- a/plugins/frontend/backstage-plugin-travis-ci/catalog-info.yaml
+++ b/plugins/frontend/backstage-plugin-travis-ci/catalog-info.yaml
@@ -5,14 +5,16 @@ metadata:
   description: |
     Backstage plugin to show Travis CI builds on the CI/CD tab and widget.
   annotations:
-    github.com/project-slug: roadiehq/backstage-plugin-travis-ci
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/frontend/backstage-plugin-travis-ci/README.md
   tags:
     - plugin
     - oss
+    - frontend
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-travis-ci
       title: NPM
 spec:
   type: library
-  owner: group:engineering
+  owner: group:open-source
   lifecycle: production

--- a/plugins/home/backstage-plugin-home-markdown/catalog-info.yaml
+++ b/plugins/home/backstage-plugin-home-markdown/catalog-info.yaml
@@ -1,0 +1,23 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-home-markdown
+  description: |
+    Homapge markdown renderer plugin
+  annotations:
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: home/backstage-plugin-home-markdown/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/home/backstage-plugin-home-markdown/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/home/backstage-plugin-home-markdownr/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/home/backstage-plugin-home-markdown
+  tags:
+    - plugin
+    - oss
+    - home
+  links:
+    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-home-markdown
+      title: NPM
+spec:
+  type: library
+  owner: group:open-source
+  lifecycle: production

--- a/plugins/scaffolder-actions/scaffolder-backend-argocd/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-argocd/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: scaffolder-backend-argocd
+  description: |
+    Scaffolder actions to interact with argocd
+  annotations:
+    github.com/project-slug: RoadieHQ/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-argocd/README.md
+  tags:
+    - scaffolder
+    - oss
+  links:
+    - url: https://www.npmjs.com/package/@roadiehq/scaffolder-backend-argocd
+      title: NPM
+spec:
+  type: library
+  owner: group:open-source
+  lifecycle: production

--- a/plugins/scaffolder-actions/scaffolder-backend-argocd/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-argocd/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-argocd/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-argocd/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/scaffolder-actions/scaffolder-backend-argocd/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/scaffolder-actions/scaffolder-backend-argocd
   tags:
     - scaffolder
     - oss

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: roadiehq/roadie-backstage-plugins
     github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-aws/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/scaffolder-actions/scaffolder-backend-module-aws/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/scaffolder-actions/scaffolder-backend-module-aws
   tags:
     - scaffolder
     - oss

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: scaffolder-backend-module-aws
+  description: |
+    Scaffolder actions to interact with AWS
+  annotations:
+    github.com/project-slug: roadiehq/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
+  tags:
+    - scaffolder
+    - oss
+  links:
+    - url: https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-aws
+      title: NPM
+spec:
+  type: library
+  owner: group:open-source
+  lifecycle: production

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: roadiehq/roadie-backstage-plugins
     github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-http-request/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/scaffolder-actions/scaffolder-backend-module-http-request/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/scaffolder-actions/scaffolder-backend-module-http-request
   tags:
     - scaffolder
     - oss

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: scaffolder-backend-module-http-request
+  description: |
+    Scaffolder action to send an arbitrary http request
+  annotations:
+    github.com/project-slug: roadiehq/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
+  tags:
+    - scaffolder
+    - oss
+  links:
+    - url: https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-http-request
+      title: NPM
+spec:
+  type: library
+  owner: group:open-source
+  lifecycle: production

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: scaffolder-backend-module-utils
+  description: |
+    Some utility scaffolder actions
+  annotations:
+    github.com/project-slug: roadiehq/roadie-backstage-plugins
+    github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+  tags:
+    - scaffolder
+    - oss
+  links:
+    - url: https://www.npmjs.com/package/@roadiehq/scaffolder-backend-module-utils
+      title: NPM
+spec:
+  type: library
+  owner: group:open-source
+  lifecycle: production

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/catalog-info.yaml
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: roadiehq/roadie-backstage-plugins
     github.com/project-readme-path: plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/scaffolder-actions/scaffolder-backend-module-utils/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/plugins/scaffolder-actions/scaffolder-backend-module-utils/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/scaffolder-actions/scaffolder-backend-module-utils
   tags:
     - scaffolder
     - oss

--- a/utils/roadie-backstage-entity-validator/catalog-info.yaml
+++ b/utils/roadie-backstage-entity-validator/catalog-info.yaml
@@ -1,19 +1,17 @@
----
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-plugin-iframe
+  name: roadie-backstage-entity-validator
   description: |
-    Backstage plugin to render iframes.
+    Backstage entity validator library
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
-    github.com/project-readme-path: plugins/frontend/backstage-plugin-iframe/README.md
+    github.com/project-readme-path: utils/roadie-backstage-entity-validator/README.md
   tags:
-    - plugin
     - oss
-    - frontend
+    - utils
   links:
-    - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-iframe
+    - url: https://www.npmjs.com/package/@roadiehq/roadie-backstage-entity-validator
       title: NPM
 spec:
   type: library

--- a/utils/roadie-backstage-entity-validator/catalog-info.yaml
+++ b/utils/roadie-backstage-entity-validator/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: RoadieHQ/roadie-backstage-plugins
     github.com/project-readme-path: utils/roadie-backstage-entity-validator/README.md
+    backstage.io/view-url: https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/utils/roadie-backstage-entity-validator/catalog-info.yaml
+    backstage.io/edit-url: https://github.com/RoadieHQ/roadie-backstage-plugins/edit/main/utils/roadie-backstage-entity-validator/catalog-info.yaml
+    backstage.io/source-location: url:https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/utils/roadie-backstage-entity-validator
   tags:
     - oss
     - utils


### PR DESCRIPTION
Some cleanup around the plugins catalog info file. 
Add a top level location file to be able to ingest all the catalog files from the repo into backstage