### PR TITLE
Hide instance column in argo cards when using a single argo instance

### DIFF
--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
@@ -79,16 +79,13 @@ const OverviewComponent = ({
 }: OverviewComponentProps) => {
   const configApi = useApi(configApiRef);
   const baseUrl = configApi.getOptionalString('argocd.baseUrl');
+  const supportsMultipleArgoInstances: boolean = Boolean(configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length);
 
   const columns: TableColumn[] = [
     {
       title: 'Name',
       highlight: true,
       render: (row: any): React.ReactNode => detailsDrawerComponent(row, baseUrl)
-    },
-    {
-      title: 'Instance',
-      render: (row: any): React.ReactNode => row.metadata?.instance?.name,
     },
     {
       title: 'Sync Status',
@@ -110,6 +107,13 @@ const OverviewComponent = ({
           : '',
     },
   ];
+
+  if (supportsMultipleArgoInstances) {
+    columns.splice(1, 0, {
+      title: 'Instance',
+      render: (row: any): React.ReactNode => row.metadata?.instance?.name,
+    })
+  }
 
   return (
     <Table

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
@@ -46,6 +46,7 @@ const HistoryTable = ({
 }) => {
   const configApi = useApi(configApiRef);
   const baseUrl = configApi.getOptionalString('argocd.baseUrl');
+  const supportsMultipleArgoInstances: boolean = Boolean(configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length);
 
   const history = data.items
     ? data.items
@@ -80,10 +81,6 @@ const HistoryTable = ({
           row.app
         ),
       highlight: true,
-    },
-    {
-      title: 'Instance',
-      render: (row: any): React.ReactNode => row.instance,
     },
     {
       title: 'Deploy Started',
@@ -124,6 +121,13 @@ const HistoryTable = ({
       sorting: false,
     },
   ];
+
+  if (supportsMultipleArgoInstances) {
+    columns.splice(1, 0, {
+      title: 'Instance',
+      render: (row: any): React.ReactNode => row.metadata?.instance?.name,
+    })
+  }
 
   return (
     <Table


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes (I'm going to add tests once we agreed on a solution, see comment below)
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)

When using a single Argo instance, the column `Instance` is empty and takes up unnecessary space. In the current implementation I'm using the `argocd.appLocatorMethods` config field as an indicator to toggle the column. Maybe there is a better way of identifying this given there are two options available to make the plugin talk to multiple argo instances. I think this only works in the cases of [option 2](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-argo-cd#support-for-multiple-argo-cd-instances---option-2---argo-cd-backend-plugin) and I wonder if there is a way to do the same in case people opt for [option 1](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-argo-cd#support-for-multiple-argocd-instances---option-1). What are you thoughts?

### Before
![Screenshot 2022-04-21 at 09 40 14](https://user-images.githubusercontent.com/1393946/164404687-2e32733e-2a4a-4e81-90c2-07f6bb53cd74.png)

### After
![Screenshot 2022-04-21 at 09 39 22](https://user-images.githubusercontent.com/1393946/164404691-9d4975ab-8ddb-455e-85ab-decef66eec18.png)

