### PR TITLE
Feature/filter activity stream by component

### DIFF
--- a/.changeset/weak-timers-scream.md
+++ b/.changeset/weak-timers-scream.md
@@ -1,0 +1,7 @@
+---
+'@roadiehq/backstage-plugin-jira': minor
+---
+
+Added a new way to fetch the issues and count them. Added a functionality to filter the activity stream by component name (if present). What's more, if Confluence is also configured and connected to your JIRA instance, you might need to define the `jira.confluenceActivityFilter` variable in your `app-config.yaml` to avoid those activities to be shown in your Activity Stream.
+
+In case the annotation `jira/component` is not present, the plugin will work exactly in the same way as in the previous versions.

--- a/packages/app/cypress/fixtures/jira/searchresult.json
+++ b/packages/app/cypress/fixtures/jira/searchresult.json
@@ -1,6 +1,31 @@
 {
-    "startAt": 0,
-    "maxResults": 0,
-    "total": 1,
-    "issues": []
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 2,
+  "issues": [
+    {
+      "self": "https://backstage-test.atlassian.net/rest/api/latest/status/10003",
+      "id": "10003",
+      "key": "10003",
+      "fields": {
+        "issuetype": {
+          "id": 1,
+          "name": "Task",
+          "iconUrl": "http://example.com/avatar.jpg"
+        }
+      }
+    },
+    {
+      "self": "https://backstage-test.atlassian.net/rest/api/latest/status/10003",
+      "id": "10004",
+      "key": "10004",
+      "fields": {
+        "issuetype": {
+          "id": 3,
+          "name": "New Feature",
+          "iconUrl": "http://example.com/avatar.jpg"
+        }
+      }
+    }
+  ]
 }

--- a/packages/app/cypress/integration/jira.ts
+++ b/packages/app/cypress/integration/jira.ts
@@ -23,7 +23,7 @@ describe('Jira plugin', () => {
         cy.intercept('GET', 'http://localhost:7007/api/proxy/jira/api/rest/api/latest/project/TEST', { fixture: 'jira/project.json' }).as('getProject')
         cy.intercept('POST', 'http://localhost:7007/api/proxy/jira/api/rest/api/latest/search', { fixture: 'jira/searchresult.json' }).as('postSearchResult')
 
-        cy.intercept('GET', 'http://localhost:7007/api/proxy/jira/api/activity?maxResults=25&streams=key+IS+TEST&os_authType=basic', { fixture: 'jira/activitystream.xml' }).as('getActivity')
+        cy.intercept('GET', 'http://localhost:7007/api/proxy/jira/api/activity?maxResults=25&streams=key+IS+TEST&streams=issue-key+IS+10003+10004&os_authType=basic', { fixture: 'jira/activitystream.xml' }).as('getActivity')
         cy.intercept('GET', 'http://localhost:7007/api/proxy/jira/api/rest/api/latest/project/TEST/statuses', { fixture: 'jira/statuses.json' }).as('getStatuses')
 
         cy.visit('/catalog/default/component/sample-service')

--- a/plugins/frontend/backstage-plugin-jira/README.md
+++ b/plugins/frontend/backstage-plugin-jira/README.md
@@ -35,6 +35,8 @@ proxy:
 jira:
   # Defaults to /jira/api and can be omitted if proxy is configured for that url
   proxyPath: /jira/api
+  # Add it in case your JIRA instance is connected to Confluence, in order to filter those activities
+  confluenceActivityFilter: wiki@uuid
   # Defaults to latest and can be omitted if you want to use the latest version of the api
   apiVersion: latest
 ```
@@ -77,6 +79,16 @@ const overviewContent = (
   </Grid>
 );
 ```
+
+## How to get the Confluence Activity Filter key
+
+To filter the Confluence activities your instance needs to have the filter to select one or more types of activity from Confluence. You can check that out by executing the following command in your bash:
+
+```bash
+curl -s -H "Authorization: <TOKEN>" <JIRA_URL>/rest/activity-stream/1.0/config | jq .
+```
+
+Then, check for a Confluence filter and copy the `key` value into the tag `jira.confluenceActivityFilter` in your Backstage's `app-config.yaml`.
 
 ## How to use Jira plugin in Backstage
 

--- a/plugins/frontend/backstage-plugin-jira/config.d.ts
+++ b/plugins/frontend/backstage-plugin-jira/config.d.ts
@@ -25,6 +25,14 @@ export interface Config {
     proxyPath?: string;
 
     /**
+     * In case Confluence is also used, when filtering by component
+     * the activities from there would also appear, add this config to
+     * remove all those occurrences from the Activity Stream.
+     * @visibility frontend
+     */
+    confluenceActivityFilter?: string;
+
+    /**
      * The verison of the Jira API
      * Should be used if you do not want to use the latest Jira API.
      * @visibility frontend

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.ts
@@ -83,7 +83,7 @@ export class JiraAPI {
     const data = {
       jql,
       maxResults: -1,
-      fields: ["key", "issueType"],
+      fields: ["key", "issuetype"],
       startAt,
     };
 

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.ts
@@ -19,7 +19,15 @@ import {
   createApiRef,
   DiscoveryApi,
 } from '@backstage/core-plugin-api';
-import { IssuesCounter, IssueType, Project, Status } from '../types';
+import {
+  IssueCountElement,
+  IssueCountResult,
+  IssueCountSearchParams,
+  IssuesCounter,
+  IssueType,
+  Project,
+  Status
+} from '../types';
 import fetch from 'cross-fetch';
 
 export const jiraApiRef = createApiRef<JiraAPI>({
@@ -67,6 +75,70 @@ export class JiraAPI {
       .filter(Boolean)
       .map(i => `'${i}'`)
       .join(',');
+
+  private async pagedIssueCountRequest(apiUrl: string, jql: string, startAt: number): Promise<IssueCountResult> {
+    const data = {
+      jql,
+      maxResults: -1,
+      fields: ["key", "issueType"],
+      startAt,
+    };
+
+    const request = await fetch(`${apiUrl}search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    if (!request.ok) {
+      throw new Error(
+        `failed to fetch data, status ${request.status}: ${request.statusText}`,
+      );
+    }
+    const response: IssueCountSearchParams = await request.json();
+    const lastElement = response.startAt + response.maxResults;
+
+    return {
+      issues: response.issues,
+      next: response.total > lastElement ? lastElement : undefined,
+    };
+  }
+
+  private async getIssueCountPaged({
+    apiUrl,
+    projectKey,
+    component,
+    statusesNames,
+  }: {
+    apiUrl: string;
+    projectKey: string;
+    component: string;
+    statusesNames: Array<string>;
+  }) {
+    const statusesString = this.convertToString(statusesNames);
+
+    const jql = `project = "${projectKey}"
+      ${statusesString ? `AND status in (${statusesString})` : ''}
+      ${component ? `AND component = "${component}"` : ''}
+      AND statuscategory not in ("Done")
+    `;
+
+    let startAt: number | undefined = 0;
+    const issues: IssueCountElement[] = [];
+
+    while(startAt !== undefined) {
+      const res: IssueCountResult = await this.pagedIssueCountRequest(
+        apiUrl,
+        jql,
+        startAt,
+      );
+      startAt = res.next;
+      issues.push(...res.issues);
+    }
+
+    return issues;
+  }
 
   private async getIssuesCountByType({
     apiUrl,
@@ -134,28 +206,61 @@ export class JiraAPI {
     }
     const project = (await request.json()) as Project;
 
-    // Generate counters for each issue type
-    const issuesTypes = project.issueTypes.map((status: IssueType) => ({
-      name: status.name,
-      iconUrl: status.iconUrl,
-    }));
+    // If component not defined, execute the same code. Otherwise use paged request
+    // to fetch also the issue-keys of all the tasks for that component.
+    let issuesCounter: IssuesCounter[] = [];
+    let ticketIds: string[] = [];
 
-    const filteredIssues = issuesTypes.filter(el => el.name !== 'Sub-task');
+    if (!component) {
+      // Generate counters for each issue type
+      const issuesTypes = project.issueTypes.map((status: IssueType) => ({
+        name: status.name,
+        iconUrl: status.iconUrl,
+      }));
 
-    const issuesCounter = await Promise.all(
-      filteredIssues.map(issue => {
-        const issueType = issue.name;
-        const issueIcon = issue.iconUrl;
-        return this.getIssuesCountByType({
-          apiUrl,
-          projectKey,
-          component,
-          statusesNames,
-          issueType,
-          issueIcon,
-        });
-      }),
-    );
+      const filteredIssues = issuesTypes.filter(el => el.name !== 'Sub-task');
+
+      issuesCounter = await Promise.all(
+        filteredIssues.map(issue => {
+          const issueType = issue.name;
+          const issueIcon = issue.iconUrl;
+          return this.getIssuesCountByType({
+            apiUrl,
+            projectKey,
+            component,
+            statusesNames,
+            issueType,
+            issueIcon,
+          });
+        }),
+      );
+    } else {
+      // Get all issues, count them using reduce and generate a ticketIds array,
+      // used to filter in the activity stream
+      const issuesTypes = project.issueTypes.map((status: IssueType): IssuesCounter => ({
+        name: status.name,
+        iconUrl: status.iconUrl,
+        total: 0,
+      }));
+      const foundIssues = await this.getIssueCountPaged({
+        apiUrl,
+        projectKey,
+        component,
+        statusesNames,
+      });
+
+      issuesCounter = foundIssues.reduce((prev, curr) => {
+        const name = curr.fields.issuetype.name;
+        const idx = issuesTypes.findIndex(i => i.name === name);
+        if (idx !== -1) {
+          issuesTypes[idx].total++;
+        }
+        return prev;
+      }, issuesTypes)
+      .filter(el => el.name !== 'Sub-task');
+      
+      ticketIds = foundIssues.map(i => i.key);
+    }
 
     return {
       project: {
@@ -170,6 +275,7 @@ export class JiraAPI {
               ...status,
             }))
           : [],
+      ticketIds: ticketIds,
     };
   }
 

--- a/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/JiraCard.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/JiraCard.tsx
@@ -82,6 +82,7 @@ export const JiraCard = (_props: EntityProps) => {
   const {
     project,
     issues,
+    ticketIds,
     projectLoading,
     projectError,
     fetchProjectInfo,
@@ -175,7 +176,12 @@ export const JiraCard = (_props: EntityProps) => {
             ))}
           </Grid>
           <Divider />
-          <ActivityStream projectKey={projectKey} tokenType={tokenType}/>
+          <ActivityStream 
+            projectKey={projectKey}
+            tokenType={tokenType}
+            componentName={component}
+            ticketIds={ticketIds}
+          />
         </div>
       ) : null}
     </InfoCard>

--- a/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/components/ActivityStream.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/components/ActivityStream.tsx
@@ -116,7 +116,17 @@ const options = {
   },
 };
 
-export const ActivityStream = ({ projectKey, tokenType }: { projectKey: string, tokenType: string | undefined; }) => {
+export const ActivityStream = ({ 
+  projectKey,
+  tokenType,
+  componentName,
+  ticketIds,
+}: { 
+  projectKey: string;
+  tokenType: string | undefined;
+  componentName: string | undefined;
+  ticketIds: string[] | undefined;
+}) => {
   const classes = useStyles();
   const [size, setSize] = useState(25);
   const [disableButton, setDisableButton] = useState(false);
@@ -124,7 +134,9 @@ export const ActivityStream = ({ projectKey, tokenType }: { projectKey: string, 
   const { activities, activitiesLoading, activitiesError } = useActivityStream(
     size,
     projectKey,
-    isBearerAuth
+    componentName,
+    ticketIds,
+    isBearerAuth,
   );
 
   const showMore = useCallback(() => {

--- a/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
@@ -39,18 +39,24 @@ const decodeHtml = (html: string) => {
   return txt.value;
 };
 
-export const useActivityStream = (size: number, projectKey: string, isBearerAuth: boolean) => {
+export const useActivityStream = (
+  size: number,
+  projectKey: string,
+  componentName: string | undefined,
+  ticketIds: string[] | undefined,
+  isBearerAuth: boolean
+) => {
   const api = useApi(jiraApiRef);
 
   const getActivityStream = useCallback(async () => {
     try {
-      const response = await api.getActivityStream(size, projectKey, isBearerAuth);
+      const response = await api.getActivityStream(size, projectKey, componentName, ticketIds, isBearerAuth);
       const parsedData = JSON.parse(
         convert.xml2json(response, { compact: true, spaces: 2 }),
       );
       const mappedData = parsedData.feed.entry.map(
         (entry: ActivityStreamEntry): ActivityStreamElement => {
-          const id = getPropertyValue(entry, 'id') || `urn:uuid:${uuidv4()}`
+          const id = `urn:uuid:${uuidv4()}`;
           const time = getPropertyValue(entry, 'updated');
           const iconLink = entry.link?.find(
             link =>
@@ -86,7 +92,7 @@ export const useActivityStream = (size: number, projectKey: string, isBearerAuth
     } catch (err:any) {
       return handleError(err);
     }
-  }, [api, size, projectKey, isBearerAuth]);
+  }, [api, size, projectKey, componentName, ticketIds, isBearerAuth]);
 
   const [state, fetchActivityStream] = useAsyncFn(() => getActivityStream(), [
     size,

--- a/plugins/frontend/backstage-plugin-jira/src/hooks/useProjectInfo.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/hooks/useProjectInfo.ts
@@ -48,6 +48,7 @@ export const useProjectInfo = (
     projectLoading: state.loading,
     project: state?.value?.project,
     issues: state?.value?.issues,
+    ticketIds: state?.value?.ticketIds,
     projectError: state.error,
     fetchProjectInfo,
   };

--- a/plugins/frontend/backstage-plugin-jira/src/responseStubs.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/responseStubs.ts
@@ -152,9 +152,23 @@ export const projectResponseStub = {
 
 export const searchResponseStub = {
   startAt: 0,
-  maxResults: 0,
+  maxResults: 50,
   total: 1,
-  issues: [],
+  issues: [
+    {
+      self:
+          'https://backstage-test.atlassian.net/rest/api/latest/status/10003',
+      id: '10003',
+      key: '10003',
+      fields: {
+        issuetype: {
+          id: 1,
+          name: 'Task',
+          iconUrl: 'http://example.com/avatar.jpg',
+        },
+      },
+    }
+  ],
 };
 
 export const statusesResponseStub = [

--- a/plugins/frontend/backstage-plugin-jira/src/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import { Entity } from '@backstage/catalog-model';
 import { Dispatch, SetStateAction } from 'react';
 
@@ -74,6 +73,12 @@ export type ActivityStreamKeys =
   | 'content'
   | 'id';
 
+export type ActivityStream = {
+  feed: {
+    entry: ActivityStreamEntry[];
+  };
+};
+
 export type ActivityStreamEntry = {
   updated: PropertyValue;
   title: PropertyValue;
@@ -111,4 +116,26 @@ export type ProjectDetailsProps = {
 
 export type Status = {
   statuses: Array<{ name: string; statusCategory: { name: string } }>;
+};
+
+export type IssueCountSearchParams = {
+  startAt: number;
+  maxResults: number;
+  total: number;
+  issues: IssueCountElement[];
+};
+
+export type IssueCountElement = {
+  key: string;
+  fields: {
+    issuetype: {
+      iconUrl: string;
+      name: string;
+    };
+  };
+};
+
+export type IssueCountResult = {
+  next: number | undefined;
+  issues: IssueCountElement[];
 };


### PR DESCRIPTION
As requested in this issue: https://github.com/RoadieHQ/roadie-backstage-plugins/issues/183, when the annotation `jira/component` is defined, the Activity Stream does not filter the activities at all. However, I found a workaround to make that work.

If your JIRA instance has a filter by `issue-key`, then you can requests the changes by ticket or list of tickets.

If the component annotation is not present, then the code is going to be executed exactly in the same way as it was before, but if the component is defined, then the way of counting the issue types and to fetch the activity stream will be slightly different. First of all, the issue type will now return some data (just the `key` and the `issuetype` in order to reduce the amount of processed data) and use a pagination approach. Then, with a `reduce()`, the `IssueCounter` will be generated, and a list of `ticketIds` will be also returned. That list will be then used to fetch the activity stream, instead of the `projectKey`.

Finally, I've added another parameter to the config called `confluenceActivityFilter`, which allows you to filter out from the activity stream the events that happened in confluence and the component is also defined. Apparently the filtering is showing also the entries without `issue-key`, so filtering out all those activities solve that issue. It's described in the README.md how to obtain the key to test it.

I have tested it and it's working as expected. Let me know if you like this solution :smile: 

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
