### PR TITLE
Map number of PRs label to the respective combobox

### DIFF
--- a/.changeset/wild-islands-hang.md
+++ b/.changeset/wild-islands-hang.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Number of PRs label mapped to the respective combobox

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
@@ -34,6 +34,7 @@ import {
   MenuItem,
   Select,
   makeStyles,
+  InputLabel,
 } from '@material-ui/core';
 import { Entity } from '@backstage/catalog-model';
 import { useEntity } from '@backstage/plugin-catalog-react';
@@ -116,7 +117,7 @@ const StatsCard = (props: Props) => {
                 <MenuItem value={50}>50</MenuItem>
                 <MenuItem value={100}>100</MenuItem>
               </Select>
-              <FormHelperText>Number of PRs</FormHelperText>
+              <FormHelperText><InputLabel>Number of PRs</InputLabel></FormHelperText>
             </FormControl>
           </Box>
         </Box>


### PR DESCRIPTION
Hi team,

Mapped the text `Number of PRs` to the respective combobox, improving accessibility.

 Solves #517 
 
 Signed-off-by: Claudia Bressi cbressi@vmware.com

#### :heavy_check_mark: Checklist

- [x] Added changeset
