### PR TITLE
adds type to the method parameter in http task

### DIFF
--- a/.changeset/smart-tigers-approve.md
+++ b/.changeset/smart-tigers-approve.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Adds type to method option for the http backstage request scaffolder action. This fixes the generated documentation.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -38,6 +38,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
         properties: {
           method: {
             title: 'Method',
+            type: 'string',
             description: 'The method type of the request',
             enum: [
               'GET',


### PR DESCRIPTION
The type was missing on the method parameter in the http request module scaffolder task. This resulted in the documentation in the actions page being missing.

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/553697/168619232-a697a478-5a51-4f7c-b002-6de67760f510.png">


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
