### PR TITLE
Fix issue with the URL in JIRA plugin

### DIFF
--- a/.changeset/late-melons-teach.md
+++ b/.changeset/late-melons-teach.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-jira': patch
+---
+
+Fixed malformed URL when the confluenceActivityFilter is being used

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.ts
@@ -294,7 +294,7 @@ export class JiraAPI {
     let filterUrl = `streams=key+IS+${projectKey}`;
     if (componentName && ticketIds) {
       filterUrl += `&streams=issue-key+IS+${ticketIds.join('+')}`;
-      filterUrl += this.confluenceActivityFilter ? `${this.confluenceActivityFilter}=activity+IS+NOT+*` : '';
+      filterUrl += this.confluenceActivityFilter ? `&${this.confluenceActivityFilter}=activity+IS+NOT+*` : '';
       // Filter to remove all the changes done in Confluence, otherwise they are also shown as part of the component's activity stream
     }
 


### PR DESCRIPTION
Signed-off-by: ivgo <ivgo@spreadgroup.com>

As you might figure out in the description, I have just noticed a malformed URL when the confluence filter is being used. I only needed to add the `&` and then it got solved.

Sorry for this error.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
