### PR TITLE
Migrate aws-auth plugin

### DIFF
--- a/plugins/backend/backstage-plugin-aws-auth/.eslintrc.js
+++ b/plugins/backend/backstage-plugin-aws-auth/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint.backend')],
+};

--- a/plugins/backend/backstage-plugin-aws-auth/catalog-info.yaml
+++ b/plugins/backend/backstage-plugin-aws-auth/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-aws-auth
+  description: |
+    Backstage plugin to authenticate other plugins with AWS IAM.
+  annotations:
+    github.com/project-slug: roadiehq/backstage-plugin-aws-auth
+  tags:
+    - plugin
+    - oss
+spec:
+  type: library
+  owner: group:roadie
+  lifecycle: experimental

--- a/plugins/backend/backstage-plugin-aws-auth/package.json
+++ b/plugins/backend/backstage-plugin-aws-auth/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@roadiehq/backstage-plugin-aws-auth",
+  "version": "0.3.4",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "scripts": {
+    "start": "backstage-cli backend:dev",
+    "build": "backstage-cli backend:build",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test --passWithNoTests",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "backstage": {
+    "role": "backend-plugin"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:RoadieHQ/roadie-backstage-plugins",
+    "directory": "plugins/backend/backstage-plugin-argo-cd-backend"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "^0.9.7",
+    "@types/express": "^4.17.11",
+    "aws-sdk": "^2.902.0",
+    "cors": "^2.8.5",
+    "express": "^4.17.1",
+    "express-promise-router": "^4.1.0",
+    "helmet": "^4.5.0",
+    "winston": "^3.2.1"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.8.0",
+    "@backstage/dev-utils": "^0.2.12"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/backend/backstage-plugin-aws-auth/src/index.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './service/router';

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/aws-api.test.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/aws-api.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as winston from 'winston';
+import { getAwsApiGenerateTempCredentialsForwarder } from './aws-api';
+
+const generateTemporaryCredentials = require('./generateTemporaryCredentials.ts');
+
+const credentialsStub = 'CREDENTIALS_STUB';
+const keyIdStub = 'TEST_KEY_ID';
+const keySecretStub = 'TEST_KEY_SECRET';
+const roleArnStub = 'arn:aws:iam::123456789012:role/TEST_ROLE';
+
+const generateTemporaryCredentialsMock = jest.fn(
+  (_: string, _2: string, _3: string) => ({
+    Credentials: credentialsStub,
+  }),
+);
+
+generateTemporaryCredentials.generateTemporaryCredentials =
+  generateTemporaryCredentialsMock;
+
+const mockLogger = winston.createLogger();
+
+describe('aws-api', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should respond with auth creds in json', async () => {
+    const awsApiGenerateTempCredentialsForwarder =
+      getAwsApiGenerateTempCredentialsForwarder({
+        AWS_ACCESS_KEY_ID: keyIdStub,
+        AWS_ACCESS_KEY_SECRET: keySecretStub,
+        logger: mockLogger,
+      });
+
+    const mockResponse = () => {
+      const res = { json: jest.fn };
+      res.json = jest.fn().mockReturnValue(res);
+      return res as any;
+    };
+
+    const response = awsApiGenerateTempCredentialsForwarder(
+      {} as any,
+      mockResponse(),
+    );
+
+    expect((await response).json).toBeCalledWith(credentialsStub);
+    expect(generateTemporaryCredentialsMock).toBeCalledWith(
+      keyIdStub,
+      keySecretStub,
+      undefined,
+    );
+  });
+
+  it('should respond with auth creds in json with roleArn', async () => {
+    const awsApiGenerateTempCredentialsForwarder =
+      getAwsApiGenerateTempCredentialsForwarder({
+        AWS_ACCESS_KEY_ID: keyIdStub,
+        AWS_ACCESS_KEY_SECRET: keySecretStub,
+        logger: mockLogger,
+      });
+
+    const mockResponse = () => {
+      const res = { json: jest.fn };
+      res.json = jest.fn().mockReturnValue(res);
+      return res as any;
+    };
+
+    const response = awsApiGenerateTempCredentialsForwarder(
+      { body: { RoleArn: roleArnStub } } as any,
+      mockResponse(),
+    );
+
+    expect((await response).json).toBeCalledWith(credentialsStub);
+    expect(generateTemporaryCredentialsMock).toBeCalledWith(
+      keyIdStub,
+      keySecretStub,
+      roleArnStub,
+    );
+  });
+});

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/aws-api.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/aws-api.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { Logger } from 'winston';
+import { generateTemporaryCredentials } from './generateTemporaryCredentials';
+
+export type LambdaData = {
+  region: string;
+  functionName: string;
+  codeSize: number;
+  description: string;
+  lastModifiedDate: string;
+  runtime: string;
+  memory: number;
+};
+
+export function getAwsApiGenerateTempCredentialsForwarder({
+  AWS_ACCESS_KEY_ID,
+  AWS_ACCESS_KEY_SECRET,
+  logger,
+}: {
+  AWS_ACCESS_KEY_ID?: string;
+  AWS_ACCESS_KEY_SECRET?: string;
+  logger: Logger;
+}) {
+  return async function forwardRequest(
+    _: express.Request,
+    response: express.Response,
+  ) {
+    try {
+      const credentials = await generateTemporaryCredentials(
+        AWS_ACCESS_KEY_ID,
+        AWS_ACCESS_KEY_SECRET,
+        _.body ? _.body.RoleArn : undefined,
+      );
+      return response.json(credentials.Credentials);
+    } catch (e: any) {
+      logger.error(e);
+      return response.status(500).json({ message: e.message });
+    }
+  };
+}

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/generateTemporaryCredentials.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/generateTemporaryCredentials.ts
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import AWS from 'aws-sdk';
 
 export async function generateTemporaryCredentials(
   AWS_ACCESS_KEY_ID?: string,
   AWS_ACCESS_KEY_SECRET?: string,
-  AWS_ROLE_ARN?: string
+  AWS_ROLE_ARN?: string,
 ) {
   const defaultSessionDuration: number = 900;
   if (AWS_ACCESS_KEY_ID && AWS_ACCESS_KEY_SECRET) {

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/generateTemporaryCredentials.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/generateTemporaryCredentials.ts
@@ -1,0 +1,31 @@
+import AWS from 'aws-sdk';
+
+export async function generateTemporaryCredentials(
+  AWS_ACCESS_KEY_ID?: string,
+  AWS_ACCESS_KEY_SECRET?: string,
+  AWS_ROLE_ARN?: string
+) {
+  const defaultSessionDuration: number = 900;
+  if (AWS_ACCESS_KEY_ID && AWS_ACCESS_KEY_SECRET) {
+    AWS.config.credentials = new AWS.Credentials({
+      accessKeyId: AWS_ACCESS_KEY_ID,
+      secretAccessKey: AWS_ACCESS_KEY_SECRET,
+    });
+  }
+
+  if (AWS_ROLE_ARN) {
+    return await new AWS.STS()
+      .assumeRole({
+        RoleArn: AWS_ROLE_ARN,
+        RoleSessionName: 'backstage-plugin-aws-auth',
+        DurationSeconds: defaultSessionDuration,
+      })
+      .promise();
+  }
+
+  return await new AWS.STS()
+    .getSessionToken({
+      DurationSeconds: defaultSessionDuration,
+    })
+    .promise();
+}

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/router.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/router.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Spotify AB
+ * Copyright 2022 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { Logger } from 'winston';
 import Router from 'express-promise-router';
 import express from 'express';
@@ -23,17 +24,19 @@ export async function createRouter(logger: Logger): Promise<express.Router> {
   router.use(express.json());
 
   const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-  const AWS_ACCESS_KEY_SECRET = process.env.AWS_ACCESS_KEY_SECRET || process.env.AWS_SECRET_ACCESS_KEY;
+  const AWS_ACCESS_KEY_SECRET =
+    process.env.AWS_ACCESS_KEY_SECRET || process.env.AWS_SECRET_ACCESS_KEY;
   if (!AWS_ACCESS_KEY_ID || !AWS_ACCESS_KEY_SECRET) {
     logger.warn(
       'AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET (or AWS_SECRET_ACCESS_KEY) environment variables not set. Using default credentials provider chain.',
     );
   }
-  const awsApiGenerateTempCredentialsForwarder = getAwsApiGenerateTempCredentialsForwarder({
-    AWS_ACCESS_KEY_ID,
-    AWS_ACCESS_KEY_SECRET,
-    logger,
-  });
+  const awsApiGenerateTempCredentialsForwarder =
+    getAwsApiGenerateTempCredentialsForwarder({
+      AWS_ACCESS_KEY_ID,
+      AWS_ACCESS_KEY_SECRET,
+      logger,
+    });
   router.use('/credentials', awsApiGenerateTempCredentialsForwarder);
 
   return router;

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/router.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/router.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Logger } from 'winston';
+import Router from 'express-promise-router';
+import express from 'express';
+import { getAwsApiGenerateTempCredentialsForwarder } from './aws-api';
+
+export async function createRouter(logger: Logger): Promise<express.Router> {
+  const router = Router();
+  router.use(express.json());
+
+  const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+  const AWS_ACCESS_KEY_SECRET = process.env.AWS_ACCESS_KEY_SECRET || process.env.AWS_SECRET_ACCESS_KEY;
+  if (!AWS_ACCESS_KEY_ID || !AWS_ACCESS_KEY_SECRET) {
+    logger.warn(
+      'AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET (or AWS_SECRET_ACCESS_KEY) environment variables not set. Using default credentials provider chain.',
+    );
+  }
+  const awsApiGenerateTempCredentialsForwarder = getAwsApiGenerateTempCredentialsForwarder({
+    AWS_ACCESS_KEY_ID,
+    AWS_ACCESS_KEY_SECRET,
+    logger,
+  });
+  router.use('/credentials', awsApiGenerateTempCredentialsForwarder);
+
+  return router;
+}

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneApplication.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneApplication.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  errorHandler,
+  notFoundHandler,
+  requestLoggingHandler,
+} from '@backstage/backend-common';
+import cors from 'cors';
+import express from 'express';
+import helmet from 'helmet';
+import { Logger } from 'winston';
+import { createRouter } from './router';
+
+export async function createStandaloneApplication(
+  logger: Logger,
+): Promise<express.Application> {
+  const app = express();
+
+  app.use(helmet());
+  app.use(cors());
+  app.use(express.json());
+  app.use(requestLoggingHandler());
+  app.use('/', await createRouter(logger));
+  app.use(notFoundHandler());
+  app.use(errorHandler());
+
+  return app;
+}

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneServer.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneServer.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Server } from 'http';
+import { Logger } from 'winston';
+import { createStandaloneApplication } from './standaloneApplication';
+
+export async function startStandaloneServer(
+  parentLogger: Logger,
+): Promise<Server> {
+  const logger = parentLogger.child({ service: 'scaffolder-backend' });
+  logger.debug('Creating application...');
+
+  const app = await createStandaloneApplication(logger);
+
+  logger.debug('Starting application server...');
+  const PORT = parseInt(process.env.PORT || '5001', 10);
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(PORT, (err?: Error) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      logger.info(`Listening on port ${PORT}`);
+      resolve(server);
+    });
+  });
+}


### PR DESCRIPTION
When migration took place we didn't add https://github.com/RoadieHQ/backstage-plugin-aws-auth to monorepo.
#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
