### PR TITLE
feat(useGithubLoggedIn): check for cached token

### DIFF
--- a/.changeset/stupid-donkeys-sell.md
+++ b/.changeset/stupid-donkeys-sell.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Check for cached access token to determine logged in state

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/useGithubLoggedIn.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/useGithubLoggedIn.tsx
@@ -37,6 +37,7 @@ export const useGithubLoggedIn = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   useEffect(() => {
+    githubApi.getAccessToken('repo', { optional: true });
     const authSubscription = githubApi.sessionState$().subscribe(state => {
       if (state === SessionState.SignedIn) {
         setIsLoggedIn(true);


### PR DESCRIPTION
Optionally check for cached access token in order to set the signed-in state if it exists. This prevents the home page components from showing the `GithubNotAuthorized` component every time Backstage is refreshed if the user is already authorized with GitHub. 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
