### PR TITLE
fix(argocd): encode app selectors

### DIFF
--- a/.changeset/slimy-eyes-raise.md
+++ b/.changeset/slimy-eyes-raise.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+properly escaped app selectors

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -167,7 +167,7 @@ export class ArgoCDApiClient implements ArgoCDApi {
     const proxyUrl = await this.getBaseUrl();
     const url = options.appName
       ? `${proxyUrl}/find/name/${options.appName}`
-      : `${proxyUrl}/find/selector/${options.appSelector}`;
+      : `${proxyUrl}/find/selector/${encodeURIComponent(options.appSelector)}`;
     return fetch(url, {
       method: 'GET',
       headers: {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -167,7 +167,7 @@ export class ArgoCDApiClient implements ArgoCDApi {
     const proxyUrl = await this.getBaseUrl();
     const url = options.appName
       ? `${proxyUrl}/find/name/${options.appName}`
-      : `${proxyUrl}/find/selector/${encodeURIComponent(options.appSelector)}`;
+      : `${proxyUrl}/find/selector/${encodeURIComponent(String(options.appSelector))}`;
     return fetch(url, {
       method: 'GET',
       headers: {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
@@ -573,7 +573,7 @@ describe('argo-cd', () => {
     it('should display fetched data from one instance', async () => {
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/find/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/find/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(
               ctx.json([
@@ -608,7 +608,7 @@ describe('argo-cd', () => {
     it('should display fetched data from multiple instances', async () => {
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/find/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/find/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(
               ctx.json([
@@ -652,7 +652,7 @@ describe('argo-cd', () => {
     it('should display fetched data from multiple instances with multiple apps', async () => {
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/find/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/find/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(
               ctx.json([
@@ -701,7 +701,7 @@ describe('argo-cd', () => {
     it('should display fetched data from an instance when scanning multiple instances', async () => {
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/find/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/find/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(
               ctx.json([
@@ -749,7 +749,7 @@ describe('argo-cd', () => {
     it('should display an empty table when receiving no data from multiple instances', async () => {
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/find/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/find/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(
               ctx.json([


### PR DESCRIPTION
This fixes #559 by escaping the selectors before they are sent to the backend. There are no changes required for the backend since Express automatically decodes these values.

> NOTE: Express automatically decodes the values in req.params (using decodeURIComponent).

Source: [Express documentation](https://expressjs.com/en/api.html#req.params)

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
