### PR TITLE
GitHub pr custom query

### DIFF
--- a/.changeset/new-toes-kick.md
+++ b/.changeset/new-toes-kick.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': minor
+---
+
+Added support for custom search queries for Homepage components

--- a/plugins/frontend/backstage-plugin-github-pull-requests/README.md
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/README.md
@@ -92,6 +92,12 @@ const overviewContent = (
 
 If you didn't set up the HomePage plugin you can see the official documentation about it [here](https://github.com/backstage/backstage/tree/master/plugins/home). You'll need to have it setup to be able to include this plugin.
 
+A reasonable default will be used as a search term for both cards but you may have reasonable to provide your own query. This can be done through the `query` prop available for both cards.
+
+**TIP**: You might want to filter by a specific Github org if you have users who share a single Github account for work and personal usage.
+
+You can build up a query using [Github Advanced Search](https://github.com/search/advanced) and once you hit "Search", the query in the search bar is what you'll want to provide as your query prop.
+
 ```tsx
 //packages/app/src/components/home/HomePage.tsx
 
@@ -110,12 +116,11 @@ export const HomePage = () => {
       </Grid>
 
       <Grid item md={6} xs={12}>
-        <HomePageYourOpenPullRequestsCard />
+        <HomePageYourOpenPullRequestsCard query="org:RoadieHQ is:pr language:CSS" />
       </Grid>
     ...
   );
 };
-
 ```
 
 ## Features

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.test.tsx
@@ -63,7 +63,7 @@ describe('<RequestedReviewsCard>', () => {
       }),
     ).toBeInTheDocument();
   });
-  it('should render home card with requested reviews', async () => {
+  it('should render home card with requested reviews, using default query', async () => {
     render(
       wrapInTestApp(
         <TestApiProvider apis={apis}>
@@ -76,5 +76,23 @@ describe('<RequestedReviewsCard>', () => {
     expect(
       await screen.findByText("Test PR don't merge", { exact: false }),
     ).toBeInTheDocument();
+  });
+  it('should render home card with requested reviews, using a custom query', async () => {
+    const customQuery = "is:open is:pr review-requested:@me archived:false is:draft"
+    render(
+      wrapInTestApp(
+        <TestApiProvider apis={apis}>
+          <Content query={customQuery} />
+        </TestApiProvider>,
+      ),
+      {},
+    );
+
+    expect(
+      await screen.findByText('Revert "Sc 7454 AWS S3 docs (#640)"', { exact: false }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Test PR don't merge", { exact: false }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.tsx
@@ -26,10 +26,15 @@ import {
 } from '../../useGithubLoggedIn';
 import Alert from '@material-ui/lab/Alert';
 
-const RequestedReviewsContet = () => {
-  const { loading, error, value } = useGithubSearchPullRequest(
-    `is:open is:pr review-requested:@me archived:false`,
-  );
+type RequestedReviewsCardProps = {
+  query: string;
+};
+
+const defaultReviewsQuery = "is:open is:pr review-requested:@me archived:false"
+
+const RequestedReviewsContent = (props: RequestedReviewsCardProps) => {
+  const { query = defaultReviewsQuery } = props;
+  const { loading, error, value } = useGithubSearchPullRequest(query);
 
   if (loading) return <SkeletonPullRequestsListView />;
   if (error) return <Alert severity="error">{error.message}</Alert>;
@@ -38,8 +43,8 @@ const RequestedReviewsContet = () => {
     <PullRequestsListView data={value} emptyStateText="No requested reviews." />
   );
 };
-export const Content = () => {
+export const Content = (props: RequestedReviewsCardProps) => {
   const isLoggedIn = useGithubLoggedIn();
 
-  return isLoggedIn ? <RequestedReviewsContet /> : <GithubNotAuthorized />;
+  return isLoggedIn ? <RequestedReviewsContent {...props} /> : <GithubNotAuthorized />;
 };

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.test.tsx
@@ -62,7 +62,7 @@ describe('<YourOpenPullRequestCard>', () => {
       }),
     ).toBeInTheDocument();
   });
-  it('should render home card with requested reviews', async () => {
+  it('should render home card with requested pull requests, using default query', async () => {
     render(
       wrapInTestApp(
         <TestApiProvider apis={apis}>
@@ -77,5 +77,27 @@ describe('<YourOpenPullRequestCard>', () => {
         exact: false,
       }),
     ).toBeInTheDocument();
+  });
+  it('should render home card with requested pull requests, using custom query', async () => {
+    const customQuery = "is:open is:pr author@me archived: false is:draft"
+    render(
+      wrapInTestApp(
+        <TestApiProvider apis={apis}>
+          <Content query={customQuery} />
+        </TestApiProvider>,
+      ),
+      {},
+    );
+
+    expect(
+      await screen.findByText('add poc', {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('add github homepage PR components', {
+        exact: false,
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.tsx
@@ -26,10 +26,15 @@ import {
 } from '../../useGithubLoggedIn';
 import Alert from '@material-ui/lab/Alert';
 
-const OpenPullRequestsContent = () => {
-  const { loading, error, value } = useGithubSearchPullRequest(
-    `is:open is:pr author:@me archived:false`,
-  );
+type OpenPullRequestsCardProps = {
+  query: string;
+};
+
+const defaultPullRequestsQuery = "is:open is:pr author:@me archived:false"
+
+const OpenPullRequestsContent = (props: OpenPullRequestsCardProps) => {
+  const { query = defaultPullRequestsQuery } = props;
+  const { loading, error, value } = useGithubSearchPullRequest(query);
 
   if (loading) return <SkeletonPullRequestsListView />;
   if (error) return <Alert severity="error">{error.message}</Alert>;
@@ -41,7 +46,7 @@ const OpenPullRequestsContent = () => {
     />
   );
 };
-export const Content = () => {
+export const Content = (props: OpenPullRequestsCardProps) => {
   const isLoggedIn = useGithubLoggedIn();
-  return isLoggedIn ? <OpenPullRequestsContent /> : <GithubNotAuthorized />;
+  return isLoggedIn ? <OpenPullRequestsContent {...props} /> : <GithubNotAuthorized />;
 };

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/mocks/handlers.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/mocks/handlers.ts
@@ -18,9 +18,11 @@ import { rest } from 'msw';
 import {
   openPullsRequestMock,
   requestedReviewsMock,
+  requestedReviewsCustomQueryMock,
   repoMock,
   marketingSiteMock,
   yourOpenPullRequests,
+  yourOpenDraftPullRequests,
   closedPullsRequestMock,
   backstagePluginArgoCdMocks,
 } from './mocks';
@@ -28,17 +30,20 @@ import {
 export const handlers = [
   rest.get('https://api.github.com/search/issues', (req, res, ctx) => {
     const query = req.url.searchParams.get('q');
-    if (query === 'is:open is:pr review-requested:@me archived:false') {
-      return res(ctx.json(requestedReviewsMock));
-    } else if (query === 'is:open is:pr author:@me archived:false') {
-      return res(ctx.json(yourOpenPullRequests));
-    } else if (
-      query ===
-      'state:closed in:title type:pr repo:RoadieHQ/backstage-plugin-argo-cd'
-    ) {
-      return res(ctx.json(closedPullsRequestMock));
+    switch(query) {
+      case 'is:open is:pr review-requested:@me archived:false':
+        return res(ctx.json(requestedReviewsMock))
+      case 'is:open is:pr review-requested:@me archived:false is:draft':
+        return res(ctx.json(requestedReviewsCustomQueryMock))
+      case 'is:open is:pr author:@me archived:false':
+        return res(ctx.json(yourOpenPullRequests))
+      case 'is:open is:pr author@me archived: false is:draft':
+        return res(ctx.json(yourOpenDraftPullRequests))
+      case 'state:closed in:title type:pr repo:RoadieHQ/backstage-plugin-argo-cd':
+        return res(ctx.json(closedPullsRequestMock))
+      default:
+        return res(ctx.json(openPullsRequestMock))
     }
-    return res(ctx.json(openPullsRequestMock));
   }),
   rest.get(
     'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins',

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/mocks/mocks.ts
@@ -750,6 +750,87 @@ export const requestedReviewsMock = {
     },
   ],
 };
+export const requestedReviewsCustomQueryMock = {
+  total_count: 1,
+  incomplete_results: false,
+  items: [
+    {
+      url: 'https://api.github.com/repos/RoadieHQ/marketing-site/issues/650',
+      repository_url: 'https://api.github.com/repos/RoadieHQ/marketing-site',
+      labels_url:
+        'https://api.github.com/repos/RoadieHQ/marketing-site/issues/650/labels{/name}',
+      comments_url:
+        'https://api.github.com/repos/RoadieHQ/marketing-site/issues/650/comments',
+      events_url:
+        'https://api.github.com/repos/RoadieHQ/marketing-site/issues/650/events',
+      html_url: 'https://github.com/RoadieHQ/marketing-site/pull/650',
+      id: 1183476633,
+      node_id: 'PR_kwDOEIx70M41KGvn',
+      number: 650,
+      title: 'Revert "Sc 7454 AWS S3 docs (#640)"',
+      user: {
+        login: 'iain-b',
+        id: 1415599,
+        node_id: 'MDQ6VXNlcjE0MTU1OTk=',
+        avatar_url: 'https://avatars.githubusercontent.com/u/1415599?v=4',
+        gravatar_id: '',
+        url: 'https://api.github.com/users/iain-b',
+        html_url: 'https://github.com/iain-b',
+        followers_url: 'https://api.github.com/users/iain-b/followers',
+        following_url:
+          'https://api.github.com/users/iain-b/following{/other_user}',
+        gists_url: 'https://api.github.com/users/iain-b/gists{/gist_id}',
+        starred_url:
+          'https://api.github.com/users/iain-b/starred{/owner}{/repo}',
+        subscriptions_url: 'https://api.github.com/users/iain-b/subscriptions',
+        organizations_url: 'https://api.github.com/users/iain-b/orgs',
+        repos_url: 'https://api.github.com/users/iain-b/repos',
+        events_url: 'https://api.github.com/users/iain-b/events{/privacy}',
+        received_events_url:
+          'https://api.github.com/users/iain-b/received_events',
+        type: 'User',
+        site_admin: false,
+      },
+      labels: [],
+      state: 'open',
+      locked: false,
+      assignee: null,
+      assignees: [],
+      milestone: null,
+      comments: 2,
+      created_at: '2022-03-28T13:51:40Z',
+      updated_at: '2022-03-28T13:52:53Z',
+      closed_at: null,
+      author_association: 'CONTRIBUTOR',
+      active_lock_reason: null,
+      draft: true,
+      pull_request: {
+        url: 'https://api.github.com/repos/RoadieHQ/marketing-site/pulls/650',
+        html_url: 'https://github.com/RoadieHQ/marketing-site/pull/650',
+        diff_url: 'https://github.com/RoadieHQ/marketing-site/pull/650.diff',
+        patch_url: 'https://github.com/RoadieHQ/marketing-site/pull/650.patch',
+        merged_at: null,
+      },
+      body: 'This reverts commit d54d9a533d48b9024b892a188e1b7102962d4d34.',
+      reactions: {
+        url: 'https://api.github.com/repos/RoadieHQ/marketing-site/issues/650/reactions',
+        total_count: 0,
+        '+1': 0,
+        '-1': 0,
+        laugh: 0,
+        hooray: 0,
+        confused: 0,
+        heart: 0,
+        rocket: 0,
+        eyes: 0,
+      },
+      timeline_url:
+        'https://api.github.com/repos/RoadieHQ/marketing-site/issues/650/timeline',
+      performed_via_github_app: null,
+      score: 1,
+    }
+  ],
+};
 export const repoMock = {
   id: 375261048,
   node_id: 'MDEwOlJlcG9zaXRvcnkzNzUyNjEwNDg=',
@@ -1167,7 +1248,7 @@ export const yourOpenPullRequests = {
       closed_at: null,
       author_association: 'CONTRIBUTOR',
       active_lock_reason: null,
-      draft: true,
+      draft: false,
       pull_request: {
         url: 'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/pulls/457',
         html_url:
@@ -1196,6 +1277,92 @@ export const yourOpenPullRequests = {
       performed_via_github_app: null,
       score: 1,
     },
+    {
+      url: 'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450',
+      repository_url:
+        'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins',
+      labels_url:
+        'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450/labels{/name}',
+      comments_url:
+        'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450/comments',
+      events_url:
+        'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450/events',
+      html_url: 'https://github.com/RoadieHQ/roadie-backstage-plugins/pull/450',
+      id: 1166632752,
+      node_id: 'PR_kwDOFl4HeM40T37p',
+      number: 450,
+      title: 'add poc',
+      user: {
+        login: 'kissmikijr',
+        id: 24729496,
+        node_id: 'MDQ6VXNlcjI0NzI5NDk2',
+        avatar_url: 'https://avatars.githubusercontent.com/u/24729496?v=4',
+        gravatar_id: '',
+        url: 'https://api.github.com/users/kissmikijr',
+        html_url: 'https://github.com/kissmikijr',
+        followers_url: 'https://api.github.com/users/kissmikijr/followers',
+        following_url:
+          'https://api.github.com/users/kissmikijr/following{/other_user}',
+        gists_url: 'https://api.github.com/users/kissmikijr/gists{/gist_id}',
+        starred_url:
+          'https://api.github.com/users/kissmikijr/starred{/owner}{/repo}',
+        subscriptions_url:
+          'https://api.github.com/users/kissmikijr/subscriptions',
+        organizations_url: 'https://api.github.com/users/kissmikijr/orgs',
+        repos_url: 'https://api.github.com/users/kissmikijr/repos',
+        events_url: 'https://api.github.com/users/kissmikijr/events{/privacy}',
+        received_events_url:
+          'https://api.github.com/users/kissmikijr/received_events',
+        type: 'User',
+        site_admin: false,
+      },
+      labels: [],
+      state: 'open',
+      locked: false,
+      assignee: null,
+      assignees: [],
+      milestone: null,
+      comments: 0,
+      created_at: '2022-03-11T16:43:06Z',
+      updated_at: '2022-03-11T16:43:06Z',
+      closed_at: null,
+      author_association: 'CONTRIBUTOR',
+      active_lock_reason: null,
+      draft: true,
+      pull_request: {
+        url: 'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/pulls/450',
+        html_url:
+          'https://github.com/RoadieHQ/roadie-backstage-plugins/pull/450',
+        diff_url:
+          'https://github.com/RoadieHQ/roadie-backstage-plugins/pull/450.diff',
+        patch_url:
+          'https://github.com/RoadieHQ/roadie-backstage-plugins/pull/450.patch',
+        merged_at: null,
+      },
+      body: '<!-- Please describe what these changes achieve -->\r\nA POC to drive plugin behaviour based on UserEntity annotations.',
+      reactions: {
+        url: 'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450/reactions',
+        total_count: 0,
+        '+1': 0,
+        '-1': 0,
+        laugh: 0,
+        hooray: 0,
+        confused: 0,
+        heart: 0,
+        rocket: 0,
+        eyes: 0,
+      },
+      timeline_url:
+        'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450/timeline',
+      performed_via_github_app: null,
+      score: 1,
+    },
+  ],
+};
+export const yourOpenDraftPullRequests = {
+  total_count: 1,
+  incomplete_results: false,
+  items: [
     {
       url: 'https://api.github.com/repos/RoadieHQ/roadie-backstage-plugins/issues/450',
       repository_url:


### PR DESCRIPTION
Closes: #562

This PR adds support for a custom `query` prop on the various homepage components provided by `@roadiehq/backstage-plugin-github-pull-requests`

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
