### PR TITLE
hide the internal url for the http scaffolder action

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -100,7 +100,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
       const url = await generateBackstageUrl(config, input.path);
 
       ctx.logger.info(
-        `Creating ${method} request with http:backstage:proxy scaffolder action against ${url}`,
+        `Creating ${method} request with http:backstage:proxy scaffolder action against ${input.path}`,
       );
 
       const queryParams: string = params


### PR DESCRIPTION
The scaffolder action is using the discovery api to build the url
to use to contact the backend. This url was being printed to the
scaffolder task log. This exposes the user to the internal network
setup of backstage.

This tunes the log line to remove the internal url.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
