### PR TITLE
use sha256 for the resource names from aws

### DIFF
--- a/.changeset/fresh-jars-study.md
+++ b/.changeset/fresh-jars-study.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-aws': patch
+---
+
+Use a sha256 of the arn for the aws resource names.

--- a/plugins/backend/catalog-backend-module-aws/package.json
+++ b/plugins/backend/catalog-backend-module-aws/package.json
@@ -49,6 +49,7 @@
     "@aws-sdk/client-cloudcontrol": "3.76.0",
     "@aws-sdk/credential-providers": "3.76.0",
     "@aws-sdk/lib-dynamodb": "3.76.0",
+    "crypto-js": "^4.1.1",
     "link2aws": "^1.0.8",
     "lodash": "^4.17.21",
     "p-limit": "^3.0.2",
@@ -57,6 +58,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.17.0",
     "@types/lodash": "^4.14.151",
+    "@types/crypto-js": "^4.1.1",
     "aws-sdk-client-mock": "^0.6.2",
     "yaml": "^1.9.2"
   },

--- a/plugins/backend/catalog-backend-module-aws/src/annotations.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/annotations.ts
@@ -21,3 +21,5 @@ export const ANNOTATION_AWS_LAMBDA_FUNCTION_ARN =
 export const ANNOTATION_AWS_S3_BUCKET_ARN = 'amazon.com/s3-bucket-arn';
 export const ANNOTATION_AWS_DDB_TABLE_ARN = 'amazon.com/dynamo-db-table-arn';
 export const ANNOTATION_AWS_EKS_CLUSTER_ARN = 'amazon.com/eks-cluster-arn';
+export const ANNOTATION_ACCOUNT_ID = 'amazon.com/account-id';
+

--- a/plugins/backend/catalog-backend-module-aws/src/processors/AWSIAMRoleProcessor.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/processors/AWSIAMRoleProcessor.ts
@@ -32,6 +32,7 @@ import { Config } from '@backstage/config';
 import * as winston from 'winston';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { CatalogClient, CatalogApi } from '@backstage/catalog-client';
+import { arnToName } from "../utils/arnToName";
 
 export class AWSIAMRoleProcessor extends AWSCatalogProcessor {
   static fromConfig(
@@ -72,8 +73,8 @@ export class AWSIAMRoleProcessor extends AWSCatalogProcessor {
 
     const relatedEntities = await this.catalogApi.getEntities({
       filter: {
-        [`metadata.annotations.${ANNOTATION_AWS_IAM_ROLE_ARN}`]:
-          resource.metadata.annotations[ANNOTATION_AWS_IAM_ROLE_ARN],
+        'metadata.name':
+          arnToName(resource.metadata.annotations[ANNOTATION_AWS_IAM_ROLE_ARN]),
       },
     });
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.ts
@@ -31,6 +31,7 @@ import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
 import { merge } from 'lodash';
 import { mapColumnsToEntityValues } from '../utils/columnMapper';
 import * as winston from 'winston';
+import {ANNOTATION_ACCOUNT_ID, ANNOTATION_AWS_DDB_TABLE_ARN} from "../annotations";
 
 export type ValueMapping = {
   entityPath: string;
@@ -108,7 +109,7 @@ export class AWSDynamoDbTableDataProvider implements EntityProvider {
     };
 
     if (account.Account) {
-      defaultAnnotations['amazon.com/account-id'] = account.Account;
+      defaultAnnotations[ANNOTATION_ACCOUNT_ID] = account.Account;
     }
 
     this.logger.info(`Querying table ${this.tableDataConfig.tableName}`);
@@ -137,9 +138,10 @@ export class AWSDynamoDbTableDataProvider implements EntityProvider {
             metadata: {
               annotations: {
                 ...defaultAnnotations,
-                ...(tableArn ? { 'amazon.com/dynamo-db-table': tableArn } : {}),
+                ...(tableArn ? { [ANNOTATION_AWS_DDB_TABLE_ARN]: tableArn } : {}),
               },
               name: row[idColumn],
+              title: row[idColumn],
             },
             spec: {
               owner: this.accountId,

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
@@ -20,6 +20,7 @@ import * as winston from 'winston';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ComponentEntity } from '@backstage/catalog-model';
 import { ANNOTATION_AWS_DDB_TABLE_ARN } from '../annotations';
+import { arnToName } from '../utils/arnToName';
 
 /**
  * Provides entities from AWS DynamoDB service.
@@ -82,7 +83,8 @@ export class AWSDynamoDbTableProvider extends AWSEntityProvider {
                     ...defaultAnnotations,
                     [ANNOTATION_AWS_DDB_TABLE_ARN]: table.TableArn,
                   },
-                  name: table.TableName.slice(0, 62),
+                  name: arnToName(table.TableArn),
+                  title: table.TableName
                 },
                 spec: {
                   owner: this.accountId,

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.test.ts
@@ -98,7 +98,7 @@ describe('AWSEKSClusterProvider', () => {
             entity: expect.objectContaining({
               kind: 'Resource',
               metadata: expect.objectContaining({
-                name: 'cluster1',
+                title: 'cluster1',
                 annotations: expect.objectContaining({
                   [ANNOTATION_AWS_EKS_CLUSTER_ARN]:
                     'arn:aws:eks:eu-west-1:123456789012:cluster/cluster1',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.ts
@@ -23,6 +23,7 @@ import {
   ANNOTATION_AWS_EKS_CLUSTER_ARN,
   ANNOTATION_AWS_IAM_ROLE_ARN,
 } from '../annotations';
+import { arnToName } from '../utils/arnToName';
 
 /**
  * Provides entities from AWS EKS Cluster service.
@@ -88,7 +89,8 @@ export class AWSEKSClusterProvider extends AWSEntityProvider {
             apiVersion: 'backstage.io/v1beta1',
             metadata: {
               annotations,
-              name,
+              name: arnToName(name),
+              title: name,
             },
             spec: {
               owner: 'unknown',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
@@ -26,6 +26,7 @@ import {
   ANNOTATION_ORIGIN_LOCATION,
   ANNOTATION_LOCATION,
 } from '@backstage/catalog-model';
+import {ANNOTATION_ACCOUNT_ID} from "../annotations";
 
 export abstract class AWSEntityProvider implements EntityProvider {
   protected readonly accountId: string;
@@ -69,7 +70,7 @@ export abstract class AWSEntityProvider implements EntityProvider {
     };
 
     if (account.Account) {
-      defaultAnnotations['amazon.com/account-id'] = account.Account;
+      defaultAnnotations[ANNOTATION_ACCOUNT_ID] = account.Account;
     }
 
     return defaultAnnotations;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.test.ts
@@ -89,7 +89,7 @@ describe('AWSIAMRoleProvider', () => {
             entity: expect.objectContaining({
               kind: 'Resource',
               metadata: expect.objectContaining({
-                name: 'asdfewfwef',
+                title: 'adsf',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
@@ -20,6 +20,7 @@ import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_IAM_ROLE_ARN } from '../annotations';
+import { arnToName } from "../utils/arnToName";
 
 const link2aws = require('link2aws');
 
@@ -79,7 +80,8 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
                 [ANNOTATION_AWS_IAM_ROLE_ARN]: role.Arn,
                 [ANNOTATION_VIEW_URL]: consoleLink.toString(),
               },
-              name: role.RoleId,
+              name: arnToName(role.Arn),
+              title: role.RoleName
             },
             spec: {
               type: 'aws-role',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.test.ts
@@ -89,7 +89,7 @@ describe('AWSIAMUserProvider', () => {
             entity: expect.objectContaining({
               kind: 'User',
               metadata: expect.objectContaining({
-                name: 'asdferfhef123asdf',
+                title: 'adsf',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
@@ -20,6 +20,7 @@ import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_IAM_USER_ARN } from '../annotations';
+import { arnToName } from '../utils/arnToName';
 
 const link2aws = require('link2aws');
 
@@ -79,7 +80,8 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
                 [ANNOTATION_AWS_IAM_USER_ARN]: user.Arn,
                 [ANNOTATION_VIEW_URL]: consoleLink.toString(),
               },
-              name: user.UserId,
+              name: arnToName(user.Arn),
+              title: user.UserName,
             },
             spec: {
               profile: {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.test.ts
@@ -89,7 +89,7 @@ describe('AWSLambdaFunctionProvider', () => {
             entity: expect.objectContaining({
               kind: 'Component',
               metadata: expect.objectContaining({
-                name: 'my-function',
+                title: 'my-function',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
@@ -23,6 +23,7 @@ import {
   ANNOTATION_AWS_IAM_ROLE_ARN,
   ANNOTATION_AWS_LAMBDA_FUNCTION_ARN,
 } from '../annotations';
+import { arnToName } from "../utils/arnToName";
 
 const link2aws = require('link2aws');
 
@@ -88,7 +89,8 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
             apiVersion: 'backstage.io/v1beta1',
             metadata: {
               annotations,
-              name: lambdaFunction.FunctionName,
+              name: arnToName(lambdaFunction.FunctionArn),
+              title: lambdaFunction.FunctionName
             },
             spec: {
               owner: 'unknown',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.test.ts
@@ -88,7 +88,7 @@ describe('AWSS3BucketProvider', () => {
             entity: expect.objectContaining({
               kind: 'Resource',
               metadata: expect.objectContaining({
-                name: 'my-bucket',
+                title: 'my-bucket',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
@@ -20,6 +20,7 @@ import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_S3_BUCKET_ARN } from '../annotations';
+import { arnToName } from '../utils/arnToName';
 
 const link2aws = require('link2aws');
 
@@ -73,7 +74,8 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
               [ANNOTATION_AWS_S3_BUCKET_ARN]: bucketArn,
               [ANNOTATION_VIEW_URL]: consoleLink,
             },
-            name: bucket.Name,
+            name: arnToName(bucketArn),
+            title: bucket.Name,
           },
           spec: {
             owner: 'unknown',

--- a/plugins/backend/catalog-backend-module-aws/src/utils/arnToName.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/utils/arnToName.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SHA256 } from 'crypto-js'
+
+export function arnToName(
+  arn: string
+) {
+  return SHA256(arn).toString().slice(0, 63)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7064,6 +7064,11 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
+"@types/crypto-js@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.1.1.tgz#602859584cecc91894eb23a4892f38cfa927890d"
+  integrity sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==
+
 "@types/d3-path@^1":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
@@ -10388,6 +10393,11 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
 
 css-box-model@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
This is a better way to name the resources. They are more likely to
be universally unique across all aws resources across accounts.

This adds in the title, which makes the resources more readable in the
backstage UI also.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
