### PR TITLE
allow naming strategies for okta user and groups

### DIFF
--- a/.changeset/smart-terms-build.md
+++ b/.changeset/smart-terms-build.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': minor
+---
+
+Allow various strategies for naming the resulting entities for the Okta entity providers.

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -35,8 +35,14 @@ export default async function createPlugin(
   for (const config of env.config.getOptionalConfigArray(
     'catalog.providers.okta',
   ) || []) {
-    const groupProvider = OktaGroupEntityProvider.fromConfig(config, {...env, namingStrategy: "kebab-case-name" });
-    const userProvider = OktaUserEntityProvider.fromConfig(config, {...env, namingStrategy: "kebab-case-email" });
+    const groupProvider = OktaGroupEntityProvider.fromConfig(config, {
+      ...env,
+      namingStrategy: 'kebab-case-name',
+    });
+    const userProvider = OktaUserEntityProvider.fromConfig(config, {
+      ...env,
+      namingStrategy: 'kebab-case-email',
+    });
 
     builder.addEntityProvider(groupProvider);
     builder.addEntityProvider(userProvider);

--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -35,8 +35,8 @@ export default async function createPlugin(
   for (const config of env.config.getOptionalConfigArray(
     'catalog.providers.okta',
   ) || []) {
-    const groupProvider = OktaGroupEntityProvider.fromConfig(config, env);
-    const userProvider = OktaUserEntityProvider.fromConfig(config, env);
+    const groupProvider = OktaGroupEntityProvider.fromConfig(config, {...env, namingStrategy: "kebab-case-name" });
+    const userProvider = OktaUserEntityProvider.fromConfig(config, {...env, namingStrategy: "kebab-case-email" });
 
     builder.addEntityProvider(groupProvider);
     builder.addEntityProvider(userProvider);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
@@ -34,7 +34,7 @@ jest.mock('@okta/okta-sdk-nodejs', () => {
   };
 });
 
-const logger = getVoidLogger()
+const logger = getVoidLogger();
 
 describe('OktaGroupProvider', () => {
   const config = new ConfigReader({
@@ -101,12 +101,14 @@ describe('OktaGroupProvider', () => {
       });
     });
 
-
     it('allows kebab casing of the group name for the name', async () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
       };
-      const provider = OktaGroupEntityProvider.fromConfig(config, { logger, namingStrategy: "kebab-case-name" });
+      const provider = OktaGroupEntityProvider.fromConfig(config, {
+        logger,
+        namingStrategy: 'kebab-case-name',
+      });
       provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toBeCalledWith({

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
@@ -68,7 +68,7 @@ describe('OktaGroupProvider', () => {
           {
             id: 'asdfwefwefwef',
             profile: {
-              name: 'Everyone',
+              name: 'Everyone@the-company',
               description: 'Everyone in the company',
             },
             listUsers: () => {
@@ -94,6 +94,29 @@ describe('OktaGroupProvider', () => {
               kind: 'Group',
               metadata: expect.objectContaining({
                 name: 'asdfwefwefwef',
+              }),
+            }),
+          }),
+        ],
+      });
+    });
+
+
+    it('allows kebab casing of the group name for the name', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+      };
+      const provider = OktaGroupEntityProvider.fromConfig(config, { logger, namingStrategy: "kebab-case-name" });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Group',
+              metadata: expect.objectContaining({
+                name: 'everyone-the-company',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -18,7 +18,11 @@ import { GroupEntity } from '@backstage/catalog-model';
 import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { OktaEntityProvider } from './OktaEntityProvider';
-import {GroupNamingStrategy, groupNamingStrategyFactory} from './groupNamingStrategyFactory';
+import {
+  GroupNamingStrategies,
+  GroupNamingStrategy,
+  groupNamingStrategyFactory,
+} from './groupNamingStrategyFactory';
 
 /**
  * Provides entities from Okta Group service.
@@ -26,16 +30,22 @@ import {GroupNamingStrategy, groupNamingStrategyFactory} from './groupNamingStra
 export class OktaGroupEntityProvider extends OktaEntityProvider {
   private readonly namingStrategy: GroupNamingStrategy;
 
-  static fromConfig(config: Config, options: { logger: winston.Logger, namingStrategy?: string }) {
+  static fromConfig(
+    config: Config,
+    options: { logger: winston.Logger; namingStrategy?: GroupNamingStrategies },
+  ) {
     const orgUrl = config.getString('orgUrl');
     const token = config.getString('token');
 
     return new OktaGroupEntityProvider({ orgUrl, token }, options);
   }
 
-  constructor(accountConfig: any, options: {  logger: winston.Logger, namingStrategy?: string }) {
+  constructor(
+    accountConfig: any,
+    options: { logger: winston.Logger; namingStrategy?: GroupNamingStrategies },
+  ) {
     super(accountConfig, options);
-    this.namingStrategy = groupNamingStrategyFactory(options.namingStrategy || 'id')
+    this.namingStrategy = groupNamingStrategyFactory(options.namingStrategy);
   }
 
   getProviderName(): string {

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -18,16 +18,24 @@ import { GroupEntity } from '@backstage/catalog-model';
 import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { OktaEntityProvider } from './OktaEntityProvider';
+import {GroupNamingStrategy, groupNamingStrategyFactory} from './groupNamingStrategyFactory';
 
 /**
  * Provides entities from Okta Group service.
  */
 export class OktaGroupEntityProvider extends OktaEntityProvider {
-  static fromConfig(config: Config, options: { logger: winston.Logger }) {
+  private readonly namingStrategy: GroupNamingStrategy;
+
+  static fromConfig(config: Config, options: { logger: winston.Logger, namingStrategy?: string }) {
     const orgUrl = config.getString('orgUrl');
     const token = config.getString('token');
 
     return new OktaGroupEntityProvider({ orgUrl, token }, options);
+  }
+
+  constructor(accountConfig: any, options: {  logger: winston.Logger, namingStrategy?: string }) {
+    super(accountConfig, options);
+    this.namingStrategy = groupNamingStrategyFactory(options.namingStrategy || 'id')
   }
 
   getProviderName(): string {
@@ -60,7 +68,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
           annotations: {
             ...defaultAnnotations,
           },
-          name: group.id,
+          name: this.namingStrategy(group),
           title: group.profile.name,
           description: group.profile.description,
         },

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
@@ -100,7 +100,10 @@ describe('AWSIAMUserProvider', () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
       };
-      const provider = OktaUserEntityProvider.fromConfig(config, { logger, namingStrategy: "kebab-case-email" });
+      const provider = OktaUserEntityProvider.fromConfig(config, {
+        logger,
+        namingStrategy: 'kebab-case-email',
+      });
       provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toBeCalledWith({
@@ -122,7 +125,10 @@ describe('AWSIAMUserProvider', () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
       };
-      const provider = OktaUserEntityProvider.fromConfig(config, { logger, namingStrategy: "strip-domain-email" });
+      const provider = OktaUserEntityProvider.fromConfig(config, {
+        logger,
+        namingStrategy: 'strip-domain-email',
+      });
       provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toBeCalledWith({

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
@@ -95,5 +95,49 @@ describe('AWSIAMUserProvider', () => {
         ],
       });
     });
+
+    it('allows kebab casing of the users email for the name', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+      };
+      const provider = OktaUserEntityProvider.fromConfig(config, { logger, namingStrategy: "kebab-case-email" });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'User',
+              metadata: expect.objectContaining({
+                name: 'fname-domain-com',
+              }),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('allows stripping the domain from the users email for the name', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+      };
+      const provider = OktaUserEntityProvider.fromConfig(config, { logger, namingStrategy: "strip-domain-email" });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'User',
+              metadata: expect.objectContaining({
+                name: 'fname',
+              }),
+            }),
+          }),
+        ],
+      });
+    });
   });
 });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -18,7 +18,11 @@ import { UserEntity } from '@backstage/catalog-model';
 import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { OktaEntityProvider } from './OktaEntityProvider';
-import {UserNamingStrategy, userNamingStrategyFactory} from './userNamingStrategyFactory';
+import {
+  UserNamingStrategies,
+  UserNamingStrategy,
+  userNamingStrategyFactory,
+} from './userNamingStrategyFactory';
 
 /**
  * Provides entities from Okta User service.
@@ -26,17 +30,23 @@ import {UserNamingStrategy, userNamingStrategyFactory} from './userNamingStrateg
 export class OktaUserEntityProvider extends OktaEntityProvider {
   private readonly namingStrategy: UserNamingStrategy;
 
-  static fromConfig(config: Config, options: { logger: winston.Logger, namingStrategy?: string }) {
+  static fromConfig(
+    config: Config,
+    options: { logger: winston.Logger; namingStrategy?: UserNamingStrategies },
+  ) {
     const orgUrl = config.getString('orgUrl');
     const token = config.getString('token');
 
     return new OktaUserEntityProvider({ orgUrl, token }, options);
   }
 
-  constructor(accountConfig: any, options: {  logger: winston.Logger, namingStrategy?: string }) {
+  constructor(
+    accountConfig: any,
+    options: { logger: winston.Logger; namingStrategy?: UserNamingStrategies },
+  ) {
     super(accountConfig, options);
-    console.log(options.namingStrategy)
-    this.namingStrategy = userNamingStrategyFactory(options.namingStrategy || 'id')
+    console.log(options.namingStrategy);
+    this.namingStrategy = userNamingStrategyFactory(options.namingStrategy);
   }
 
   getProviderName(): string {

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategyFactory.ts
@@ -21,15 +21,13 @@ export type GroupNamingStrategy = (group: Group) => string;
 export type GroupNamingStrategies = 'id' | 'kebab-case-name' | undefined;
 
 export const groupNamingStrategyFactory = (
-  name: GroupNamingStrategies,
+  name: GroupNamingStrategies = "id",
 ): GroupNamingStrategy => {
   switch (name) {
     case 'id':
-    case undefined:
       return group => group.id;
     case 'kebab-case-name':
       return group => kebabCase(group.profile.name);
     default:
-      return group => group.id;
-  }
+      throw new Error(`Unknown naming strategy ${name}`);  }
 };

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategyFactory.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Group } from "@okta/okta-sdk-nodejs";
+import { kebabCase } from 'lodash';
+
+export type GroupNamingStrategy = (group: Group) => string;
+export type GroupNamingStrategies = "id" | "kebab-case-name" | undefined;
+
+export const groupNamingStrategyFactory = (name: GroupNamingStrategies): GroupNamingStrategy => {
+    switch(name) {
+        case "id":
+        case undefined:
+            return (group) => group.id
+        case "kebab-case-name":
+            return (group) => kebabCase(group.profile.name)
+        default:
+            return (group) => group.id
+    }
+}

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategyFactory.ts
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-import { Group } from "@okta/okta-sdk-nodejs";
+import { Group } from '@okta/okta-sdk-nodejs';
 import { kebabCase } from 'lodash';
 
 export type GroupNamingStrategy = (group: Group) => string;
-export type GroupNamingStrategies = "id" | "kebab-case-name" | undefined;
+export type GroupNamingStrategies = 'id' | 'kebab-case-name' | undefined;
 
-export const groupNamingStrategyFactory = (name: GroupNamingStrategies): GroupNamingStrategy => {
-    switch(name) {
-        case "id":
-        case undefined:
-            return (group) => group.id
-        case "kebab-case-name":
-            return (group) => kebabCase(group.profile.name)
-        default:
-            return (group) => group.id
-    }
-}
+export const groupNamingStrategyFactory = (
+  name: GroupNamingStrategies,
+): GroupNamingStrategy => {
+  switch (name) {
+    case 'id':
+    case undefined:
+      return group => group.id;
+    case 'kebab-case-name':
+      return group => kebabCase(group.profile.name);
+    default:
+      return group => group.id;
+  }
+};

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategyFactory.ts
@@ -25,11 +25,10 @@ export type UserNamingStrategies =
   | undefined;
 
 export const userNamingStrategyFactory = (
-  name: UserNamingStrategies,
+  name: UserNamingStrategies = "id",
 ): UserNamingStrategy => {
   switch (name) {
     case 'id':
-    case undefined:
       return user => user.id;
     case 'kebab-case-email':
       return user => kebabCase(user.profile.email);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategyFactory.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { User } from "@okta/okta-sdk-nodejs";
+import { kebabCase } from 'lodash';
+
+export type UserNamingStrategy = (user: User) => string;
+export type UserNamingStrategies = "id" | "kebab-case-email" | "strip-domain-email" | undefined;
+
+export const userNamingStrategyFactory = (name: UserNamingStrategies): UserNamingStrategy => {
+    switch(name) {
+        case "id":
+        case undefined:
+            return (user) => user.id
+        case "kebab-case-email":
+            return (user) => kebabCase(user.profile.email)
+        case "strip-domain-email":
+            return (user) => user.profile.email.substring(0, user.profile.email.indexOf('@'))
+        default:
+            throw new Error(`Unknown naming strategy ${name}`);
+    }
+}

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategyFactory.ts
@@ -14,22 +14,29 @@
  * limitations under the License.
  */
 
-import { User } from "@okta/okta-sdk-nodejs";
+import { User } from '@okta/okta-sdk-nodejs';
 import { kebabCase } from 'lodash';
 
 export type UserNamingStrategy = (user: User) => string;
-export type UserNamingStrategies = "id" | "kebab-case-email" | "strip-domain-email" | undefined;
+export type UserNamingStrategies =
+  | 'id'
+  | 'kebab-case-email'
+  | 'strip-domain-email'
+  | undefined;
 
-export const userNamingStrategyFactory = (name: UserNamingStrategies): UserNamingStrategy => {
-    switch(name) {
-        case "id":
-        case undefined:
-            return (user) => user.id
-        case "kebab-case-email":
-            return (user) => kebabCase(user.profile.email)
-        case "strip-domain-email":
-            return (user) => user.profile.email.substring(0, user.profile.email.indexOf('@'))
-        default:
-            throw new Error(`Unknown naming strategy ${name}`);
-    }
-}
+export const userNamingStrategyFactory = (
+  name: UserNamingStrategies,
+): UserNamingStrategy => {
+  switch (name) {
+    case 'id':
+    case undefined:
+      return user => user.id;
+    case 'kebab-case-email':
+      return user => kebabCase(user.profile.email);
+    case 'strip-domain-email':
+      return user =>
+        user.profile.email.substring(0, user.profile.email.indexOf('@'));
+    default:
+      throw new Error(`Unknown naming strategy ${name}`);
+  }
+};


### PR DESCRIPTION
allow naming strategies for okta user and groups

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
