### PR TITLE
Update to mitigate CVE-2022-31129

### DIFF
--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -48,7 +48,7 @@
     "@types/node-fetch": "^2.5.7",
     "history": "^5.0.0",
     "lodash": "^4.17.21",
-    "moment": "^2.27.0",
+    "moment": "^2.29.4",
     "msw": "^0.39.2",
     "node-fetch": "^2.6.1",
     "react-router": "6.0.0-beta.0",

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -46,6 +46,7 @@
     "@octokit/rest": "^18.5.3",
     "@octokit/types": "^5.0.1",
     "@types/node-fetch": "^2.5.7",
+    "changeset": "^0.2.6",
     "history": "^5.0.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9814,6 +9814,14 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+changeset@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/changeset/-/changeset-0.2.6.tgz#6e6f3df72b41ef8915db25a22e16b00c8c93f003"
+  integrity sha512-d21ym9zLPOKMVhIa8ulJo5IV3QR2NNdK6BWuwg48qJA0XSQaMeDjo1UGThcTn7YDmU08j3UpKyFNvb3zplk8mw==
+  dependencies:
+    udc "^1.0.0"
+    underscore "^1.8.3"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -17649,7 +17657,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.27.0, moment@^2.29.1:
+moment@^2.27.0, moment@^2.29.1, moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -22865,6 +22873,11 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
+udc@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/udc/-/udc-1.0.1.tgz#c5e62448acf35eaa524d5c3698c863a5bac46bfc"
+  integrity sha512-jv+D9de1flsum5QkFtBdjyppCQAdz9kTck/0xST5Vx48T9LL2BYnw0Iw77dSKDQ9KZ/PS3qPO1vfXHDpLZlxcQ==
+
 uglify-js@^3.1.4:
   version "3.15.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
@@ -22911,6 +22924,11 @@ underscore@^1.12.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
+
+underscore@^1.8.3:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.4.tgz#7886b46bbdf07f768e0052f1828e1dcab40c0dee"
+  integrity sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Update plugin to reference the required version of moment in order to mitigate CVE-2022-31129

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [X] Added changeset (run `yarn add changeset` in the root)

This aims to mitigate the following [CVE](https://nvd.nist.gov/vuln/detail/CVE-2022-31129), by simply upgrading the moment version.
