### PR TITLE
pretty print the json result to the file

### DIFF
--- a/.changeset/strong-adults-attend.md
+++ b/.changeset/strong-adults-attend.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+Pretty print the json merge result to the file.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.test.ts
@@ -98,7 +98,7 @@ describe('roadiehq:utils:json:merge', () => {
         path: 'fake-file.json',
         content: {
           scripts: {
-            lsltrh: "ls -ltrh"
+            lsltrh: 'ls -ltrh',
           },
         },
       },
@@ -106,7 +106,9 @@ describe('roadiehq:utils:json:merge', () => {
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.json')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.json', 'utf-8');
-    expect(JSON.parse(file)).toEqual({ scripts: { lsltr: "ls -ltr", lsltrh: "ls -ltrh" } });
+    expect(JSON.parse(file)).toEqual({
+      scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
+    });
   });
 
   it('should put path on the output property', async () => {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.test.ts
@@ -87,7 +87,7 @@ describe('roadiehq:utils:json:merge', () => {
   it('should append the content to the file if it already exists', async () => {
     mock({
       'fake-tmp-dir': {
-        'fake-file.json': '{ "stuff": "yeah" }',
+        'fake-file.json': '{ "scripts": { "lsltr": "ls -ltr" } }',
       },
     });
 
@@ -97,14 +97,16 @@ describe('roadiehq:utils:json:merge', () => {
       input: {
         path: 'fake-file.json',
         content: {
-          foo: 'bar',
+          scripts: {
+            lsltrh: "ls -ltrh"
+          },
         },
       },
     });
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.json')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.json', 'utf-8');
-    expect(JSON.parse(file)).toEqual({ stuff: 'yeah', foo: 'bar' });
+    expect(JSON.parse(file)).toEqual({ scripts: { lsltr: "ls -ltr", lsltrh: "ls -ltrh" } });
   });
 
   it('should put path on the output property', async () => {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.ts
@@ -63,8 +63,10 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
           fs.readFileSync(sourceFilepath).toString(),
         );
       } else {
-        ctx.logger.info(`The file ${sourceFilepath} does not exist, creating it.`)
-        existingContent = {}
+        ctx.logger.info(
+          `The file ${sourceFilepath} does not exist, creating it.`,
+        );
+        existingContent = {};
       }
 
       fs.writeFileSync(

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/json/merge.ts
@@ -56,17 +56,20 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
         ctx.input.path,
       );
 
-      let existingContent = {};
+      let existingContent;
 
       if (fs.existsSync(sourceFilepath)) {
         existingContent = JSON.parse(
           fs.readFileSync(sourceFilepath).toString(),
         );
+      } else {
+        ctx.logger.info(`The file ${sourceFilepath} does not exist, creating it.`)
+        existingContent = {}
       }
 
       fs.writeFileSync(
         sourceFilepath,
-        JSON.stringify(merge(existingContent, ctx.input.content)),
+        JSON.stringify(merge(existingContent, ctx.input.content), null, 2),
       );
       ctx.output('path', sourceFilepath);
     },


### PR DESCRIPTION
pretty print the json result to the file.

The json:merge action is a scaffolder task that reads from a json file and merges the provided content to the contents and writes it back to the same file. Previously it was printing the updated json to a single line in the file. This change adds formatting to the resulting json.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
