### PR TITLE
only show open dependabot alerts on widget

### DIFF
--- a/.changeset/few-colts-sip.md
+++ b/.changeset/few-colts-sip.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': patch
+---
+
+Fix dependabot widget to only show open alerts.

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
@@ -215,9 +215,10 @@ export const DependabotAlertsWidget = () => {
   const query = `
   query GetDependabotAlertsWidget($name: String!, $owner: String!) {
     repository(name: $name, owner: $owner) {
-      vulnerabilityAlerts(first: 100) {
+      vulnerabilityAlerts(first: 1, states: OPEN) {
         totalCount
         nodes {
+          state
           createdAt
           id
           dismissedAt

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsWidget/DependabotAlertsWidget.tsx
@@ -215,7 +215,7 @@ export const DependabotAlertsWidget = () => {
   const query = `
   query GetDependabotAlertsWidget($name: String!, $owner: String!) {
     repository(name: $name, owner: $owner) {
-      vulnerabilityAlerts(first: 1, states: OPEN) {
+      vulnerabilityAlerts(first: 100, states: OPEN) {
         totalCount
         nodes {
           state


### PR DESCRIPTION
only show open dependabot alerts on widget

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
