### PR TITLE
feat: [sc-10582] upgrade depdendencies as mentioned by rugvip

### DIFF
--- a/.changeset/smooth-tips-end.md
+++ b/.changeset/smooth-tips-end.md
@@ -1,0 +1,11 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+'@roadiehq/backstage-plugin-buildkite': patch
+'@roadiehq/backstage-plugin-datadog': patch
+'@roadiehq/backstage-plugin-github-insights': patch
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+'@roadiehq/backstage-plugin-security-insights': patch
+'@roadiehq/backstage-plugin-travis-ci': patch
+---
+
+Move react-router and react-router-dom dependencies to peerDependencies because of the migration to the stabel version of react-router in backstage/backstage. See the migration guide [here](https://backstage.io/docs/tutorials/react-router-stable-migration#for-plugin-authors)

--- a/plugins/frontend/backstage-plugin-argo-cd/package.json
+++ b/plugins/frontend/backstage-plugin-argo-cd/package.json
@@ -49,13 +49,13 @@
     "io-ts-promise": "^2.0.2",
     "io-ts-reporters": "^1.2.2",
     "moment": "^2.29.1",
-    "react-router": "6.0.0-beta.0",
-    "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0  || ^6.3.0",
+    "react-router-dom": "6.0.0-beta.0  || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.0",

--- a/plugins/frontend/backstage-plugin-buildkite/package.json
+++ b/plugins/frontend/backstage-plugin-buildkite/package.json
@@ -43,13 +43,13 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "history": "^5.0.0",
     "moment": "^2.29.1",
-    "react-router": "6.0.0-beta.0",
-    "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0 || ^6.3.0",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.0",

--- a/plugins/frontend/backstage-plugin-datadog/package.json
+++ b/plugins/frontend/backstage-plugin-datadog/package.json
@@ -44,13 +44,13 @@
     "history": "^5.0.0",
     "moment": "^2.29.1",
     "re-resizable": "^6.9.0",
-    "react-router": "6.0.0-beta.0",
-    "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0 || ^6.3.0",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.0",

--- a/plugins/frontend/backstage-plugin-github-insights/package.json
+++ b/plugins/frontend/backstage-plugin-github-insights/package.json
@@ -49,12 +49,12 @@
     "history": "^5.0.0",
     "immer": "9.0.7",
     "zustand": "3.6.9",
-    "react-router": "^6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.0",

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -51,12 +51,12 @@
     "moment": "^2.27.0",
     "msw": "^0.39.2",
     "node-fetch": "^2.6.1",
-    "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.0",

--- a/plugins/frontend/backstage-plugin-security-insights/package.json
+++ b/plugins/frontend/backstage-plugin-security-insights/package.json
@@ -49,12 +49,12 @@
     "luxon": "^2.0.1",
     "moment": "^2.27.0",
     "react-minimal-pie-chart": "^8.2.0",
-    "react-router": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.0",

--- a/plugins/frontend/backstage-plugin-travis-ci/package.json
+++ b/plugins/frontend/backstage-plugin-travis-ci/package.json
@@ -45,13 +45,13 @@
     "date-fns": "^2.18.0",
     "history": "^5.0.0",
     "moment": "^2.29.1",
-    "react-router": "6.0.0-beta.0",
-    "react-router-dom": "6.0.0-beta.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0"
+    "react-dom": "^16.13.1 || ^17.0.0",
+    "react-router": "6.0.0-beta.0 || ^6.3.0",
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/core-app-api": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14163,7 +14163,7 @@ highlight.js@^10.4.1, highlight.js@^10.7.2, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-history@^5.0.0, history@^5.2.0:
+history@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -20384,13 +20384,6 @@ react-router@6.0.0-beta.0:
   integrity sha512-VgMdfpVcmFQki/LZuLh8E/MNACekDetz4xqft+a6fBZvvJnVqKbLqebF7hyoawGrV1HcO5tVaUang2Og4W2j1Q==
   dependencies:
     prop-types "^15.7.2"
-
-react-router@^6.0.0-beta.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.2.tgz#495e683a0c04461eeb3d705fe445d6cf42f0c249"
-  integrity sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==
-  dependencies:
-    history "^5.2.0"
 
 react-side-effect@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
Move the deps to peerDependencies with backward compatibility. Migration guide for this is here:
https://backstage.io/docs/tutorials/react-router-stable-migration#for-plugin-authors