### PR TITLE
some comments from blam in the OS team

### DIFF
--- a/.changeset/stale-starfishes-visit.md
+++ b/.changeset/stale-starfishes-visit.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/plugin-scaffolder-frontend-module-http-request-field': major
+---
+
+Move parameters for the `SelectFieldFromApi` field under `ui:options`.

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/README.md
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/README.md
@@ -41,20 +41,21 @@ spec:
             # Use `SelectFieldFromApi` to configure the select field for the entry.
             ui:field: SelectFieldFromApi
 
-            # The Path on the Backstage API and the parameters to fetch the data for the dropdown
-            ui:path: 'catalog/entity-facets'
-            ui:params:
-              facet: 'kind'
-
-            # This selects the array element from the API fetch response. It finds the array with the name kind
-            # under the facets object
-            ui:arraySelector: 'facets.kind'
-
-            # (Optional) This selects the field in the array to use for the value of each select item. If its not specified
-            # it will use the value of the item directly.
-            ui:valueSelector: 'count'
-            # (Optional) This selects the field in the array to use for the label of each select item.
-            ui:labelSelector: 'value'
+            ui:options:
+              # The Path on the Backstage API and the parameters to fetch the data for the dropdown
+              path: 'catalog/entity-facets'
+              params:
+                facet: 'kind'
+    
+              # This selects the array element from the API fetch response. It finds the array with the name kind
+              # under the facets object
+              arraySelector: 'facets.kind'
+    
+              # (Optional) This selects the field in the array to use for the value of each select item. If its not specified
+              # it will use the value of the item directly.
+              valueSelector: 'count'
+              # (Optional) This selects the field in the array to use for the label of each select item.
+              labelSelector: 'value'
 ```
 
 The configuration above will result in an outgoing request to: `https://my.backstage.com/api/catalog/entity-facets?facet=kind`

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/README.md
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/README.md
@@ -46,11 +46,11 @@ spec:
               path: 'catalog/entity-facets'
               params:
                 facet: 'kind'
-    
+
               # This selects the array element from the API fetch response. It finds the array with the name kind
               # under the facets object
               arraySelector: 'facets.kind'
-    
+
               # (Optional) This selects the field in the array to use for the value of each select item. If its not specified
               # it will use the value of the item directly.
               valueSelector: 'count'

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/package.json
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/package.json
@@ -40,6 +40,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.45",
     "@rjsf/core": "^3.0.1",
+    "zod": "^3.19.1",
     "lodash": "^4.17.21",
     "react-use": "^17.2.4"
   },

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
@@ -39,7 +39,9 @@ export const SelectFieldFromApi = (props: FieldProps<string>) => {
 
   const { error } = useAsync(async () => {
     const baseUrl = await discoveryApi.getBaseUrl('');
-    const options = selectFieldFromApiConfigSchema.parse(props.uiSchema['ui:options']);
+    const options = selectFieldFromApiConfigSchema.parse(
+      props.uiSchema['ui:options'],
+    );
     const params = new URLSearchParams(options.params);
     const response = await fetchApi.fetch(
       `${baseUrl}${options.path}?${params}`,
@@ -53,7 +55,9 @@ export const SelectFieldFromApi = (props: FieldProps<string>) => {
 
         if (options.valueSelector) {
           value = get(item, options.valueSelector);
-          label = options.labelSelector ? get(item, options.labelSelector) : value;
+          label = options.labelSelector
+            ? get(item, options.labelSelector)
+            : value;
         } else {
           if (!(typeof item === 'string')) {
             throw new Error(

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
@@ -30,6 +30,7 @@ import {
 } from '@backstage/core-components';
 import { useAsync } from 'react-use';
 import { get } from 'lodash';
+import { selectFieldFromApiConfigSchema } from '../../types';
 
 export const SelectFieldFromApi = (props: FieldProps<string>) => {
   const discoveryApi = useApi(discoveryApiRef);
@@ -38,20 +39,21 @@ export const SelectFieldFromApi = (props: FieldProps<string>) => {
 
   const { error } = useAsync(async () => {
     const baseUrl = await discoveryApi.getBaseUrl('');
-    const params = new URLSearchParams(props.uiSchema['ui:params']);
+    const options = selectFieldFromApiConfigSchema.parse(props.uiSchema['ui:options']);
+    const params = new URLSearchParams(options.params);
     const response = await fetchApi.fetch(
-      `${baseUrl}${props.uiSchema['ui:path']}?${params}`,
+      `${baseUrl}${options.path}?${params}`,
     );
     const body = await response.json();
-    const array = get(body, props.uiSchema['ui:arraySelector']);
+    const array = get(body, options.arraySelector);
     setDropDownData(
       array.map((item: unknown) => {
         let value: string | undefined;
         let label: string | undefined;
 
-        if (props.uiSchema['ui:valueSelector']) {
-          value = get(item, props.uiSchema['ui:valueSelector']);
-          label = get(item, props.uiSchema['ui:labelSelector']) || value;
+        if (options.valueSelector) {
+          value = get(item, options.valueSelector);
+          label = options.labelSelector ? get(item, options.labelSelector) : value;
         } else {
           if (!(typeof item === 'string')) {
             throw new Error(

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { z } from 'zod'
+import { z } from 'zod';
 
 export const selectFieldFromApiConfigSchema = z.object({
   params: z.record(z.string(), z.string()).optional(),

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { z } from 'zod'
+
+export const selectFieldFromApiConfigSchema = z.object({
+  params: z.record(z.string(), z.string()).optional(),
+  path: z.string(),
+  arraySelector: z.string().or(z.array(z.string())),
+  valueSelector: z.string().or(z.array(z.string())).optional(),
+  labelSelector: z.string().or(z.array(z.string())).optional(),
+});


### PR DESCRIPTION
This patchset addresses ssome comments from blam in the OS backstage team

- use zod for type validation of input
- nest all options until ui:options

Ill bump the major version for this.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
