### PR TITLE
fix(argo-cd): Encode all app names and selectors

### DIFF
--- a/.changeset/big-ears-protect.md
+++ b/.changeset/big-ears-protect.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Encoded all usage of app names and selectors

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -132,12 +132,16 @@ export class ArgoCDApiClient implements ArgoCDApi {
     const proxyUrl = await this.getBaseUrl();
     if (this.searchInstances) {
       return this.fetchDecode(
-        `${proxyUrl}/argoInstance/${options.instance}/applications/name/${options.appName}`,
+        `${proxyUrl}/argoInstance/${
+          options.instance
+        }/applications/name/${encodeURIComponent(options.appName as string)}`,
         argoCDAppDetails,
       );
     }
     return this.fetchDecode(
-      `${proxyUrl}${options.url}/applications/${options.appName}`,
+      `${proxyUrl}${options.url}/applications/${encodeURIComponent(
+        options.appName as string,
+      )}`,
       argoCDAppDetails,
     );
   }
@@ -150,12 +154,18 @@ export class ArgoCDApiClient implements ArgoCDApi {
     const proxyUrl = await this.getBaseUrl();
     if (this.searchInstances) {
       return this.fetchDecode(
-        `${proxyUrl}/argoInstance/${options.instance}/applications/selector/${options.appSelector}`,
+        `${proxyUrl}/argoInstance/${
+          options.instance
+        }/applications/selector/${encodeURIComponent(
+          options.appSelector as string,
+        )}`,
         argoCDAppList,
       );
     }
     return this.fetchDecode(
-      `${proxyUrl}${options.url}/applications/selector/${options.appSelector}`,
+      `${proxyUrl}${options.url}/applications/selector/${encodeURIComponent(
+        options.appSelector as string,
+      )}`,
       argoCDAppList,
     );
   }
@@ -166,9 +176,9 @@ export class ArgoCDApiClient implements ArgoCDApi {
     }
     const proxyUrl = await this.getBaseUrl();
     const url = options.appName
-      ? `${proxyUrl}/find/name/${options.appName}`
+      ? `${proxyUrl}/find/name/${encodeURIComponent(options.appName as string)}`
       : `${proxyUrl}/find/selector/${encodeURIComponent(
-          String(options.appSelector),
+          options.appSelector as string,
         )}`;
     return fetch(url, {
       method: 'GET',

--- a/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
@@ -594,7 +594,7 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name%3dguestbook',
           (_, res, ctx) => res(ctx.json(getResponseStubAppListForInstanceOne)),
         ),
       );
@@ -633,13 +633,13 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name%3dguestbook',
           (_, res, ctx) => res(ctx.json(getResponseStubAppListForInstanceOne)),
         ),
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(ctx.json(getResponseStubAppListForInstanceTwo())),
         ),
@@ -677,14 +677,14 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(ctx.json(getResponseStubAppListWithMultipleApps)),
         ),
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(ctx.json(getResponseStubAppListForInstanceTwo())),
         ),
@@ -726,14 +726,14 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(ctx.json(getResponseStubAppListWithMultipleApps)),
         ),
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name%3dguestbook',
           (_, res, ctx) => res(ctx.json(getEmptyResponseStub)),
         ),
       );
@@ -774,13 +774,13 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/selector/name%3dguestbook',
           (_, res, ctx) => res(ctx.json(getEmptyResponseStub)),
         ),
       );
       worker.use(
         rest.get(
-          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name=guestbook',
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name%3dguestbook',
           (_, res, ctx) => res(ctx.json(getEmptyResponseStub)),
         ),
       );


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

This is building on #564 and expanding that practice. Encoding `appNames` probably isn't useful, but it's also not harmful. Figured it'd be better than making another PR later.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
