### PR TITLE
Allow merge actions to take string input

### DIFF
--- a/.changeset/stupid-otters-prove.md
+++ b/.changeset/stupid-otters-prove.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': minor
+---
+
+Allow merge actions to accept string

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -32,6 +32,7 @@ import {
   createSleepAction,
   createAppendFileAction,
   createMergeJSONAction,
+  createMergeAction,
 } from '@roadiehq/scaffolder-backend-module-utils';
 import {
   createAwsS3CpAction,
@@ -64,6 +65,7 @@ export const createActions = (options: {
     createWriteFileAction(),
     createAppendFileAction(),
     createMergeJSONAction({}),
+    createMergeAction(),
     createAwsS3CpAction(),
     createEcrAction(),
     createHttpBackstageAction({ config }),

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -130,6 +130,29 @@ describe('roadiehq:utils:json:merge', () => {
       '/fake-tmp-dir/fake-file.json',
     );
   });
+
+  it('can handle json text input', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.json': '{ "scripts": { "lsltr": "ls -ltr" } }',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.json',
+        content: '{"scripts": { "lsltrh": "ls -ltrh" } }',
+      },
+    });
+
+    expect(fs.existsSync('fake-tmp-dir/fake-file.json')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.json', 'utf-8');
+    expect(JSON.parse(file)).toEqual({
+      scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
+    });
+  });
 });
 
 describe('roadiehq:utils:merge', () => {
@@ -201,6 +224,56 @@ describe('roadiehq:utils:merge', () => {
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });
   });
+
+  it('can handle json text input', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.json': '{ "scripts": { "lsltr": "ls -ltr" } }',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.json',
+        content: '{"scripts": { "lsltrh": "ls -ltrh" } }',
+      },
+    });
+
+    expect(fs.existsSync('fake-tmp-dir/fake-file.json')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.json', 'utf-8');
+    expect(JSON.parse(file)).toEqual({
+      scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
+    });
+  });
+
+  it('can handle yaml text input', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': 'scripts:\n  lsltr: ls -ltr\n',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        content: `
+scripts:
+  lsltrh: 'ls -ltrh'
+`,
+      },
+    });
+
+    expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
+    expect(YAML.parse(file)).toEqual({
+      scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
+    });
+  });
+
   it('can merge content into a yaml file', async () => {
     mock({
       'fake-tmp-dir': {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -36,9 +36,18 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
             type: 'string',
           },
           content: {
-            title: 'Content',
-            description: 'This will be merged into to the file',
-            type: 'object',
+            oneOf: [
+              {
+                title: 'Content',
+                description: 'This will be merged into to the file',
+                type: 'object',
+              },
+              {
+                title: 'Content',
+                description: 'This will be merged into to the file',
+                type: 'string',
+              },
+            ],
           },
         },
       },
@@ -70,10 +79,14 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
         );
         existingContent = {};
       }
+      const content =
+        typeof ctx.input.content === 'string'
+          ? JSON.parse(ctx.input.content)
+          : ctx.input.content;
 
       fs.writeFileSync(
         sourceFilepath,
-        JSON.stringify(merge(existingContent, ctx.input.content), null, 2),
+        JSON.stringify(merge(existingContent, content), null, 2),
       );
       ctx.output('path', sourceFilepath);
     },
@@ -95,9 +108,18 @@ export function createMergeAction() {
             type: 'string',
           },
           content: {
-            title: 'Content',
-            description: 'This will be merged into to the file',
-            type: 'object',
+            oneOf: [
+              {
+                title: 'Content',
+                description: 'This will be merged into to the file',
+                type: 'object',
+              },
+              {
+                title: 'Content',
+                description: 'This will be merged into to the file',
+                type: 'string',
+              },
+            ],
           },
         },
       },
@@ -125,19 +147,29 @@ export function createMergeAction() {
       let mergedContent;
 
       switch (extname(sourceFilepath)) {
-        case '.json':
+        case '.json': {
+          const newContent =
+            typeof ctx.input.content === 'string'
+              ? JSON.parse(ctx.input.content)
+              : ctx.input.content; // This supports the case where dynamic keys are required
           mergedContent = JSON.stringify(
-            merge(JSON.parse(originalContent), ctx.input.content),
+            merge(JSON.parse(originalContent), newContent),
             null,
             2,
           );
           break;
-        case '.yaml':
+        }
         case '.yml':
+        case '.yaml': {
+          const newContent =
+            typeof ctx.input.content === 'string'
+              ? YAML.parse(ctx.input.content)
+              : ctx.input.content; // This supports the case where dynamic keys are required
           mergedContent = YAML.stringify(
-            merge(YAML.parse(originalContent), ctx.input.content),
+            merge(YAML.parse(originalContent), newContent),
           );
           break;
+        }
         default:
           break;
       }

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -36,18 +36,10 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
             type: 'string',
           },
           content: {
-            oneOf: [
-              {
-                title: 'Content',
-                description: 'This will be merged into to the file',
-                type: 'object',
-              },
-              {
-                title: 'Content',
-                description: 'This will be merged into to the file',
-                type: 'string',
-              },
-            ],
+            description:
+              'This will be merged into to the file. Can be either an object or a string.',
+            title: 'Content',
+            type: ['string', 'object'],
           },
         },
       },
@@ -108,18 +100,10 @@ export function createMergeAction() {
             type: 'string',
           },
           content: {
-            oneOf: [
-              {
-                title: 'Content',
-                description: 'This will be merged into to the file',
-                type: 'object',
-              },
-              {
-                title: 'Content',
-                description: 'This will be merged into to the file',
-                type: 'string',
-              },
-            ],
+            description:
+              'This will be merged into to the file. Can be either an object or a string.',
+            title: 'Content',
+            type: ['string', 'object'],
           },
         },
       },


### PR DESCRIPTION
e.g. 

```yaml
    - id: update
      name: Update
      action: roadiehq:utils:json:merge
      input:
        path: my-file.json
        content: |
          { 
            "${{parameters.myKey}}": "${{parameters.myValue}}" 
          }
```

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
