### PR TITLE
fix: fix issue where languages card is empty when no languages are detected

### DIFF
--- a/.changeset/six-peaches-float.md
+++ b/.changeset/six-peaches-float.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-insights': patch
+---
+
+fix issue where languages card is empty when no languages are detected. empty language cards are no longer shown.

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -87,7 +87,7 @@ const LanguagesCard = () => {
       </Alert>
     );
   }
-  return value && owner && repo ? (
+  return value?.length && owner && repo ? (
     <InfoCard title="Languages" className={classes.infoCard}>
       <div className={classes.barContainer}>
         {Object.entries(value as Language).map((language, index: number) => {

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -16,6 +16,8 @@
 
 import React from 'react';
 import { Chip, makeStyles, Tooltip } from '@material-ui/core';
+// eslint-disable-next-line
+import Alert from '@material-ui/lab/Alert';
 import {
   InfoCard,
   Progress,
@@ -29,7 +31,6 @@ import {
   GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -72,7 +73,6 @@ const LanguagesCard = () => {
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useRequest(entity, 'languages', 0, 0);
   const projectAlert = isGithubInsightsAvailable(entity);
-  const alertApi = useApi(alertApiRef);
 
   if (!projectAlert) {
     return (
@@ -80,9 +80,14 @@ const LanguagesCard = () => {
     );
   }
 
-  if (loading) return <Progress />;
-  if (error) {
-    alertApi.post({ message: error.message, severity: 'error' });
+  if (loading) {
+    return <Progress />;
+  } else if (error) {
+    return (
+      <Alert severity="error" className={classes.infoCard}>
+        {error.message}
+      </Alert>
+    );
   }
   return Object.keys(value).length && owner && repo ? (
     <InfoCard title="Languages" className={classes.infoCard}>

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import { Chip, makeStyles, Tooltip } from '@material-ui/core';
-import Alert from '@material-ui/lab/Alert';
 import {
   InfoCard,
   Progress,
@@ -30,6 +29,7 @@ import {
   GITHUB_INSIGHTS_ANNOTATION,
 } from '../../utils/isGithubInsightsAvailable';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -72,22 +72,19 @@ const LanguagesCard = () => {
   const { owner, repo } = useProjectEntity(entity);
   const { value, loading, error } = useRequest(entity, 'languages', 0, 0);
   const projectAlert = isGithubInsightsAvailable(entity);
+  const alertApi = useApi(alertApiRef);
+
   if (!projectAlert) {
     return (
       <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
     );
   }
 
-  if (loading) {
-    return <Progress />;
-  } else if (error) {
-    return (
-      <Alert severity="error" className={classes.infoCard}>
-        {error.message}
-      </Alert>
-    );
+  if (loading) return <Progress />;
+  if (error) {
+    alertApi.post({ message: error.message, severity: 'error' });
   }
-  return value?.length && owner && repo ? (
+  return Object.keys(value).length && owner && repo ? (
     <InfoCard title="Languages" className={classes.infoCard}>
       <div className={classes.barContainer}>
         {Object.entries(value as Language).map((language, index: number) => {


### PR DESCRIPTION
Small bug fix, in some cases when GitHub has not detected any languages used in a repository, the language card will be empty like:  
<img width="372" alt="image" src="https://user-images.githubusercontent.com/15904543/196749952-04540b55-1943-47ee-845b-0753250d61a3.png">


<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
