### PR TITLE
Add support for authenticated Jira proxy via Identity API

### DIFF
--- a/.changeset/poor-papayas-listen.md
+++ b/.changeset/poor-papayas-listen.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-jira': minor
+---
+
+Add support for authenticated Jira proxy via Identity API

--- a/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/JiraCard.test.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/JiraCard.test.tsx
@@ -37,12 +37,16 @@ import {
   statusesResponseStub,
 } from '../../responseStubs';
 import { ConfigReader } from '@backstage/config';
+import { getIdentityApiStub } from '../../identityStubs';
 
 const discoveryApi = UrlPatternDiscovery.compile('http://exampleapi.com');
 const configApi = new ConfigReader({});
 
 const apis: [AnyApiRef, Partial<unknown>][] = [
-  [jiraApiRef, new JiraAPI({ discoveryApi, configApi })],
+  [
+    jiraApiRef,
+    new JiraAPI({ discoveryApi, configApi, identityApi: getIdentityApiStub }),
+  ],
 ];
 
 describe('JiraCard', () => {

--- a/plugins/frontend/backstage-plugin-jira/src/identityStubs.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/identityStubs.ts
@@ -1,0 +1,10 @@
+import { IdentityApi } from '@backstage/core-plugin-api';
+
+export const getIdentityApiStub: IdentityApi = {
+  getProfileInfo: jest.fn(),
+  getBackstageIdentity: jest.fn(),
+  async getCredentials() {
+    return { token: 'fake-id-token' };
+  },
+  signOut: jest.fn(),
+};

--- a/plugins/frontend/backstage-plugin-jira/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/plugin.ts
@@ -20,7 +20,9 @@ import {
   createApiFactory,
   discoveryApiRef,
   createComponentExtension,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
+
 import { jiraApiRef, JiraAPI } from './api';
 
 export const jiraPlugin = createPlugin({
@@ -28,11 +30,16 @@ export const jiraPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: jiraApiRef,
-      deps: { discoveryApi: discoveryApiRef, configApi: configApiRef },
-      factory: ({ discoveryApi, configApi }) => {
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+        identityApi: identityApiRef,
+      },
+      factory: ({ discoveryApi, configApi, identityApi }) => {
         return new JiraAPI({
           discoveryApi,
           configApi,
+          identityApi,
         });
       },
     }),


### PR DESCRIPTION
The Jira plugin uses the Backstage proxy to forward requests to Jira. As soon as authentication for API requests is enabled (https://github.com/backstage/backstage/blob/master/contrib/docs/tutorials/authenticate-api-requests.md), calls to the proxy fail.

This change adds support for the Identity API which allows authenticated requests to the proxy.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
