### PR TITLE
ECR repo creation - Add Image scanning configuration

### DIFF
--- a/.changeset/cold-dancers-wave.md
+++ b/.changeset/cold-dancers-wave.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-aws': minor
+---
+
+Add AWS ECR image scanning boolean when creating a new repo. Allows toggling ECR native image scanning on ECR push

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -125,7 +125,11 @@ catalog:
       target: ../entities/test-template.yaml
       rules:
         - allow: [Template]
-
+    # Roadie example AWS ECR repo creation
+    - type: file
+      target: ../entities/ecr-repo-create-template.yaml
+      rules:
+        - allow: [Template]
     # Backstage example components
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml

--- a/packages/entities/ecr-repo-create-template.yaml
+++ b/packages/entities/ecr-repo-create-template.yaml
@@ -31,7 +31,7 @@ spec:
           default: false
         scanOnPush:
           title: Enable Image Scanning
-          description:  The image scanning configuration for the repository. This determines whether images are scanned for known vulnerabilities after being pushed to the repository.
+          description: The image scanning configuration for the repository. This determines whether images are scanned for known vulnerabilities after being pushed to the repository.
           type: boolean
           default: false
         tags:

--- a/packages/entities/ecr-repo-create-template.yaml
+++ b/packages/entities/ecr-repo-create-template.yaml
@@ -29,6 +29,11 @@ spec:
           description: set image mutability to true or false
           type: boolean
           default: false
+        scanOnPush:
+          title: Enable Image Scanning
+          description:  The image scanning configuration for the repository. This determines whether images are scanned for known vulnerabilities after being pushed to the repository.
+          type: boolean
+          default: false
         tags:
           type: array
           items:
@@ -50,5 +55,6 @@ spec:
       input:
         repoName: ${{ parameters.repoName }}
         tags: ${{parameters.tags}}
+        scanOnPush: ${{parameters.scanOnPush}}
         imageMutability: ${{parameters.imageMutability}}
         region: ${{parameters.region}}

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
@@ -144,6 +144,7 @@ spec:
     - title: Add Repository Details
       required:
         - RepoName
+        - Region
       properties:
         RepoName:
           title: ECR Repository Name
@@ -153,11 +154,16 @@ spec:
         Region:
           title: aws region
           type: string
-          deescription: region for aws ECR
+          description: region for aws ECR
           default: 'us-east-1'
         ImageMutability:
           title: Enable Image Mutability
           description: set image mutability to true or false
+          type: boolean
+          default: false
+        ScanOnPush:
+          title: Enable Image Scanning
+          description: The image scanning configuration for the repository. This determines whether images are scanned for known vulnerabilities after being pushed to the repository.
           type: boolean
           default: false
         Tags:
@@ -182,5 +188,6 @@ spec:
         repoName: ${{ parameters.RepoName }}
         tags: ${{parameters.Tags}}
         imageMutability: ${{parameters.ImageMutability}}
+        scanOnPush: ${{parameters.ScanOnPush}}
         region: ${{parameters.Region}}
 ```

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/ecr/create.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/ecr/create.ts
@@ -32,6 +32,7 @@ export function createEcrAction(options?: {
     repoName: string;
     tags: Array<any>;
     imageMutability: boolean;
+    scanOnPush: boolean;
     region: string;
   }>({
     id: 'roadiehq:aws:ecr:create',
@@ -55,6 +56,12 @@ export function createEcrAction(options?: {
             title: 'ImageMutability',
             description: 'set image mutability to true or false',
           },
+          scanOnPush: {
+            type: 'boolean',
+            title: 'Scan On Push',
+            description:
+              'The image scanning configuration for the repository. This determines whether images are scanned for known vulnerabilities after being pushed to the repository.',
+          },
           region: {
             type: 'string',
             title: 'aws region',
@@ -69,6 +76,7 @@ export function createEcrAction(options?: {
         : ImageTagMutability.IMMUTABLE;
       const input: CreateRepositoryCommandInput = {
         repositoryName: ctx.input.repoName,
+        imageScanningConfiguration: { scanOnPush: ctx.input.scanOnPush },
         imageTagMutability: setImageMutability,
         tags: ctx.input.tags,
       };
@@ -82,10 +90,12 @@ export function createEcrAction(options?: {
       const client = new ECRClient(config);
       try {
         const response = await client.send(createCommand);
-        ctx.logger.info(response);
+        ctx.logger.info(
+          `Created ECR repository: ${response.repository?.repositoryUri}`,
+        );
       } catch (e) {
         assertError(e);
-        ctx.logger.warn('unable to create ecr repository');
+        ctx.logger.warn(`Unable to create ECR repository: ${e}`);
       }
     },
   });


### PR DESCRIPTION
Signed-off-by: Andrew Kundrock <akundrock@somalogic.com>

<!-- Please describe what these changes achieve -->
https://github.com/RoadieHQ/roadie-backstage-plugins/issues/695

* Adds AWS ECR image scanning on push functionality to the custom action via a boolean (check box) in the UI
* Added additional unit tests to the ECR creation action. Function coverage is now at 100%
* Updated documentation for an example ECR repo creation template

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)

## Other notes
I left a change to app-config.yaml so that the "ECR creation" software template is enabled by default. I can remove this if desired.