### PR TITLE
expose the rss and markdown plugins as formal plugins

### DIFF
--- a/.changeset/hungry-humans-applaud.md
+++ b/.changeset/hungry-humans-applaud.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-rss': patch
+---
+
+Expose rss as a full plugin, instead of extending the home plugin.

--- a/.changeset/large-nails-dance.md
+++ b/.changeset/large-nails-dance.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': patch
+---
+
+Expose markdown plugin as a plugin instead of extending the homepage plugin.

--- a/plugins/home/backstage-plugin-home-markdown/src/plugin.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/plugin.ts
@@ -14,14 +14,24 @@
  * limitations under the License.
  */
 
-import { homePlugin, createCardExtension } from '@backstage/plugin-home';
+import { createCardExtension } from '@backstage/plugin-home';
+import { createPlugin } from '@backstage/core-plugin-api';
+import { rootRouteRef } from './routes';
+
+/** @public */
+export const markdownPlugin = createPlugin({
+  id: 'markdown',
+  routes: {
+    root: rootRouteRef,
+  },
+});
 
 /**
  * A component to render a predefined markdown file from github.
  *
  * @public
  */
-export const HomePageMarkdown = homePlugin.provide(
+export const HomePageMarkdown = markdownPlugin.provide(
   createCardExtension<{
     owner: string;
     repo: string;

--- a/plugins/home/backstage-plugin-home-markdown/src/routes.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/routes.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'markdown',
+});

--- a/plugins/home/backstage-plugin-home-rss/src/routes.ts
+++ b/plugins/home/backstage-plugin-home-rss/src/routes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Larder Software Limited
+ * Copyright 2022 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,30 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createRouteRef } from '@backstage/core-plugin-api';
 
-import { createCardExtension } from '@backstage/plugin-home';
-import { createPlugin } from '@backstage/core-plugin-api';
-import { rootRouteRef } from './routes';
-
-/** @public */
-export const rssPlugin = createPlugin({
+export const rootRouteRef = createRouteRef({
   id: 'rss',
-  routes: {
-    root: rootRouteRef,
-  },
 });
-
-/**
- * A component to render a predefined RSS feed.
- *
- * @public
- */
-export const HomePageRSS = rssPlugin.provide(
-  createCardExtension<{
-    feedURL: string;
-  }>({
-    name: 'HomePageRSS',
-    title: '',
-    components: () => import('./RSSCard'),
-  }),
-);


### PR DESCRIPTION
expose the rss and markdown plugins as formal plugins

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
