### PR TITLE
Sc 11684 update select field from api

### DIFF
--- a/.changeset/fluffy-yaks-mix.md
+++ b/.changeset/fluffy-yaks-mix.md
@@ -1,0 +1,8 @@
+---
+'@roadiehq/plugin-scaffolder-frontend-module-http-request-field': minor
+---
+
+Make array selector optional for SelectFieldFromApi
+
+Where the array selector is not supplied return the response as is.
+The motivation here is to support response which are already a array.

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.test.tsx
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import {
+  renderWithEffects,
+  TestApiProvider,
+  wrapInTestApp,
+} from '@backstage/test-utils';
+import { SelectFieldFromApi } from './SelectFieldFromApi';
+import {
+  AnyApiRef,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import { FieldProps } from '@rjsf/core';
+
+describe('SelectFieldFromApi', () => {
+  const fetchApi = { fetch: jest.fn() };
+
+  const discovery = {
+    async getBaseUrl(plugin: string) {
+      return `http://backstage.tests/api/${plugin}`;
+    },
+  };
+
+  const apis: [AnyApiRef, any][] = [
+    [fetchApiRef, fetchApi],
+    [discoveryApiRef, discovery],
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should use response body directly where there is no arraySelector', async () => {
+    fetchApi.fetch.mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValue(['result1', 'result2']),
+    });
+    const uiSchema = { 'ui:options': { path: '/test-endpoint' } };
+    const props = { uiSchema } as unknown as FieldProps<string>;
+    const { getByTestId, getByText } = await renderWithEffects(
+      wrapInTestApp(
+        <TestApiProvider apis={apis}>
+          <SelectFieldFromApi {...props} />
+        </TestApiProvider>,
+      ),
+    );
+    const input = await getByTestId('select');
+
+    fireEvent.click(input);
+
+    expect(getByText('result1')).toBeInTheDocument();
+    expect(getByText('result2')).toBeInTheDocument();
+  });
+
+  it('should use array specified by arraySelector', async () => {
+    fetchApi.fetch.mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValue({ myarray: ['result1', 'result2'] }),
+    });
+    const uiSchema = {
+      'ui:options': { path: '/test-endpoint', arraySelector: 'myarray' },
+    };
+    const props = { uiSchema } as unknown as FieldProps<string>;
+    const { getByTestId, getByText } = await renderWithEffects(
+      wrapInTestApp(
+        <TestApiProvider apis={apis}>
+          <SelectFieldFromApi {...props} />
+        </TestApiProvider>,
+      ),
+    );
+    const input = await getByTestId('select');
+
+    fireEvent.click(input);
+
+    expect(getByText('result1')).toBeInTheDocument();
+    expect(getByText('result2')).toBeInTheDocument();
+  });
+});

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
@@ -47,7 +47,9 @@ export const SelectFieldFromApi = (props: FieldProps<string>) => {
       `${baseUrl}${options.path}?${params}`,
     );
     const body = await response.json();
-    const array = get(body, options.arraySelector);
+    const array = options.arraySelector
+      ? get(body, options.arraySelector)
+      : body;
     setDropDownData(
       array.map((item: unknown) => {
         let value: string | undefined;

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
@@ -18,7 +18,7 @@ import { z } from 'zod';
 export const selectFieldFromApiConfigSchema = z.object({
   params: z.record(z.string(), z.string()).optional(),
   path: z.string(),
-  arraySelector: z.string().or(z.array(z.string())),
+  arraySelector: z.string().or(z.array(z.string())).optional(),
   valueSelector: z.string().or(z.array(z.string())).optional(),
   labelSelector: z.string().or(z.array(z.string())).optional(),
 });


### PR DESCRIPTION
Make arraySelector optional & default to the body when it is not set. This allows us to handle array response not wrapped in an object.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
