### PR TITLE
make cloudsmith a public plugin

### DIFF
--- a/.changeset/tender-hornets-burn.md
+++ b/.changeset/tender-hornets-burn.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-cloudsmith': patch
+---
+
+Make cloudsmith a public plugin.

--- a/plugins/frontend/backstage-plugin-cloudsmith/package.json
+++ b/plugins/frontend/backstage-plugin-cloudsmith/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
+  "private": false,
   "homepage": "https://roadie.io/backstage/plugins/cloudsmith/",
   "bugs": {
     "url": "https://github.com/RoadieHQ/roadie-backstage-plugins/issues",


### PR DESCRIPTION
make cloudsmith a public plugin

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
