### PR TITLE
adds a couple of new actions to the scaffolder utils

### DIFF
--- a/.changeset/nervous-dryers-repair.md
+++ b/.changeset/nervous-dryers-repair.md
@@ -1,0 +1,10 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+Adds a few new action steps to the scaffolder `utils` package:
+
+- `roadiehq:utils:fs:parse` - reads a file from the workspace and parses it using `yaml` or `json` parsers.
+- `roadiehq:utils:jsonata` - allows JSONata expressions to be applied to an object to transform or query data.
+- `roadiehq:utils:serialize:yaml` - allows an object to be serialized into yaml
+- `roadiehq:utils:serialize:json` - allows an object to be serialized into json

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -33,6 +33,10 @@ import {
   createAppendFileAction,
   createMergeJSONAction,
   createMergeAction,
+  createParseFileAction,
+  createSerializeYamlAction,
+  createSerializeJsonAction,
+  createJSONataAction,
 } from '@roadiehq/scaffolder-backend-module-utils';
 import {
   createAwsS3CpAction,
@@ -68,6 +72,10 @@ export const createActions = (options: {
     createMergeAction(),
     createAwsS3CpAction(),
     createEcrAction(),
+    createParseFileAction(),
+    createSerializeYamlAction(),
+    createSerializeJsonAction(),
+    createJSONataAction(),
     createHttpBackstageAction({ config }),
     ...defaultActions,
   ];

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -40,6 +40,7 @@ const actions = [
   createSleepAction(),
   createZipAction(),
   createAppendFileAction(),
+  createParseFileAction(),
   ...createBuiltinActions({
     containerRunner,
     integrations,
@@ -194,4 +195,42 @@ spec:
       input:
         path: ${{ parameters.path }}
         content: ${{ parameters.content }}
+```
+
+### Example of using parseFile action
+
+```yaml
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: parse-file-template
+  title: Parse From File
+  description: Example temaplte to parse from a file with on the given path with the given content in the workspace.
+spec:
+  owner: roadie
+  type: service
+
+  parameters:
+    - title: Parse From File
+      properties:
+        path:
+          title: Path
+          type: string
+          description: The path to the file
+        parser:
+          title: Parser
+          type: string
+          enum:
+            - yaml
+            - json
+            - multiyaml
+          description: The content to parse from the file
+  steps:
+    - id: parsefile
+      name: Parse File
+      action: roadiehq:utils:fs:parse
+      input:
+        path: ${{ parameters.path }}
+        parser: ${{ parameters.parser }}
 ```

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
@@ -40,7 +40,8 @@
     "cross-fetch": "^3.1.4",
     "fs-extra": "^10.0.0",
     "winston": "^3.2.1",
-    "yaml": "^1.9.2"
+    "yaml": "^1.9.2",
+    "jsonata": "^1.8.6"
   },
   "devDependencies": {
     "@backstage/cli": "^0.20.0",

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/parseFile.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/parseFile.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createTemplateAction } from '@backstage/plugin-scaffolder-backend';
+import { resolveSafeChildPath } from '@backstage/backend-common';
+import fs from 'fs-extra';
+import yaml from 'yaml';
+
+const parsers: Record<'yaml' | 'json' | 'multiyaml', (cnt: string) => any> = {
+  yaml: (cnt: string) => yaml.parse(cnt),
+  json: (cnt: string) => JSON.parse(cnt),
+  multiyaml: (cnt: string) =>
+    yaml.parseAllDocuments(cnt).map(parsed => parsed.toJSON()),
+};
+
+export function createParseFileAction() {
+  return createTemplateAction<{
+    path: string;
+    parser?: 'yaml' | 'json' | 'multiyaml';
+  }>({
+    id: 'roadiehq:utils:fs:parse',
+    description: 'Reads a file from the workspace and optionally parses it',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['path'],
+        properties: {
+          path: {
+            title: 'Path',
+            description: 'Path to the file to read.',
+            type: 'string',
+          },
+          parser: {
+            title: 'Parse',
+            description: 'Optionally parse the content to an object.',
+            type: 'string',
+            enum: ['yaml', 'json', 'multiyaml'],
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          content: {
+            title: 'Content of the file',
+            type: ['string', 'object'],
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const sourceFilepath = resolveSafeChildPath(
+        ctx.workspacePath,
+        ctx.input.path,
+      );
+      const parserName = ctx.input.parser;
+      let parser = (content: string) => content;
+
+      if (parserName) {
+        parser = parsers[parserName];
+      }
+
+      const content: any = parser(fs.readFileSync(sourceFilepath).toString());
+
+      ctx.output('content', content);
+    },
+  });
+}

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Larder Software Limited
+ * Copyright 2022 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { createWriteFileAction } from './writeFile';
-export { createAppendFileAction } from './appendFile';
-export { createParseFileAction } from './parseFile';
+export { createJSONataAction } from './jsonata';

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/jsonata.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/jsonata.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createTemplateAction } from '@backstage/plugin-scaffolder-backend';
+import jsonata from 'jsonata';
+
+export function createJSONataAction() {
+  return createTemplateAction<{
+    data: any;
+    expression: string;
+  }>({
+    id: 'roadiehq:utils:jsonata',
+    description:
+      'Allows performing jsonata opterations and transformations on objects',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['data', 'expression'],
+        properties: {
+          data: {
+            title: 'Data',
+            description: 'Input data to perform JSONata expression.',
+            type: 'object',
+          },
+          expression: {
+            title: 'Expression',
+            description: 'JSONata expression to perform on the input',
+            type: 'string',
+          },
+        },
+      },
+      output: {
+        type: 'object',
+        properties: {
+          result: {
+            title: 'Output result from JSONata',
+            type: 'object',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const expression = jsonata(ctx.input.expression);
+      const result = expression.evaluate(ctx.input.data);
+
+      ctx.output('result', result);
+    },
+  });
+}

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Larder Software Limited
+ * Copyright 2022 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { createWriteFileAction } from './writeFile';
-export { createAppendFileAction } from './appendFile';
-export { createParseFileAction } from './parseFile';
+export { createSerializeJsonAction } from './json';
+export { createSerializeYamlAction } from './yaml';

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/json.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/json.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createTemplateAction } from '@backstage/plugin-scaffolder-backend';
+
+export function createSerializeJsonAction() {
+  return createTemplateAction<{
+    data: any;
+    replacer?: string[];
+    space?: string;
+  }>({
+    id: 'roadiehq:utils:serialize:json',
+    description: 'Allows performing serialization on an object',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['data'],
+        properties: {
+          data: {
+            title: 'Data',
+            description: 'Input data to perform seriazation on.',
+            type: 'object',
+          },
+          replacer: {
+            title: 'Replacer',
+            description: 'Replacer array',
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          space: {
+            title: 'Space',
+            description: 'Space character',
+            type: 'string',
+          },
+        },
+      },
+      output: {
+        type: 'serialized',
+        properties: {
+          result: {
+            title: 'Output result from serialization',
+            type: 'string',
+          },
+        },
+      },
+    },
+
+    async handler(ctx) {
+      ctx.output(
+        'serialized',
+        JSON.stringify(ctx.input.data, ctx.input.replacer, ctx.input.space),
+      );
+    },
+  });
+}

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createTemplateAction } from '@backstage/plugin-scaffolder-backend';
+import yaml from 'yaml';
+
+export function createSerializeYamlAction() {
+  return createTemplateAction<{
+    data: any;
+    options?: {
+      indent: number;
+    };
+  }>({
+    id: 'roadiehq:utils:serialize:yaml',
+    description: 'Allows performing serialization on an object',
+    schema: {
+      input: {
+        type: 'object',
+        required: ['data'],
+        properties: {
+          data: {
+            title: 'Data',
+            description: 'Input data to perform seriazation on.',
+            type: 'object',
+          },
+          replacer: {
+            title: 'Replacer',
+            description: 'Replacer array',
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          options: {
+            title: 'Options',
+            description: 'YAML stringify options',
+            type: 'object',
+            properties: {
+              indent: {
+                type: 'number',
+              },
+            },
+          },
+        },
+      },
+      output: {
+        type: 'serialized',
+        properties: {
+          result: {
+            title: 'Output result from serialization',
+            type: 'string',
+          },
+        },
+      },
+    },
+
+    async handler(ctx) {
+      ctx.output(
+        'serialized',
+        yaml.stringify(ctx.input.data, ctx.input.options),
+      );
+    },
+  });
+}

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/index.ts
@@ -17,3 +17,5 @@ export * from './actions/zip';
 export * from './actions/fs';
 export * from './actions/merge';
 export * from './actions/sleep';
+export * from './actions/jsonata';
+export * from './actions/serialize';

--- a/yarn.lock
+++ b/yarn.lock
@@ -17902,6 +17902,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonata@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-1.8.6.tgz#e5f0e6ace870a34bac881a182ca2b31227122791"
+  integrity sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA==
+
 jsonc-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"


### PR DESCRIPTION
adds a couple of new actions to the scaffolder utils

- `roadiehq:utils:fs:parse` - reads a file from the workspace and parses it using `yaml` or `json` parsers.
- `roadiehq:utils:jsonata` - allows JSONata expressions to be applied to an object to transform or query data.
- `roadiehq:utils:serialize:yaml` - allows an object to be serialized into yaml
- `roadiehq:utils:serialize:json` - allows an object to be serialized into json

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
