### PR TITLE
add option to markdown hp card to allow purging comments

### DIFF
--- a/.changeset/little-queens-worry.md
+++ b/.changeset/little-queens-worry.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': minor
+---
+
+Allow html comments to be purged from the markdown content before rendering.

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import Alert from '@material-ui/lab/Alert';
+import { Alert } from '@material-ui/lab';
 import { Progress, MarkdownContent } from '@backstage/core-components';
 import { useGithubFile } from './useGithubFile';
 import {
@@ -34,11 +34,14 @@ const GithubFileContent = (props: MarkdownContentProps) => {
   } else if (error) {
     return <Alert severity="error">{error.message}</Alert>;
   }
-  return (
-    <MarkdownContent
-      content={Buffer.from(value.content, 'base64').toString('utf8')}
-    />
-  );
+
+  let content = Buffer.from(value.content, 'base64').toString('utf8');
+
+  if (props.purgeHtmlComments) {
+    content = content.replace(/<!--.*?-->/g, '');
+  }
+
+  return <MarkdownContent content={content} />;
 };
 
 const GithubNotAuthorized = () => {

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/types.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/types.ts
@@ -24,6 +24,7 @@ export type MarkdownContentProps = {
   repo: string;
   path: string;
   branch?: string;
+  purgeHtmlComments?: boolean;
 };
 
 export const BASE_URL = 'https://api.github.com';

--- a/plugins/home/backstage-plugin-home-markdown/src/plugin.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/plugin.ts
@@ -37,6 +37,7 @@ export const HomePageMarkdown = markdownPlugin.provide(
     repo: string;
     path: string;
     branch?: string;
+    purgeHtmlComments?: boolean;
   }>({
     name: 'HomePageMarkdown',
     title: 'Markdown',


### PR DESCRIPTION
add option to markdown hp card to allow purging comments

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
