### PR TITLE
[Feat] scaffolder http-requests module: Add baseUrl override option

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/.changeset/twenty-parents-hope.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/.changeset/twenty-parents-hope.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': minor
+---
+
+Added the optional baseUrl scaffolder action property. Used to optionally override backend.baseUrl set in the application config

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -28,17 +28,18 @@ jest.mock('./helpers', () => ({
 describe('http:backstage:request', () => {
   let config: Config;
   let action: any;
-  const mockBaseUrl = 'http://backstage.tests';
+  const mockConfigBaseUrl = 'http://backstage.tests.config.baseurl';
+  const mockUserBaseUrl = 'http://backstage.tests.user.baseurl';
   const logger = getVoidLogger();
 
   beforeEach(() => {
     jest.resetAllMocks();
     config = new ConfigReader({
       app: {
-        baseUrl: mockBaseUrl,
+        baseUrl: mockConfigBaseUrl,
       },
       backend: {
-        baseUrl: mockBaseUrl,
+        baseUrl: mockConfigBaseUrl,
         listen: {
           port: 7007,
         },
@@ -72,7 +73,33 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: 'http://backstage.tests/api/proxy/foo',
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
+            method: 'GET',
+            headers: {},
+          },
+          logger,
+        );
+      });
+    });
+
+    describe('with a user provided baseUrl', () => {
+      it('should create a request', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'GET',
+            baseUrl: mockUserBaseUrl,
+          },
+        });
+        expect(http).toBeCalledWith(
+          {
+            url: `${mockUserBaseUrl}/api/proxy/foo`,
             method: 'GET',
             headers: {},
           },
@@ -103,7 +130,7 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: 'http://backstage.tests/api/proxy/foo',
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
             method: 'POST',
             headers: {
               'content-type': 'application/json',
@@ -132,7 +159,7 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: 'http://backstage.tests/api/proxy/foo',
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
             method: 'POST',
             headers: {},
             body: 'test',
@@ -164,7 +191,7 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: 'http://backstage.tests/api/proxy/foo',
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
             method: 'POST',
             headers: {
               authorization: `Bearer ${BACKSTAGE_TOKEN}`,
@@ -200,7 +227,7 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: 'http://backstage.tests/api/proxy/foo',
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
             method: 'POST',
             headers: HEADERS,
             body: 'test',
@@ -229,7 +256,7 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: 'http://backstage.tests/api/proxy/foo',
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
             method: 'POST',
             headers: {
               'content-type': 'application/json',
@@ -258,7 +285,7 @@ describe('http:backstage:request', () => {
         });
         expect(http).toBeCalledWith(
           {
-            url: `${mockBaseUrl}/api/proxy/foo`,
+            url: `${mockConfigBaseUrl}/api/proxy/foo`,
             method: 'GET',
             headers: {
               authorization: 'Bearer some-token',
@@ -284,7 +311,9 @@ describe('http:backstage:request', () => {
                 method: 'GET',
               },
             }),
-        ).rejects.toThrowError('Unable to get base url');
+        ).rejects.toThrowError(
+          'Unable to generate Backstage Url, baseUrl not provided in scaffolder action or the app config.',
+        );
       });
     });
   });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -31,6 +31,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
     headers?: Headers;
     params?: Params;
     body?: Body;
+    baseUrl?: string;
   }>({
     id: 'http:backstage:request',
     description:
@@ -76,6 +77,12 @@ export function createHttpBackstageAction(options: { config: Config }) {
             description: 'The body you would like to pass to your request',
             type: 'object',
           },
+          baseUrl: {
+            title: 'Base Url',
+            description:
+              'Override the backend URL provided by the app config. In some deployment models this may need to be set explicitly',
+            type: 'string',
+          },
         },
       },
       output: {
@@ -101,7 +108,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
       const { input } = ctx;
       const token = ctx.secrets?.backstageToken;
       const { method, params } = input;
-      const url = await generateBackstageUrl(config, input.path);
+      const url = await generateBackstageUrl(config, input.path, input.baseUrl);
 
       ctx.logger.info(
         `Creating ${method} request with http:backstage:proxy scaffolder action against ${input.path}`,

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
@@ -21,11 +21,22 @@ import { HttpOptions } from './types';
 class HttpError extends Error {}
 const DEFAULT_TIMEOUT = 60_000;
 
-export const generateBackstageUrl = (config: Config, path: string): string => {
-  // ensure the request points to the correct domain
-  const externalUrl = config.getOptionalString('backend.baseUrl') || '';
-  if (externalUrl === '') {
-    throw new Error('Unable to get base url');
+export const generateBackstageUrl = (
+  config: Config,
+  path: string,
+  baseUrl?: string,
+): string => {
+  // Use the user-provided baseUrl, otherwise use the backend.baseUrl from the app config.
+  let externalUrl = '';
+  const configBaseUrl = config.getOptionalString('backend.baseUrl');
+  if (baseUrl) {
+    externalUrl = baseUrl;
+  } else if (configBaseUrl) {
+    externalUrl = configBaseUrl;
+  } else {
+    throw new Error(
+      'Unable to generate Backstage Url, baseUrl not provided in scaffolder action or the app config.',
+    );
   }
   return externalUrl + path;
 };


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

## Problem
The current _**scaffolder-backend-module-http-request**_ module constructs the backend url using the `generateBackstageUrl()` function. This function uses the `backend.baseUrl` defined in the app-config.yaml.

There are some deployment models (E.g. k8s, or separated frontend and backend containers) where different services, routing, dns, etc., requires `backend.baseUrl` in the `app-config.yaml` be different then the URL _**scaffolder-backend-module-http-request**_ module requires.

## Proposed Change

This change allows the user to specify an optional `baseUrl` parameter in the template action to override the default `backend.baseUrl` in `app-config.yaml`.

Example action using `baseUrl`
```
....
  steps:
    - id: some_request_id
      name: Custom HTTP Request - with Base Url Override
      action: http:customHttp:request
      input:
        method: 'GET'
        path: '/api/my-api/health'
        baseUrl: 'http://localhost:3000'    <------ New optional Input
```

- The constructed URL in this case will be: `http://localhost:3000/api/my-api/health`

- If no `baseUrl` is provided, the constructed URL will use the _**backend.baseUrl**_ from _**app-config.yaml**_:  `http://${backend.baseUrl}/api/my-api/health`

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
