### PR TITLE
#761 Fix languages card undefined error

### DIFF
--- a/.changeset/dull-ladybugs-sin.md
+++ b/.changeset/dull-ladybugs-sin.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-insights': minor
+---
+
+Fix languages card causing crash when undefined

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx
@@ -89,7 +89,7 @@ const LanguagesCard = () => {
       </Alert>
     );
   }
-  return Object.keys(value).length && owner && repo ? (
+  return value && Object.keys(value).length && owner && repo ? (
     <InfoCard title="Languages" className={classes.infoCard}>
       <div className={classes.barContainer}>
         {Object.entries(value as Language).map((language, index: number) => {


### PR DESCRIPTION
Signed-off-by: Mike Samvelian <mike.samvelian@paper.co>

<!-- Please describe what these changes achieve -->
The changes in this PR fix issue #761. Repro steps can be found in the issue. 
The "value" variable used [here](https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/LanguagesCard/LanguagesCard.tsx#L92) can sometimes be [undefined](https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-github-insights/src/hooks/useRequest.ts#L74) causing the page to crash. 


# Before:
![](https://user-images.githubusercontent.com/102695183/206656310-c87dfd7e-e619-4ad6-8eeb-805eacff0d56.png)

# After:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/102695183/206821114-364d8bbd-6b0c-4919-9eb0-80c2b583844a.png">


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
