### PR TITLE
Use to Environment Variable Substitution in README

### DIFF
--- a/.changeset/hungry-numbers-hammer.md
+++ b/.changeset/hungry-numbers-hammer.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Use environment variable substitution in docs example.

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -16,8 +16,7 @@ catalog:
   providers:
     okta:
       - orgUrl: 'https://tenant.okta.com'
-        token:
-          $env: OKTA_TOKEN
+        token: ${OKTA_TOKEN}
 ```
 
 ### Filter Users and Groups
@@ -29,8 +28,7 @@ catalog:
   providers:
     okta:
       - orgUrl: 'https://tenant.okta.com'
-        token:
-          $env: OKTA_TOKEN
+        token: ${OKTA_TOKEN}
         userFilter: profile.department eq "engineering"
         groupFilter: profile.name eq "Everyone"
 ```


### PR DESCRIPTION
As per [this](https://backstage.io/docs/conf/writing#env-includes) official Backstage documentation, [Environment Variable Substitution](https://backstage.io/docs/conf/writing#environment-variable-substitution) is a more convenient way to supply variables. Also, it is much more beginner friendly. The `$env` include is mentioned much later in the documentation and it's not used in any of the examples on PostgreSQL and GitHub configuration, so it looks like it's not a standard way of supplying environment variables.
Using `$env` is not wrong, however, it would save a lot of headache, for anyone only starting with Backstage.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
