### PR TITLE
Log Okta user/group/org provider completion

### DIFF
--- a/.changeset/tall-roses-wink.md
+++ b/.changeset/tall-roses-wink.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Emit an info-level log upon completion of Okta provider execution in addition to start of execution.

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -112,5 +112,6 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
         locationKey: this.getProviderName(),
       })),
     });
+    this.logger.info(`Finished providing okta group resources from okta: ${this.orgUrl}`);
   }
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -82,9 +82,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
       throw new Error('Not initialized');
     }
 
-    this.logger.info(
-      `Providing okta group resources from okta: ${this.orgUrl}`,
-    );
+    this.logger.info(`Providing group resources from okta: ${this.orgUrl}`);
     const groupResources: GroupEntity[] = [];
 
     const client = this.getClient(this.orgUrl);
@@ -112,6 +110,8 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
         locationKey: this.getProviderName(),
       })),
     });
-    this.logger.info(`Finished providing okta group resources from okta: ${this.orgUrl}`);
+    this.logger.info(
+      `Finished providing ${groupResources.length} group resources from okta: ${this.orgUrl}`,
+    );
   }
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -88,8 +88,10 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       throw new Error('Not initialized');
     }
 
-    this.logger.info('Providing okta user and group resources from okta');
+    this.logger.info('Providing user and group resources from okta');
     const resources: (GroupEntity | UserEntity)[] = [];
+    let providedUserCount = 0;
+    let providedGroupCount = 0;
 
     await Promise.all(
       this.accounts.map(async account => {
@@ -104,6 +106,8 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
             }),
           );
         });
+
+        providedUserCount = resources.length;
 
         await client
           .listGroups({ search: account.groupFilter })
@@ -126,6 +130,8 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       }),
     );
 
+    providedGroupCount = resources.length - providedUserCount;
+
     await this.connection.applyMutation({
       type: 'full',
       entities: resources.map(entity => ({
@@ -133,6 +139,8 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
         locationKey: this.getProviderName(),
       })),
     });
-    this.logger.info('Finished providing okta user and group resources from okta');
+    this.logger.info(
+      `Finished providing ${providedUserCount} user and ${providedGroupCount} group resources from okta`,
+    );
   }
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -88,7 +88,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       throw new Error('Not initialized');
     }
 
-    this.logger.info(`Providing okta user and group resources from okta`);
+    this.logger.info('Providing okta user and group resources from okta');
     const resources: (GroupEntity | UserEntity)[] = [];
 
     await Promise.all(
@@ -133,5 +133,6 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
         locationKey: this.getProviderName(),
       })),
     });
+    this.logger.info('Finished providing okta user and group resources from okta');
   }
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -88,5 +88,6 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
         locationKey: this.getProviderName(),
       })),
     });
+    this.logger.info(`Finished providing okta user resources from okta: ${this.orgUrl}`);
   }
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -65,7 +65,7 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
       throw new Error('Not initialized');
     }
 
-    this.logger.info(`Providing okta user resources from okta: ${this.orgUrl}`);
+    this.logger.info(`Providing user resources from okta: ${this.orgUrl}`);
     const userResources: UserEntity[] = [];
 
     const client = this.getClient(this.orgUrl);
@@ -88,6 +88,8 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
         locationKey: this.getProviderName(),
       })),
     });
-    this.logger.info(`Finished providing okta user resources from okta: ${this.orgUrl}`);
+    this.logger.info(
+      `Finished providing ${userResources.length} user resources from okta: ${this.orgUrl}`,
+    );
   }
 }


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

This pull emits an info-level log when the various Okta entity providers complete execution in addition to the existing log that gets emitted when they begin execution. This allows better visibility into provider runtime.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
