### PR TITLE
[iframe plugin] passing `class` props to components

### DIFF
--- a/.changeset/thirty-donuts-wink.md
+++ b/.changeset/thirty-donuts-wink.md
@@ -2,4 +2,4 @@
 '@roadiehq/backstage-plugin-iframe': patch
 ---
 
-passing `class` prop to elements
+passing `classes` prop down to elements

--- a/.changeset/thirty-donuts-wink.md
+++ b/.changeset/thirty-donuts-wink.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-iframe': patch
+---
+
+passing `class` prop to elements

--- a/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
@@ -112,7 +112,13 @@ export const IFrameCard = (props: IFrameComponentProps) => {
   const { src, srcFromAnnotation, height, width, title } = props;
   if (src) {
     return (
-      <IFrameFromSrc class={props.class} src={src} height={height} width={width} title={title} />
+      <IFrameFromSrc
+        class={props.class}
+        src={src}
+        height={height}
+        width={width}
+        title={title}
+      />
     );
   }
 

--- a/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
@@ -28,13 +28,13 @@ import { determineError } from './utils/helpers';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
 const IFrameComponentContent = (props: IFrameComponentContentProps) => {
-  const { class: className, height, src, title, width } = props;
+  const { classes, height, src, title, width } = props;
 
   return (
     <Content>
       <ContentHeader title={title} />
       <iframe
-        className={className || ''}
+        className={classes || ''}
         src={src}
         height={height || '100%'}
         width={width || '100%'}
@@ -71,7 +71,7 @@ const IFrameFromAnnotation = (props: IFrameFromAnnotationProps) => {
 
   return (
     <IFrameComponentContent
-      class={props.class}
+      classes={props.classes}
       src={src}
       title={title}
       height={height}
@@ -94,7 +94,7 @@ const IFrameFromSrc = (props: IFrameProps) => {
 
   return (
     <IFrameComponentContent
-      class={props.class}
+      classes={props.classes}
       src={src}
       title={title}
       height={height}
@@ -113,7 +113,7 @@ export const IFrameCard = (props: IFrameComponentProps) => {
   if (src) {
     return (
       <IFrameFromSrc
-        class={props.class}
+        classes={props.classes}
         src={src}
         height={height}
         width={width}
@@ -125,7 +125,7 @@ export const IFrameCard = (props: IFrameComponentProps) => {
   if (srcFromAnnotation) {
     return (
       <IFrameFromAnnotation
-        class={props.class}
+        classes={props.classes}
         srcFromAnnotation={srcFromAnnotation}
         height={height}
         width={width}

--- a/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { ErrorComponent } from './ErrorComponent';
 import {
   IFrameProps,
+  IFrameComponentContentProps,
   IFrameComponentProps,
   IFrameFromAnnotationProps,
 } from './types';
@@ -26,20 +27,14 @@ import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { determineError } from './utils/helpers';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-type IFrameComponentContentProps = {
-  src: string;
-  title: string;
-  height?: string;
-  width?: string;
-};
-
 const IFrameComponentContent = (props: IFrameComponentContentProps) => {
-  const { title, src, height, width } = props;
+  const { class: className, height, src, title, width } = props;
 
   return (
     <Content>
       <ContentHeader title={title} />
       <iframe
+        className={className || ''}
         src={src}
         height={height || '100%'}
         width={width || '100%'}
@@ -76,6 +71,7 @@ const IFrameFromAnnotation = (props: IFrameFromAnnotationProps) => {
 
   return (
     <IFrameComponentContent
+      class={props.class}
       src={src}
       title={title}
       height={height}
@@ -98,6 +94,7 @@ const IFrameFromSrc = (props: IFrameProps) => {
 
   return (
     <IFrameComponentContent
+      class={props.class}
       src={src}
       title={title}
       height={height}
@@ -115,11 +112,14 @@ export const IFrameCard = (props: IFrameComponentProps) => {
   const { src, srcFromAnnotation, height, width, title } = props;
   if (src) {
     return (
-      <IFrameFromSrc src={src} height={height} width={width} title={title} />
+      <IFrameFromSrc class={props.class} src={src} height={height} width={width} title={title} />
     );
-  } else if (srcFromAnnotation) {
+  }
+
+  if (srcFromAnnotation) {
     return (
       <IFrameFromAnnotation
+        class={props.class}
         srcFromAnnotation={srcFromAnnotation}
         height={height}
         width={width}
@@ -127,6 +127,7 @@ export const IFrameCard = (props: IFrameComponentProps) => {
       />
     );
   }
+
   return (
     <ErrorComponent errorMessage="You must provide `src` or `srcFromAnnotation`" />
   );

--- a/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
@@ -8,11 +8,11 @@ export type IFrameProps = {
   title?: string;
   height?: string;
   width?: string;
-  class?: string;
+  classes?: string;
 };
 
 export type IFrameComponentContentProps = {
-  class?: string;
+  classes?: string;
   src: string;
   title: string;
   height?: string;
@@ -25,7 +25,7 @@ export type IFrameComponentProps = {
   title?: string;
   height?: string;
   width?: string;
-  class?: string;
+  classes?: string;
 };
 
 export type IFrameFromAnnotationProps = {
@@ -33,7 +33,7 @@ export type IFrameFromAnnotationProps = {
   title?: string;
   height?: string;
   width?: string;
-  class?: string;
+  classes?: string;
 };
 
 export type IFrameContentProps = {

--- a/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
@@ -11,6 +11,14 @@ export type IFrameProps = {
   class?: string;
 };
 
+export type IFrameComponentContentProps = {
+  class?: string;
+  src: string;
+  title: string;
+  height?: string;
+  width?: string;
+};
+
 export type IFrameComponentProps = {
   src?: string;
   srcFromAnnotation?: string;

--- a/plugins/frontend/backstage-plugin-iframe/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/plugin.ts
@@ -57,7 +57,7 @@ export const HomePageIFrameCard = homePlugin.provide(
     src: string;
     height?: string;
     width?: string;
-    class?: string;
+    classes?: string;
   }>({
     name: 'HomePageIFrameCard',
     title: 'IFrame Card',


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

The types already permit the `class` prop on the iframe components, but it was not being used. This passes the prop down to the appropriate components to enable styling the iframe. 

I also moved one of the types from inline into the `types.ts`.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
