### PR TITLE
allow posting string data to backstage request

### DIFF
--- a/.changeset/cyan-avocados-walk.md
+++ b/.changeset/cyan-avocados-walk.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': minor
+---
+
+Allow posting string data via the `http:backstage:request` action.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -115,6 +115,40 @@ describe('http:backstage:request', () => {
       });
     });
 
+    describe('with body defined as application/json and passing a string', () => {
+      it('should create a request and pass body parameter', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+              name: 'test',
+            }),
+          },
+        });
+        expect(http).toBeCalledWith(
+          {
+            url: 'http://backstage.tests/api/proxy/foo',
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: '{"name":"test"}',
+          },
+          logger,
+        );
+      });
+    });
+
     describe('with body defined as a string', () => {
       it('should create a request and pass body parameter', async () => {
         (http as jest.Mock).mockReturnValue({
@@ -136,6 +170,33 @@ describe('http:backstage:request', () => {
             method: 'POST',
             headers: {},
             body: 'test',
+          },
+          logger,
+        );
+      });
+    });
+
+    describe('with body defined as a string xml', () => {
+      it('should create a request and pass body parameter', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'POST',
+            body: '<?xml version="1.0" encoding="UTF-8"><node>asdf</node>',
+          },
+        });
+        expect(http).toBeCalledWith(
+          {
+            url: 'http://backstage.tests/api/proxy/foo',
+            method: 'POST',
+            headers: {},
+            body: '<?xml version="1.0" encoding="UTF-8"><node>asdf</node>',
           },
           logger,
         );

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -30,7 +30,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
     method: Methods;
     headers?: Headers;
     params?: Params;
-    body?: Body;
+    body?: any;
   }>({
     id: 'http:backstage:request',
     description:
@@ -74,7 +74,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
           body: {
             title: 'Request body',
             description: 'The body you would like to pass to your request',
-            type: 'object',
+            type: ['object', 'string'],
           },
         },
       },
@@ -115,6 +115,7 @@ export function createHttpBackstageAction(options: { config: Config }) {
 
       if (
         input.body &&
+        typeof input.body !== 'string' &&
         input.headers &&
         input.headers['content-type'] &&
         input.headers['content-type'].includes('application/json')


### PR DESCRIPTION
allow posting string data to backstage request

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
