### PR TITLE
add aws secrets manager action

### DIFF
--- a/.changeset/grumpy-items-tell.md
+++ b/.changeset/grumpy-items-tell.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-aws': minor
+---
+
+add create secrets manager action to aws module

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/README.md
@@ -6,6 +6,7 @@ This contains a collection of actions:
 
 - `roadiehq:aws:s3:cp`
 - `roadiehq:aws:ecr:create`
+- `roadiehq:aws:secrets-manager:create`
 
 ## Getting started
 
@@ -30,12 +31,13 @@ Import the action that you'd like to register to your backstage instance.
 
 ```typescript
 // packages/backend/src/plugins/scaffolder.ts
-import { createAwsS3CpAction, createEcrAction } from '@roadiehq/scaffolder-backend-module-aws';
+import { createAwsS3CpAction, createEcrAction, createAwsSecretsManagerCreateAction } from '@roadiehq/scaffolder-backend-module-aws';
 ...
 
 const actions = [
   createAwsS3CpAction(),
   createEcrAction(),
+  createAwsSecretsManagerCreateAction(),
   ...createBuiltinActions({
     containerRunner,
     integrations,
@@ -189,5 +191,75 @@ spec:
         tags: ${{parameters.Tags}}
         imageMutability: ${{parameters.ImageMutability}}
         scanOnPush: ${{parameters.ScanOnPush}}
+        region: ${{parameters.Region}}
+```
+
+##### For Secrets Manager create action
+
+```yaml
+---
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-secret-repo-template
+  title: Create Secret
+  description: Create secret in Secrets Manager using scaffolder custom action
+spec:
+  owner: roadie
+  type: service
+
+  parameters:
+    - title: Add Secret Details
+      required:
+        - Name
+        - Region
+      properties:
+        Name:
+          title: Secret name
+          type: string
+          description: name of the secret to be created
+          ui:autofocus: true
+        Description:
+          title: Description
+          type: string
+          description: description of the secret
+        Value:
+          title: Value
+          description: secret string value
+          type: string
+        Tags:
+          type: array
+          items:
+            type: object
+            description: Secret tags
+            title: tag
+            properties:
+              Key:
+                type: string
+                title: Key
+              Value:
+                type: string
+                title: Value
+        Profile:
+          title: AWS profile
+          description: AWS profile
+          type: string
+          default: 'default'
+        Region:
+          title: AWS region
+          type: string
+          description: region for aws secrets manager
+          default: 'us-east-1'
+
+  steps:
+    - id: createSecret
+      name: create secret - prod
+      action: roadiehq:aws:secrets-manager:create
+      input:
+        name: ${{ parameters.Name }}
+        description: ${{ parameters.Description }}
+        value: ${{ parameters.Value }}
+        tags: ${{parameters.Tags}}
+        profile: ${{parameters.Profile}}
         region: ${{parameters.Region}}
 ```

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/package.json
@@ -31,8 +31,9 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.53.0",
     "@aws-sdk/client-ecr": "^3.169.0",
+    "@aws-sdk/client-s3": "^3.53.0",
+    "@aws-sdk/client-secrets-manager": "^3.241.0",
     "@aws-sdk/types": "^3.53.0",
     "@backstage/backend-common": "^0.17.0",
     "@backstage/config": "^1.0.5",

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.test.ts
@@ -16,7 +16,7 @@
 
 import { getVoidLogger } from '@backstage/backend-common';
 import { PassThrough } from 'stream';
-import { createAwsSecretsManagerCreateSecretAction } from './create';
+import { createAwsSecretsManagerCreateAction as createAwsSecretsManagerCreateAction } from './create';
 import { mockClient } from 'aws-sdk-client-mock';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 
@@ -34,7 +34,7 @@ describe('Create secret without tags', () => {
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
   };
-  const action = createAwsSecretsManagerCreateSecretAction();
+  const action = createAwsSecretsManagerCreateAction();
 
   it('Should call Secrets Manager client send', async () => {
     await action.handler({
@@ -65,7 +65,7 @@ describe('Create secret without optional properties', () => {
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
   };
-  const action = createAwsSecretsManagerCreateSecretAction();
+  const action = createAwsSecretsManagerCreateAction();
 
   it('Should call Secrets Manager client send', async () => {
     await action.handler({
@@ -95,7 +95,7 @@ describe('Create secret with optional properties', () => {
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
   };
-  const action = createAwsSecretsManagerCreateSecretAction();
+  const action = createAwsSecretsManagerCreateAction();
 
   it('Should call Secrets Manager client send', async () => {
     await action.handler({

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import { PassThrough } from 'stream';
+import { createAwsSecretsManagerCreateSecretAction } from './create';
+import { mockClient } from 'aws-sdk-client-mock';
+import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
+
+// @ts-ignore
+const secretsManagerClient = mockClient(SecretsManagerClient);
+const region = 'us-east-1';
+
+describe('Create secret without tags', () => {
+  const secretName = 'no-tags';
+
+  const mockContext = {
+    workspacePath: '/fake-tmp-dir',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+  const action = createAwsSecretsManagerCreateSecretAction();
+
+  it('Should call Secrets Manager client send', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        name: secretName,
+        description: '',
+        value: '',
+        tags: [],
+        profile: '',
+        region: region,
+      },
+    });
+    expect(secretsManagerClient.send.getCall(0).args[0].input).toMatchObject({
+      Name: secretName,
+      Tags: [],
+    });
+  });
+});
+
+describe('Create secret without optional properties', () => {
+  const secretName = 'no-optional-properties';
+
+  const mockContext = {
+    workspacePath: '/fake-tmp-dir',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+  const action = createAwsSecretsManagerCreateSecretAction();
+
+  it('Should call Secrets Manager client send', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        name: secretName,
+        description: '',
+        value: '',
+        tags: [],
+        profile: '',
+        region: region,
+      },
+    });
+    expect(secretsManagerClient.send.getCall(1).args[0].input).toMatchObject({
+      Name: secretName,
+    });
+  });
+});
+
+describe('Create secret with optional properties', () => {
+  const secretName = 'optional-properties';
+
+  const mockContext = {
+    workspacePath: '/fake-tmp-dir',
+    logger: getVoidLogger(),
+    logStream: new PassThrough(),
+    output: jest.fn(),
+    createTemporaryDirectory: jest.fn(),
+  };
+  const action = createAwsSecretsManagerCreateSecretAction();
+
+  it('Should call Secrets Manager client send', async () => {
+    await action.handler({
+      ...mockContext,
+      input: {
+        name: secretName,
+        description: 'description',
+        value: 'value',
+        tags: [{ Key: 'keytest', Value: 'valuetest' }],
+        profile: 'aws-profile',
+        region: region,
+      },
+    });
+    expect(secretsManagerClient.send.getCall(2).args[0].input).toMatchObject({
+      Name: secretName,
+      Description: 'description',
+      SecretString: 'value',
+      Tags: [{ Key: 'keytest', Value: 'valuetest' }],
+    });
+  });
+});

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.ts
@@ -101,7 +101,6 @@ export function createAwsSecretsManagerCreateAction(options?: {
         region: ctx.input.region,
       };
 
-      ctx.logger.info(config);
       const secretsManagerClient = new SecretsManagerClient(config);
 
       try {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTemplateAction } from '@backstage/plugin-scaffolder-backend';
+import {
+  SecretsManagerClient,
+  SecretsManagerClientConfig,
+  CreateSecretCommand,
+} from '@aws-sdk/client-secrets-manager';
+import { CredentialProvider } from '@aws-sdk/types';
+import { assertError } from '@backstage/errors';
+
+export function createAwsSecretsManagerCreateSecretAction(options?: {
+  credentials?: CredentialProvider;
+}) {
+  return createTemplateAction<{
+    name: string;
+    description: string;
+    value: string;
+    tags: Array<{ Key: string; Value: string }>;
+    profile: string;
+    region: string;
+  }>({
+    id: 'loadsmart:aws:secrets-manager:create',
+    description: 'Creates a new secret in AWS Secrets Manager',
+    schema: {
+      input: {
+        required: ['name', 'region'],
+        type: 'object',
+        properties: {
+          name: {
+            title: 'Secret name',
+            description: 'The name of the secret to be created',
+            type: 'string',
+          },
+          description: {
+            title: 'Secret description',
+            description: 'The description of the secret to be created',
+            type: 'string',
+            required: false,
+          },
+          value: {
+            title: 'Secret value',
+            description: 'The string value to be encrypted in the new secret',
+            type: 'string',
+            required: false,
+          },
+          tags: {
+            title: 'Tags',
+            description: 'AWS tags to be added to the secret',
+            type: 'array',
+            required: false,
+            items: {
+              type: 'object',
+              properties: {
+                Key: {
+                  type: 'string',
+                },
+                Value: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+          profile: {
+            title: 'AWS profile',
+            description: 'AWS profile to use',
+            type: 'string',
+            required: false,
+          },
+          region: {
+            title: 'Region',
+            description: 'AWS region to create the secret on',
+            type: 'string',
+          },
+        },
+      },
+    },
+    async handler(ctx) {
+      const config: SecretsManagerClientConfig & {
+        profile?: string;
+        region?: string;
+      } = {
+        ...(options?.credentials && {
+          credentials: await options.credentials(),
+        }),
+        profile: ctx.input.profile,
+        region: ctx.input.region,
+      };
+
+      ctx.logger.info(config);
+      const secretsManagerClient = new SecretsManagerClient(config);
+
+      try {
+        await secretsManagerClient.send(
+          new CreateSecretCommand({
+            Name: ctx.input.name,
+            Description: ctx.input.description,
+            SecretString: ctx.input.value,
+            Tags: ctx.input.tags,
+          }),
+        );
+        ctx.logger.info(`secret successfully created: ${ctx.input.name}`);
+      } catch (e) {
+        assertError(e);
+        ctx.logger.error('Error creating secret:', e);
+      }
+    },
+  });
+}

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/create.ts
@@ -23,7 +23,7 @@ import {
 import { CredentialProvider } from '@aws-sdk/types';
 import { assertError } from '@backstage/errors';
 
-export function createAwsSecretsManagerCreateSecretAction(options?: {
+export function createAwsSecretsManagerCreateAction(options?: {
   credentials?: CredentialProvider;
 }) {
   return createTemplateAction<{
@@ -34,7 +34,7 @@ export function createAwsSecretsManagerCreateSecretAction(options?: {
     profile: string;
     region: string;
   }>({
-    id: 'loadsmart:aws:secrets-manager:create',
+    id: 'roadiehq:aws:secrets-manager:create',
     description: 'Creates a new secret in AWS Secrets Manager',
     schema: {
       input: {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { createAwsSecretsManagerCreateSecretAction } from './create';
+export { createAwsSecretsManagerCreateAction } from './create';

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/secrets-manager/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { createAwsSecretsManagerCreateSecretAction } from './create';


### PR DESCRIPTION
Add a new AWS scaffolder action to create a secret in AWS Secrets Manager. Also, it includes an AWS profile input to support creation of secrets in multiple AWS accounts, as required in my scenario

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
