### PR TITLE
Support additional argocd label constraints

### DIFF
--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -120,7 +120,9 @@ export class ArgoService implements ArgoServiceApi {
   ): Promise<any> {
     const urlSuffix = options.name
       ? `/${options.name}`
-      : `?selector${options.selector!.includes(" ") ? encodeURIComponent(" ") : "="}${encodeURIComponent(options.selector!)}`;
+      : `?selector${
+          options.selector!.includes(' ') ? encodeURIComponent(' ') : '='
+        }${encodeURIComponent(options.selector!)}`;
     const requestOptions: RequestInit = {
       method: 'GET',
       headers: {

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -120,7 +120,7 @@ export class ArgoService implements ArgoServiceApi {
   ): Promise<any> {
     const urlSuffix = options.name
       ? `/${options.name}`
-      : `?selector=${options.selector}`;
+      : `?selector${options.selector!.includes(" ") ? encodeURIComponent(" ") : "="}${encodeURIComponent(options.selector!)}`;
     const requestOptions: RequestInit = {
       method: 'GET',
       headers: {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -114,8 +114,10 @@ export class ArgoCDApiClient implements ArgoCDApi {
     const query = Object.keys(params)
       .filter(key => params[key] !== undefined)
       .map(
-        k =>
-          `${encodeURIComponent(k)}=${encodeURIComponent(params[k] as string)}`,
+        k => {
+          const prefix = params[k]!.includes(" ") ? encodeURIComponent(" ") : "=";
+          return `${encodeURIComponent(k)}${prefix}${encodeURIComponent(params[k] as string)}`
+        }
       )
       .join('&');
     return this.fetchDecode(

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -113,12 +113,12 @@ export class ArgoCDApiClient implements ArgoCDApi {
     };
     const query = Object.keys(params)
       .filter(key => params[key] !== undefined)
-      .map(
-        k => {
-          const prefix = params[k]!.includes(" ") ? encodeURIComponent(" ") : "=";
-          return `${encodeURIComponent(k)}${prefix}${encodeURIComponent(params[k] as string)}`
-        }
-      )
+      .map(k => {
+        const prefix = params[k]!.includes(' ') ? encodeURIComponent(' ') : '=';
+        return `${encodeURIComponent(k)}${prefix}${encodeURIComponent(
+          params[k] as string,
+        )}`;
+      })
       .join('&');
     return this.fetchDecode(
       `${proxyUrl}${options.url}/applications?${query}`,


### PR DESCRIPTION
Removed hardcoded '=' constraint from url query parameters. Added support for different argocd label constraints

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
