### PR TITLE
add amplitude plugin to show metrics in backstage

### DIFF
--- a/.changeset/chilly-jokes-sit.md
+++ b/.changeset/chilly-jokes-sit.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-amplitude': major
+---
+
+Initial release of Amplitude plugin with a single home page card.

--- a/plugins/frontend/backstage-plugin-amplitude/.eslintrc.js
+++ b/plugins/frontend/backstage-plugin-amplitude/.eslintrc.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/frontend/backstage-plugin-amplitude/README.md
+++ b/plugins/frontend/backstage-plugin-amplitude/README.md
@@ -1,3 +1,34 @@
 # backstage-plugin-amplitude
 
 This plugin allows you to display statistics from Amplitude.
+
+You will first need to configure a proxy with the api key and secret for the Amplitude API and encode it for a basic Authorization header.
+
+```yaml
+proxy:
+  '/amplitude':
+    target: 'https://amplitude.com/api'
+    headers:
+      Authorization: Basic ${AMPLITUDE_API_SECRET}
+```
+
+It can show the data from an existing dashboard on the backstage homeapge using the `AmplitudeChartCard` by adding the following to your `HomePage.tsx`:
+
+```typescript jsx
+import { AmplitudeChartCard } from '@roadiehq/backstage-plugin-amplitude';
+...
+
+export const HomePage = () => {
+  return (
+    <PageWithHeader title="Home" themeId="home">
+      <Content>
+        <Grid container spacing={3}>
+          ...
+          <Grid item md={6} xs={12}>
+            <AmplitudeChartCard
+              chartId="abcdef"
+              title="Chart Data"
+            />
+          </Grid>
+          ...
+```

--- a/plugins/frontend/backstage-plugin-amplitude/README.md
+++ b/plugins/frontend/backstage-plugin-amplitude/README.md
@@ -1,0 +1,3 @@
+# backstage-plugin-amplitude
+
+This plugin allows you to display statistics from Amplitude.

--- a/plugins/frontend/backstage-plugin-amplitude/package.json
+++ b/plugins/frontend/backstage-plugin-amplitude/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@roadiehq/backstage-plugin-amplitude",
+  "version": "0.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "homepage": "https://roadie.io/backstage/plugins/amplitude/",
+  "bugs": {
+    "url": "https://github.com/RoadieHQ/roadie-backstage-plugins/issues",
+    "email": "support@roadie.io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "github:RoadieHQ/roadie-backstage-plugins",
+    "directory": "plugins/frontend/backstage-plugin-amplitude"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/core-components": "^0.12.0",
+    "@backstage/core-plugin-api": "^1.1.0",
+    "@backstage/catalog-model": "^1.1.3",
+    "@backstage/plugin-catalog-react": "^1.2.1",
+    "@backstage/theme": "^0.2.16",
+    "@material-ui/core": "^4.12.2",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.45",
+    "react-use": "^17.2.4",
+    "@backstage/plugin-home": "^0.4.27"
+  },
+  "peerDependencies": {
+    "react": "^16.13.1 || ^17.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.21.1",
+    "@backstage/core-app-api": "^1.2.0",
+    "@backstage/dev-utils": "^1.0.8",
+    "@backstage/test-utils": "^1.2.2",
+    "@testing-library/jest-dom": "^5.10.1",
+    "@testing-library/react": "^12.1.3",
+    "@testing-library/user-event": "^13.1.8",
+    "@types/jest": "*",
+    "@types/node": "*",
+    "msw": "^0.35.0",
+    "cross-fetch": "^3.1.5",
+    "jest-environment-jsdom": "^29.2.1",
+    "jest-fetch-mock": "^3.0.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/plugins/frontend/backstage-plugin-amplitude/package.json
+++ b/plugins/frontend/backstage-plugin-amplitude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-amplitude",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,8 +39,6 @@
     "@backstage/plugin-catalog-react": "^1.2.1",
     "@backstage/theme": "^0.2.16",
     "@material-ui/core": "^4.12.2",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.45",
     "react-use": "^17.2.4",
     "@backstage/plugin-home": "^0.4.27"
   },
@@ -53,9 +51,9 @@
     "@backstage/dev-utils": "^1.0.8",
     "@backstage/test-utils": "^1.2.2",
     "@testing-library/jest-dom": "^5.10.1",
-    "@testing-library/react": "^12.1.3",
+    "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^13.1.8",
-    "@types/jest": "*",
+    "@types/jest": "^26.0.7",
     "@types/node": "*",
     "msw": "^0.35.0",
     "cross-fetch": "^3.1.5",

--- a/plugins/frontend/backstage-plugin-amplitude/package.json
+++ b/plugins/frontend/backstage-plugin-amplitude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-amplitude",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/frontend/backstage-plugin-amplitude/src/api/AmplitudeApi.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/api/AmplitudeApi.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApiRef } from '@backstage/core-plugin-api';
+
+export const amplitudeApiRef = createApiRef<AmplitudeApi>({
+  id: 'plugin.amplitude.service',
+});
+
+export type ChartData = {
+  data: {
+    series: number[][];
+    seriesMeta: string[];
+    xValues: string[];
+  };
+};
+
+export type AmplitudeApi = {
+  getChart: (options: { chartId: string }) => Promise<ChartData>;
+};

--- a/plugins/frontend/backstage-plugin-amplitude/src/api/AmplitudeClient.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/api/AmplitudeClient.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AmplitudeApi, ChartData } from './AmplitudeApi';
+import { FetchApi, DiscoveryApi } from '@backstage/core-plugin-api';
+
+type Options = {
+  fetchApi: FetchApi;
+  discoveryApi: DiscoveryApi;
+};
+
+export class AmplitudeClient implements AmplitudeApi {
+  private readonly fetchApi: FetchApi;
+  private readonly discoveryApi: DiscoveryApi;
+
+  constructor(options: Options) {
+    this.fetchApi = options.fetchApi;
+    this.discoveryApi = options.discoveryApi;
+  }
+
+  async getChart(options: { chartId: string }): Promise<ChartData> {
+    const { chartId } = options;
+    const url = this.discoveryApi.getBaseUrl('amplitude');
+    const response = await this.fetchApi.fetch(
+      `${url}/3/chart/${chartId}/query`,
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to retrieve chart: ${response.statusText}`);
+    }
+    return await response.json();
+  }
+}

--- a/plugins/frontend/backstage-plugin-amplitude/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/api/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { amplitudeApiRef } from './AmplitudeApi';
+export type { AmplitudeApi, ChartData } from './AmplitudeApi';
+export { AmplitudeClient } from './AmplitudeClient';

--- a/plugins/frontend/backstage-plugin-amplitude/src/components/AmplitudeChartCard/Content.tsx
+++ b/plugins/frontend/backstage-plugin-amplitude/src/components/AmplitudeChartCard/Content.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { AmplitudeChartCardContentProps } from './types';
+import { AmplitudeApi, AmplitudeClient } from '../../api';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import useAsync from 'react-use/lib/useAsync';
+import { ErrorPanel, Progress, TrendLine } from '@backstage/core-components';
+import { Card, CardHeader, Grid } from '@material-ui/core';
+
+/**
+ * A component to render the stats about a amplitude chart.
+ *
+ * @public
+ */
+export const Content = ({ chartId, title }: AmplitudeChartCardContentProps) => {
+  const fetchApi = useApi(fetchApiRef);
+  const discoveryApi = useApi(discoveryApiRef);
+  const amplitudeApi: AmplitudeApi = new AmplitudeClient({
+    fetchApi,
+    discoveryApi,
+  });
+
+  const {
+    value: chartData,
+    loading,
+    error,
+  } = useAsync(async () => {
+    return await amplitudeApi.getChart({ chartId });
+  });
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error || !chartData) {
+    return <ErrorPanel error={error || new Error('chartId was not found')} />;
+  }
+
+  return (
+    <Card variant="outlined">
+      <CardHeader title={title || 'Amplitude'} />
+      <Grid container>
+        <Grid item>
+          {chartData.data.series.map((data, index) => {
+            return (
+              <TrendLine data={data} title={chartData.data.seriesMeta[index]} />
+            );
+          })}
+        </Grid>
+      </Grid>
+    </Card>
+  );
+};

--- a/plugins/frontend/backstage-plugin-amplitude/src/components/AmplitudeChartCard/index.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/components/AmplitudeChartCard/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Content } from './Content';

--- a/plugins/frontend/backstage-plugin-amplitude/src/components/AmplitudeChartCard/types.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/components/AmplitudeChartCard/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Props for AmplitudeChartCard content component {@link Content}.
+ *
+ * @public
+ */
+export type AmplitudeChartCardContentProps = {
+  chartId: string;
+  title: string;
+};

--- a/plugins/frontend/backstage-plugin-amplitude/src/index.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './plugin';

--- a/plugins/frontend/backstage-plugin-amplitude/src/plugin.test.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/plugin.test.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { amplitudePlugin } from './plugin';
+
+describe('amplitude', () => {
+  it('should export plugin', () => {
+    expect(amplitudePlugin).toBeDefined();
+  });
+});

--- a/plugins/frontend/backstage-plugin-amplitude/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/plugin.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createApiFactory,
+  createPlugin,
+  FetchApi,
+  fetchApiRef,
+  DiscoveryApi,
+  discoveryApiRef,
+} from '@backstage/core-plugin-api';
+import { createCardExtension } from '@backstage/plugin-home';
+
+import { AmplitudeClient, amplitudeApiRef } from './api';
+
+export const amplitudePlugin = createPlugin({
+  id: 'amplitude',
+  apis: [
+    createApiFactory({
+      api: amplitudeApiRef,
+      deps: { fetchApi: fetchApiRef, discoveryApi: discoveryApiRef },
+      factory: ({
+        fetchApi,
+        discoveryApi,
+      }: {
+        fetchApi: FetchApi;
+        discoveryApi: DiscoveryApi;
+      }) => {
+        return new AmplitudeClient({
+          fetchApi,
+          discoveryApi,
+        });
+      },
+    }),
+  ],
+});
+
+export const AmplitudeChartCard = amplitudePlugin.provide(
+  createCardExtension<{ chartId: string; title: string }>({
+    name: 'AmplitudeChartCard',
+    title: '',
+    components: () => import('./components/AmplitudeChartCard'),
+  }),
+);

--- a/plugins/frontend/backstage-plugin-amplitude/src/routes.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/routes.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'amplitude-frontend',
+});

--- a/plugins/frontend/backstage-plugin-amplitude/src/setupTests.ts
+++ b/plugins/frontend/backstage-plugin-amplitude/src/setupTests.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '@testing-library/jest-dom';
+import 'cross-fetch/polyfill';


### PR DESCRIPTION
add amplitude plugin to show metrics in backstage

todo:

I plan to add the same card but for entities using an annotation for the chart-id

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
