### PR TITLE
Sc 12700 add openapi asyncapi placeholder support

### DIFF
--- a/.changeset/tricky-terms-retire.md
+++ b/.changeset/tricky-terms-retire.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': minor
+---
+
+Add openapi and asyncapi placeholder support

--- a/utils/roadie-backstage-entity-validator/src/validator.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.js
@@ -40,7 +40,7 @@ function modifyPlaceholders(obj) {
   for (const k in obj) {
     if (typeof obj[k] === 'object') {
       try {
-        if (obj[k].$text) {
+        if (obj[k].$text || obj[k].$openapi || obj[k].$asyncapi) {
           obj[k] = 'DUMMY TEXT';
           return;
         }

--- a/utils/roadie-backstage-entity-validator/src/validator.test.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.test.js
@@ -48,6 +48,32 @@ spec:
   definition:
     $text: "./openapi/v1.oas3.yaml"
 `,
+      'catalog-info-with-openapi-placeholder.yml': `
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: test-service-api
+  description: API for test-service
+spec:
+  type: openapi
+  lifecycle: production
+  owner: group:team-atools
+  definition:
+    $openapi: "./openapi/v1.oas3.yaml"
+`,
+      'catalog-info-with-asyncapi-placeholder.yml': `
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: test-service-api
+  description: API for test-service
+spec:
+  type: openapi
+  lifecycle: production
+  owner: group:team-atools
+  definition:
+    $asyncapi: "./asyncapi/some-spec.yaml"
+`,
       'catalog-info.yml': `
 ---
 apiVersion: backstage.io/v1alpha1
@@ -154,6 +180,12 @@ spec:
   it('Should successfully validate catalog info with replacements', async () => {
     await expect(
       validator.validateFromFile('catalog-info-with-replacement.yml'),
+    ).resolves.toBeUndefined();
+    await expect(
+      validator.validateFromFile('catalog-info-with-openapi-placeholder.yml'),
+    ).resolves.toBeUndefined();
+    await expect(
+      validator.validateFromFile('catalog-info-with-asyncapi-placeholder.yml'),
     ).resolves.toBeUndefined();
   });
 


### PR DESCRIPTION
Api entities with $openapi / $asyncapi placeholders are failing validation as the definition is not a string (it's an unresolved placeholder object).

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
