### PR TITLE
add 'user-agent' header to cloudsmith api call and update readme

### DIFF
--- a/.changeset/slow-toys-switch.md
+++ b/.changeset/slow-toys-switch.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-cloudsmith': patch
+---
+
+Added 'User-Agent' header to Cloudsmith API request

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Amongst others, the following plugins can be found within this repo:
 
 - [Argo CD Backend](https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd-backend) (contributed by [American Airlines](https://github.com/AmericanAirlines))
 
+- [Cloudsmith](https://www.npmjs.com/package/@roadiehq/backstage-plugin-cloudsmith) 
+
 Installation instructions for each plugin can be found in their individual README files.
 
 Backstage is an open platform for creating developer portals. To learn more about the problems it can help solve, please check out our [Ultimate Guide to Backstage by Spotify](https://roadie.io/backstage-spotify/).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Amongst others, the following plugins can be found within this repo:
 
 - [Argo CD Backend](https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd-backend) (contributed by [American Airlines](https://github.com/AmericanAirlines))
 
-- [Cloudsmith](https://www.npmjs.com/package/@roadiehq/backstage-plugin-cloudsmith) 
+- [Cloudsmith](https://www.npmjs.com/package/@roadiehq/backstage-plugin-cloudsmith)
 
 Installation instructions for each plugin can be found in their individual README files.
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -44,6 +44,7 @@ proxy:
     target: 'https://api.cloudsmith.io/v1'
     headers:
       X-Api-Key: ${CLOUDSMITH_API_KEY}
+      User-Agent: 'Roadie-Backstage'
 
   '/aws-news-feed':
     target: 'https://aws.amazon.com/about-aws/whats-new/recent/feed/'

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -44,7 +44,7 @@ proxy:
     target: 'https://api.cloudsmith.io/v1'
     headers:
       X-Api-Key: ${CLOUDSMITH_API_KEY}
-      User-Agent: 'Roadie-Backstage'
+      User-Agent: 'Backstage'
 
   '/aws-news-feed':
     target: 'https://aws.amazon.com/about-aws/whats-new/recent/feed/'

--- a/plugins/frontend/backstage-plugin-cloudsmith/README.md
+++ b/plugins/frontend/backstage-plugin-cloudsmith/README.md
@@ -57,6 +57,7 @@ proxy:
     target: 'https://api.cloudsmith.io/v1'
     headers:
       X-Api-Key: ${CLOUDSMITH_API_KEY}
+      User-Agent: 'Roadie-Backstage'
 ```
 
 When you run the backstage backend, you will need to set the `CLOUDSMITH_API_KEY` environment variable.

--- a/plugins/frontend/backstage-plugin-cloudsmith/README.md
+++ b/plugins/frontend/backstage-plugin-cloudsmith/README.md
@@ -57,7 +57,7 @@ proxy:
     target: 'https://api.cloudsmith.io/v1'
     headers:
       X-Api-Key: ${CLOUDSMITH_API_KEY}
-      User-Agent: 'Roadie-Backstage'
+      User-Agent: 'Backstage'
 ```
 
 When you run the backstage backend, you will need to set the `CLOUDSMITH_API_KEY` environment variable.


### PR DESCRIPTION
- added "User-Agent" header to the Cloudsmith API request
- updated README to include the header
- added Cloudsmith to the plugin list in the main README

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
