### PR TITLE
feat: replace moment by luxon

### DIFF
--- a/.changeset/red-melons-eat.md
+++ b/.changeset/red-melons-eat.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+feat: replaced moment by luxon

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -47,8 +47,9 @@
     "@octokit/types": "^5.0.1",
     "@types/node-fetch": "^2.5.7",
     "history": "^5.0.0",
+    "humanize-duration": "^3.28.0",
     "lodash": "^4.17.21",
-    "moment": "^2.27.0",
+    "luxon": "^3.2.1",
     "msw": "^0.39.2",
     "node-fetch": "^2.6.1",
     "react-use": "^17.2.4"
@@ -65,8 +66,9 @@
     "@backstage/test-utils": "^1.2.4",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^11.2.5",
-    "jest-environment-jsdom": "^29.2.1",
-    "cross-fetch": "^3.1.4"
+    "@types/humanize-duration": "^3.27.1",
+    "cross-fetch": "^3.1.4",
+    "jest-environment-jsdom": "^29.2.1"
   },
   "files": [
     "dist"

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
@@ -18,9 +18,9 @@ import { useEffect, useState } from 'react';
 import { useAsyncRetry } from 'react-use';
 import { githubPullRequestsApiRef } from '../api/GithubPullRequestsApi';
 import { useApi, githubAuthApiRef } from '@backstage/core-plugin-api';
-import moment from 'moment';
 import { SearchPullRequestsResponseData } from '../types';
 import { useBaseUrl } from './useBaseUrl';
+import { DateTime } from 'luxon';
 
 export type PullRequest = {
   id: number;
@@ -54,7 +54,7 @@ export function usePullRequests({
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(5);
   const getElapsedTime = (start: string) => {
-    return moment(start).fromNow();
+    return DateTime.fromISO(start).toRelative();
   };
 
   const {

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
@@ -17,9 +17,10 @@
 import { useAsync } from 'react-use';
 import { githubPullRequestsApiRef } from '../api/GithubPullRequestsApi';
 import { useApi, githubAuthApiRef } from '@backstage/core-plugin-api';
-import moment from 'moment';
 import { useBaseUrl } from './useBaseUrl';
 import { PullRequestState, SearchPullRequestsResponseData } from '../types';
+import { Duration } from 'luxon';
+import humanizeDuration from 'humanize-duration';
 
 export type PullRequestStats = {
   avgTimeUntilMerge: string;
@@ -164,10 +165,10 @@ export function usePullRequestsStatistics({
         avgTimeUntilMerge: 'Never',
         mergedToClosedRatio: '0%',
       };
-    const avgTimeUntilMergeDiff = moment.duration(
+    const avgTimeUntilMergeDiff = Duration.fromMillis(
       calcResult.avgTimeUntilMerge / calcResult.mergedCount,
     );
-    const avgTimeUntilMerge = avgTimeUntilMergeDiff.humanize();
+    const avgTimeUntilMerge = humanizeDuration(avgTimeUntilMergeDiff);
     return {
       ...calcResult,
       avgTimeUntilMerge: avgTimeUntilMerge,


### PR DESCRIPTION
Hi 👋 

I noticed that our app was bundling `moment` (72kb gzipped) and I found that was your amazing plugin importing it.

This PR aims to replace `moment` with `dayjs`. Perhaps this could be made using native JS but I don't have the full picture and `dayjs` is a `moment` replacement with the same API.

https://bundlephobia.com/package/moment@2.29.4
https://bundlephobia.com/package/dayjs@1.11.7

The savings should be around 93% from 72kb (gzipped) to ~4kb (gzipped). Please test and make sure all is working properly 🙏 

Most probably you are also using moment in other plugins and if makes sense could be also a good idea to replace them also (or if you want I can make this PR broader to include all of those).

Thank you for the amazing work 🙂 

-----

_Changed from `dayjs` to  `luxon` as it is the canonical temporal management library inside the Backstage community._

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
