### PR TITLE
feat(PullRequestTable): show PR descriptions in expandable rows

### DIFF
--- a/.changeset/friendly-lemons-love.md
+++ b/.changeset/friendly-lemons-love.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': minor
+---
+
+Display pull request descriptions on `PullRequestTable`

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
@@ -31,6 +31,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import {
   Table,
   TableColumn,
+  MarkdownContent,
   MissingAnnotationEmptyState,
 } from '@backstage/core-components';
 import {
@@ -44,7 +45,7 @@ import { Entity } from '@backstage/catalog-model';
 import { getStatusIconType } from '../Icons';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-const generatedColumns: TableColumn[] = [
+const generatedColumns: TableColumn<PullRequest>[] = [
   {
     title: 'ID',
     field: 'number',
@@ -137,7 +138,15 @@ export const PullRequestsTableView: FC<Props> = ({
   SearchComponent,
 }) => {
   return (
-    <Table
+    <Table<PullRequest>
+      detailPanel={({ rowData }) => (
+        <Box marginLeft="14px">
+          <MarkdownContent
+            content={rowData.body ?? '_No description provided._'}
+            dialect="gfm"
+          />
+        </Box>
+      )}
       isLoading={loading}
       options={{ paging: true, search: false, pageSize, padding: 'dense' }}
       totalCount={total}

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
@@ -34,6 +34,7 @@ export type PullRequest = {
   merged: string | null;
   creatorNickname: string;
   creatorProfileLink: string;
+  body: string;
 };
 
 export function usePullRequests({
@@ -101,11 +102,13 @@ export function usePullRequests({
                 state: pr_state,
                 draft,
                 pull_request: { merged_at },
+                body,
               }) => ({
                 url: html_url,
                 id,
                 number,
                 title,
+                body,
                 state: pr_state,
                 draft,
                 merged: merged_at,


### PR DESCRIPTION
Signed-off-by: Phil Kuang <pkuang@factset.com>

Adds ability to view PR descriptions on expandable rows in PR table:

![Screen Shot 2023-02-07 at 11 59 14 AM](https://user-images.githubusercontent.com/6998196/217312358-61f3f7fe-70e5-49b1-83e0-c38308bb08e7.png)

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
