### PR TITLE
feat: allow setting the baseUrl in the scaffolder-backend-module-http-request

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
@@ -138,3 +138,8 @@ Headers
 ```
 
 You can also visit the `/create/actions` route in your Backstage application to find out more about the parameters this action accepts when it's installed to configure how you like.
+
+## Configuration options
+
+By default, the plugin will use `backend.baseUrl` as the Backstage backend address. 
+This can be overriden by setting `plugin.scaffolder-backend-module-http-request.baseUrl`.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
@@ -25,6 +25,7 @@ import { Writable } from 'stream';
 import * as winston from 'winston';
 
 const mockBaseUrl = 'http://backstage.tests';
+const mockCustomBaseUrl = 'http://localhost:7007';
 
 let mockResponse: Response;
 let config: Config;
@@ -95,6 +96,32 @@ describe('http', () => {
           await expect(
             async () => await generateBackstageUrl(config, url),
           ).rejects.toThrowError('Unable to get base url');
+        });
+      });
+    });
+
+    describe('with override', () => {
+      describe('when the override is in place', () => {
+        it('returns the same url as passed in', async () => {
+          config = new ConfigReader({
+            app: {
+              baseUrl: mockBaseUrl,
+            },
+            backend: {
+              baseUrl: mockBaseUrl,
+              listen: {
+                port: 7007,
+              },
+            },
+            plugin: {
+              'scaffolder-backend-module-http-request': {
+                baseUrl: mockCustomBaseUrl,
+              },
+            }
+          });
+          expect(await generateBackstageUrl(config, proxyPath)).toEqual(
+            `${mockCustomBaseUrl}/api/proxy/foo`,
+          );
         });
       });
     });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
@@ -23,7 +23,9 @@ const DEFAULT_TIMEOUT = 60_000;
 
 export const generateBackstageUrl = (config: Config, path: string): string => {
   // ensure the request points to the correct domain
-  const externalUrl = config.getOptionalString('backend.baseUrl') || '';
+  const externalUrl = (
+    config.getOptionalString('plugin.scaffolder-backend-module-http-request.baseUrl') || config.getOptionalString('backend.baseUrl') || ''
+  );
   if (externalUrl === '') {
     throw new Error('Unable to get base url');
   }


### PR DESCRIPTION
The backstage http plugin is great, but running backstage behind the oauth2Proxy makes authentication from the task cumbersome. 
We would like to be able to configure the baseUrl to http://localhost:7007 as task runner and backend are collocated.

Signed-off-by: Alex Eftimie <alex.eftimie@getyourguide.com>

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
