### PR TITLE
OAuth okta authentication

### DIFF
--- a/.changeset/hot-mugs-carry.md
+++ b/.changeset/hot-mugs-carry.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Enabled the use of OAuth credentials for authenticating to okta. This allows credential to be provisiond that have the minimum required level of privilege for the provider to function.

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -9,7 +9,7 @@ To setup the Okta providers you will need an [Okta API Token](https://developer.
 
 You will need to configure your okta credentials in the `app-config.yaml`.
 
-### Basic Config
+### Basic Config via an API Token
 
 ```yaml
 catalog:
@@ -17,6 +17,22 @@ catalog:
     okta:
       - orgUrl: 'https://tenant.okta.com'
         token: ${OKTA_TOKEN}
+```
+
+### OAuth 2.0 Scoped Authentication
+
+API tokens have god-like scope, so to limit the risk profile you can alternatively [create an OAuth app](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) in Okta. You will need to grant it with the `okta.groups.read` and `okta.users.read` scopes as a bare minimum. In the following example the `oauth.privateKey` maye be passed as either a string encoded PEM or stringified JWK.
+
+```yaml
+catalog:
+  providers:
+    okta:
+      - orgUrl: 'https://tenant.okta.com'
+        ouath: {
+          clientId: ${OKTA_OAUTH_CLIENT_ID},
+          keyId: ${OKTA_OAUTH_KEY_ID},
+          privateKey: ${OKTA_OAUTH_PRIVATE_KEY},
+        }
 ```
 
 ### Filter Users and Groups

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -35,6 +35,8 @@ catalog:
         }
 ```
 
+Note: `keyId` is optional but _must_ be passed wen using a PEM as the `privateKey`
+
 ### Filter Users and Groups
 
 The provider allows configuring Okta search filtering for users and groups. See here for more details on what is possible: https://developer.okta.com/docs/reference/core-okta-api/#filter

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -21,7 +21,7 @@ catalog:
 
 ### OAuth 2.0 Scoped Authentication
 
-API tokens have god-like scope, so to limit the risk profile you can alternatively [create an OAuth app](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) in Okta. You will need to grant it with the `okta.groups.read` and `okta.users.read` scopes as a bare minimum. In the following example the `oauth.privateKey` maye be passed as either a string encoded PEM or stringified JWK.
+API tokens have god-like scope so to limit the risk profile you can alternatively [create an OAuth app](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) in Okta. You will need to grant it with the `okta.groups.read` and `okta.users.read` scopes as a bare minimum. In the following example the `oauth.privateKey` may be passed as either a string encoded PEM or stringified JWK.
 
 ```yaml
 catalog:

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -28,7 +28,7 @@ catalog:
   providers:
     okta:
       - orgUrl: 'https://tenant.okta.com'
-        ouath: {
+        oauth: {
           clientId: ${OKTA_OAUTH_CLIENT_ID},
           keyId: ${OKTA_OAUTH_KEY_ID},
           privateKey: ${OKTA_OAUTH_PRIVATE_KEY},

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -21,7 +21,7 @@ catalog:
 
 ### OAuth 2.0 Scoped Authentication
 
-API tokens have god-like scope so to limit the risk profile you can alternatively [create an OAuth app](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) in Okta. You will need to grant it with the `okta.groups.read` and `okta.users.read` scopes as a bare minimum. In the following example the `oauth.privateKey` may be passed as either a string encoded PEM or stringified JWK.
+[Create an OAuth app](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/#create-an-oauth-2-0-app-in-okta) in Okta. You will need to grant it with the `okta.groups.read` and `okta.users.read` scopes as a bare minimum. In the following example the `oauth.privateKey` may be passed as either a string encoded PEM or stringified JWK.
 
 ```yaml
 catalog:

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { getVoidLogger } from '@backstage/backend-common';
-import { OktaEntityProvider } from './OktaEntityProvider';
+import { OktaEntityProvider, OktaScope } from './OktaEntityProvider';
 import { AccountConfig } from '../types';
 import { Client } from '@okta/okta-sdk-nodejs';
 
@@ -31,7 +31,7 @@ class ConcreteEntityProvider extends OktaEntityProvider {
 
   getClient(
     orgUrl: string,
-    oauthScopes: string[] | undefined = undefined,
+    oauthScopes: OktaScope[] | undefined = undefined,
   ): Client {
     return super.getClient(orgUrl, oauthScopes);
   }
@@ -54,7 +54,7 @@ describe('OktaEntityProvider', () => {
         orgUrl: 'http://someorg',
         token: 'secret',
       });
-      provider.getClient('http://someorg', ['some.scope']);
+      provider.getClient('http://someorg', ['okta.users.read']);
 
       expect(Client).toBeCalledWith({
         orgUrl: 'http://someorg',
@@ -73,7 +73,7 @@ describe('OktaEntityProvider', () => {
           clientId: 'theclientid',
         },
       });
-      provider.getClient('http://someorg', ['some.scope']);
+      provider.getClient('http://someorg', ['okta.users.read']);
 
       expect(Client).toBeCalledWith({
         authorizationMode: 'PrivateKey',
@@ -81,7 +81,7 @@ describe('OktaEntityProvider', () => {
         keyId: 'thekeyid',
         orgUrl: 'http://someorg',
         privateKey: 'some string encoded PEM or JWK',
-        scopes: ['some.scope'],
+        scopes: ['okta.users.read'],
       });
     });
   });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getVoidLogger } from '@backstage/backend-common';
+import { OktaEntityProvider } from './OktaEntityProvider';
+import { AccountConfig } from '../types';
+import { Client } from '@okta/okta-sdk-nodejs';
+
+class ConcreteEntityProvider extends OktaEntityProvider {
+  public getProviderName(): string {
+    throw new Error('Method not implemented.');
+  }
+  constructor(accountConfig: AccountConfig) {
+    super([accountConfig], {
+      logger: getVoidLogger(),
+    });
+  }
+
+  getClient(
+    orgUrl: string,
+    oauthScopes: string[] | undefined = undefined,
+  ): Client {
+    return super.getClient(orgUrl, oauthScopes);
+  }
+}
+
+jest.mock('@okta/okta-sdk-nodejs', () => {
+  return {
+    Client: jest.fn().mockImplementation(() => {}),
+  };
+});
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('OktaEntityProvider', () => {
+  describe('when an api token is given', () => {
+    it('instantiates the okta client with an api token', async () => {
+      const provider = new ConcreteEntityProvider({
+        orgUrl: 'http://someorg',
+        token: 'secret',
+      });
+      provider.getClient('http://someorg', ['some.scope']);
+
+      expect(Client).toBeCalledWith({
+        orgUrl: 'http://someorg',
+        token: 'secret',
+      });
+    });
+  });
+
+  describe('when OAauth credentials are given', () => {
+    it('instantiates the okta client with all required OAauth parameters', async () => {
+      const provider = new ConcreteEntityProvider({
+        orgUrl: 'http://someorg',
+        oauth: {
+          privateKey: 'some string encoded PEM or JWK',
+          keyId: 'thekeyid',
+          clientId: 'theclientid',
+        },
+      });
+      provider.getClient('http://someorg', ['some.scope']);
+
+      expect(Client).toBeCalledWith({
+        authorizationMode: 'PrivateKey',
+        clientId: 'theclientid',
+        keyId: 'thekeyid',
+        orgUrl: 'http://someorg',
+        privateKey: 'some string encoded PEM or JWK',
+        scopes: ['some.scope'],
+      });
+    });
+  });
+});

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
@@ -57,18 +57,19 @@ export abstract class OktaEntityProvider implements EntityProvider {
 
     if (account.oauth && oauthScopes) {
       // use OAuth authentication strategy
+      const { clientId, privateKey, keyId } = account.oauth;
       return new Client({
-        orgUrl: account.orgUrl,
+        orgUrl,
         authorizationMode: 'PrivateKey',
-        clientId: account.oauth.clientId,
+        clientId,
         scopes: oauthScopes,
-        privateKey: account.oauth.privateKey,
-        keyId: account.oauth.keyId,
+        privateKey,
+        keyId,
       });
     } else if (account.token) {
       // use api token authentication strategy
       return new Client({
-        orgUrl: account.orgUrl,
+        orgUrl,
         token: account.token,
       });
     }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
@@ -55,13 +55,7 @@ export abstract class OktaEntityProvider implements EntityProvider {
       throw new Error(`accountConfig for ${orgUrl} not found`);
     }
 
-    if (
-      account.oauth &&
-      account.oauth.keyId &&
-      account.oauth.privateKey &&
-      account.oauth.clientId &&
-      oauthScopes
-    ) {
+    if (account.oauth && oauthScopes) {
       // use OAuth authentication strategy
       return new Client({
         orgUrl: account.orgUrl,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
@@ -27,6 +27,8 @@ import {
   ANNOTATION_ORIGIN_LOCATION,
 } from '@backstage/catalog-model';
 
+export type OktaScope = 'okta.groups.read' | 'okta.users.read';
+
 export abstract class OktaEntityProvider implements EntityProvider {
   protected readonly accounts: AccountConfig[];
   protected readonly logger: Logger;
@@ -44,7 +46,7 @@ export abstract class OktaEntityProvider implements EntityProvider {
 
   protected getClient(
     orgUrl: string,
-    oauthScopes: string[] | undefined = undefined,
+    oauthScopes: OktaScope[] | undefined = undefined,
   ): Client {
     const account = this.accounts.find(
       acccountConfig => acccountConfig.orgUrl === orgUrl,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -30,6 +30,7 @@ import {
 } from './userNamingStrategyFactory';
 import { AccountConfig } from '../types';
 import { groupEntityFromOktaGroup } from './groupEntityFromOktaGroup';
+import { getAccountConfig } from './accountConfig';
 
 /**
  * Provides entities from Okta Group service.
@@ -48,12 +49,9 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
       userNamingStrategy?: UserNamingStrategies;
     },
   ) {
-    const orgUrl = config.getString('orgUrl');
-    const token = config.getString('token');
+    const accountConfig = getAccountConfig(config);
 
-    const groupFilter = config.getOptionalString('groupFilter');
-
-    return new OktaGroupEntityProvider({ orgUrl, token, groupFilter }, options);
+    return new OktaGroupEntityProvider(accountConfig, options);
   }
 
   constructor(
@@ -85,7 +83,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     this.logger.info(`Providing group resources from okta: ${this.orgUrl}`);
     const groupResources: GroupEntity[] = [];
 
-    const client = this.getClient(this.orgUrl);
+    const client = this.getClient(this.orgUrl, ['okta.groups.read']);
 
     const defaultAnnotations = await this.buildDefaultAnnotations();
 

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -31,6 +31,7 @@ import {
 import { userEntityFromOktaUser } from './userEntityFromOktaUser';
 import { AccountConfig } from '../types';
 import { groupEntityFromOktaGroup } from './groupEntityFromOktaGroup';
+import { getAccountConfig } from './accountConfig';
 
 /**
  * Provides entities from Okta Org service.
@@ -49,15 +50,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
   ) {
     const oktaConfigs = config
       .getOptionalConfigArray('catalog.providers.okta')
-      ?.map(oktaConfig => {
-        const orgUrl = oktaConfig.getString('orgUrl');
-        const token = oktaConfig.getString('token');
-
-        const userFilter = oktaConfig.getOptionalString('userFilter');
-        const groupFilter = oktaConfig.getOptionalString('groupFilter');
-
-        return { orgUrl, token, groupFilter, userFilter };
-      });
+      ?.map(getAccountConfig);
 
     return new OktaOrgEntityProvider(oktaConfigs || [], options);
   }
@@ -95,7 +88,10 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
 
     await Promise.all(
       this.accounts.map(async account => {
-        const client = this.getClient(account.orgUrl);
+        const client = this.getClient(account.orgUrl, [
+          'okta.groups.read',
+          'okta.users.read',
+        ]);
 
         const defaultAnnotations = await this.buildDefaultAnnotations();
 

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -25,6 +25,7 @@ import {
 } from './userNamingStrategyFactory';
 import { AccountConfig } from '../types';
 import { userEntityFromOktaUser } from './userEntityFromOktaUser';
+import { getAccountConfig } from './accountConfig';
 
 /**
  * Provides entities from Okta User service.
@@ -38,12 +39,9 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
     config: Config,
     options: { logger: winston.Logger; namingStrategy?: UserNamingStrategies },
   ) {
-    const orgUrl = config.getString('orgUrl');
-    const token = config.getString('token');
+    const accountConfig = getAccountConfig(config);
 
-    const userFilter = config.getOptionalString('userFilter');
-
-    return new OktaUserEntityProvider({ orgUrl, token, userFilter }, options);
+    return new OktaUserEntityProvider(accountConfig, options);
   }
 
   constructor(
@@ -68,7 +66,7 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
     this.logger.info(`Providing user resources from okta: ${this.orgUrl}`);
     const userResources: UserEntity[] = [];
 
-    const client = this.getClient(this.orgUrl);
+    const client = this.getClient(this.orgUrl, ['okta.users.read']);
 
     const defaultAnnotations = await this.buildDefaultAnnotations();
 

--- a/plugins/backend/catalog-backend-module-okta/src/providers/accountConfig.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/accountConfig.ts
@@ -19,7 +19,7 @@ import { AccountConfig } from '../types';
 
 export const getAccountConfig = (config: Config): AccountConfig => {
   const orgUrl = config.getString('orgUrl');
-  const token = config.getString('token');
+  const token = config.getOptionalString('token');
 
   const userFilter = config.getOptionalString('userFilter');
   const groupFilter = config.getOptionalString('groupFilter');

--- a/plugins/backend/catalog-backend-module-okta/src/providers/accountConfig.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/accountConfig.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config } from '@backstage/config';
+import { AccountConfig } from '../types';
+
+export const getAccountConfig = (config: Config): AccountConfig => {
+  const orgUrl = config.getString('orgUrl');
+  const token = config.getString('token');
+
+  const userFilter = config.getOptionalString('userFilter');
+  const groupFilter = config.getOptionalString('groupFilter');
+  const clientId = config.getOptionalString('oauth.clientId');
+  const keyId = config.getOptionalString('oauth.keyId');
+  const privateKey = config.getOptionalString('oauth.privateKey');
+
+  const oauth =
+    clientId || keyId || privateKey
+      ? { clientId, keyId, privateKey }
+      : undefined;
+
+  return {
+    orgUrl,
+    token,
+    userFilter,
+    groupFilter,
+    oauth,
+  };
+};

--- a/plugins/backend/catalog-backend-module-okta/src/providers/accountConfig.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/accountConfig.ts
@@ -28,9 +28,7 @@ export const getAccountConfig = (config: Config): AccountConfig => {
   const privateKey = config.getOptionalString('oauth.privateKey');
 
   const oauth =
-    clientId || keyId || privateKey
-      ? { clientId, keyId, privateKey }
-      : undefined;
+    clientId && privateKey ? { clientId, keyId, privateKey } : undefined;
 
   return {
     orgUrl,

--- a/plugins/backend/catalog-backend-module-okta/src/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/types.ts
@@ -16,7 +16,12 @@
 
 export type AccountConfig = {
   orgUrl: string;
-  token: string;
+  token?: string;
+  oauth?: {
+    clientId?: string;
+    keyId?: string;
+    privateKey?: string;
+  };
   userFilter?: string;
   groupFilter?: string;
 };

--- a/plugins/backend/catalog-backend-module-okta/src/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/types.ts
@@ -18,9 +18,9 @@ export type AccountConfig = {
   orgUrl: string;
   token?: string;
   oauth?: {
-    clientId?: string;
+    clientId: string;
     keyId?: string;
-    privateKey?: string;
+    privateKey: string;
   };
   userFilter?: string;
   groupFilter?: string;


### PR DESCRIPTION
The okta provider currently only supports API tokens. These tokens have god-like permissions so sharing them with e.g backstage installations potentially carries a high level of risk. This change allows provisioning an OAuth app in okta that has the bare minimum [scopes](https://developer.okta.com/docs/api/oauth2/) namely `okta.groups.read` and `okta.users.read`. 

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
