### PR TITLE
do not require github insights widgets to prompt login

### DIFF
--- a/.changeset/twelve-clocks-tickle.md
+++ b/.changeset/twelve-clocks-tickle.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-insights': minor
+---
+
+Allow github insights widgets to be configured to not auto prompt when the component page is shown.

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -205,14 +205,11 @@ const overviewContent = (
     <EntitySwitch>
       <EntitySwitch.Case if={e => Boolean(isGithubInsightsAvailable(e))}>
         <Grid item md={6}>
-          <EntityGithubInsightsLanguagesCard autoPromptLogin={false} />
-          <EntityGithubInsightsReleasesCard autoPromptLogin={false} />
+          <EntityGithubInsightsLanguagesCard />
+          <EntityGithubInsightsReleasesCard />
         </Grid>
         <Grid item md={6}>
-          <EntityGithubInsightsReadmeCard
-            maxHeight={350}
-            autoPromptLogin={false}
-          />
+          <EntityGithubInsightsReadmeCard maxHeight={350} />
         </Grid>
       </EntitySwitch.Case>
     </EntitySwitch>

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -205,11 +205,14 @@ const overviewContent = (
     <EntitySwitch>
       <EntitySwitch.Case if={e => Boolean(isGithubInsightsAvailable(e))}>
         <Grid item md={6}>
-          <EntityGithubInsightsLanguagesCard />
-          <EntityGithubInsightsReleasesCard />
+          <EntityGithubInsightsLanguagesCard autoPromptLogin={false} />
+          <EntityGithubInsightsReleasesCard autoPromptLogin={false} />
         </Grid>
         <Grid item md={6}>
-          <EntityGithubInsightsReadmeCard maxHeight={350} />
+          <EntityGithubInsightsReadmeCard
+            maxHeight={350}
+            autoPromptLogin={false}
+          />
         </Grid>
       </EntitySwitch.Case>
     </EntitySwitch>

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/AuthPromptWrapper/AuthPromptWrapper.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/AuthPromptWrapper/AuthPromptWrapper.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OAuthApi, SessionApi } from '@backstage/core-plugin-api';
+import {
+  Button,
+  Grid,
+  makeStyles,
+  Tooltip,
+  Typography,
+} from '@material-ui/core';
+import React, { PropsWithChildren, useState } from 'react';
+import useAsync from 'react-use/lib/useAsync';
+import { Progress } from '@backstage/core-components';
+import { Alert } from '@material-ui/lab';
+
+const useStyles = makeStyles(theme => ({
+  infoCard: {
+    marginBottom: theme.spacing(3),
+    '& + .MuiAlert-root': {
+      marginTop: theme.spacing(3),
+    },
+  },
+}));
+
+export type PromptableLoginProps<TProps = {}> = TProps & {
+  autoPromptLogin?: boolean;
+};
+
+const NotAuthorized = (props: { auth: OAuthApi; scope: string[] }) => {
+  const { auth, scope } = props;
+  return (
+    <Grid container>
+      <Grid item xs={8}>
+        <Typography>
+          You are not logged in. You need to be signed in to see the content of
+          this card.
+        </Typography>
+      </Grid>
+      <Grid item xs={4} container justifyContent="flex-end">
+        <Tooltip placement="top" arrow title="Sign in to Github">
+          <Button
+            variant="outlined"
+            color="primary"
+            // Calling getAccessToken instead of a plain signIn because we are going to get the correct scopes right away. No need to second request
+            onClick={() => auth.getAccessToken(scope)}
+          >
+            Sign in
+          </Button>
+        </Tooltip>
+      </Grid>
+    </Grid>
+  );
+};
+
+export type AuthPromptWrapperProps = PropsWithChildren<{
+  auth: OAuthApi & SessionApi;
+  autoPrompt: boolean;
+  scope: string[];
+}>;
+
+export const AuthPromptWrapper = (props: AuthPromptWrapperProps) => {
+  const { auth, scope, autoPrompt, children } = props;
+  const [sessionState, setSessionState] = useState<string | undefined>();
+  const classes = useStyles();
+
+  const { value, loading, error } = useAsync(async () => {
+    auth.sessionState$().subscribe(state => {
+      setSessionState(state);
+    });
+
+    return await auth.getAccessToken(scope, {
+      instantPopup: autoPrompt,
+      optional: true,
+    });
+  }, [sessionState]);
+
+  if (loading) {
+    return <Progress />;
+  }
+
+  if (error) {
+    return (
+      <Alert severity="error" className={classes.infoCard}>
+        {error.message}
+      </Alert>
+    );
+  }
+
+  if (value === '' && !autoPrompt) {
+    return <NotAuthorized auth={auth} scope={scope} />;
+  }
+  return <>{children}</>;
+};

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/AuthPromptWrapper/GithubAuthPromptWrapper.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/AuthPromptWrapper/GithubAuthPromptWrapper.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AuthPromptWrapper, AuthPromptWrapperProps } from './AuthPromptWrapper';
+import { githubAuthApiRef, useApi } from '@backstage/core-plugin-api';
+import React from 'react';
+
+export const GithubAuthPromptWrapper = (
+  props: Omit<AuthPromptWrapperProps, 'auth'>,
+) => {
+  const auth = useApi(githubAuthApiRef);
+  return <AuthPromptWrapper {...props} auth={auth} />;
+};

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/AuthPromptWrapper/index.ts
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/AuthPromptWrapper/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { AuthPromptWrapper } from './AuthPromptWrapper';
+export type {
+  PromptableLoginProps,
+  AuthPromptWrapperProps,
+} from './AuthPromptWrapper';
+export { GithubAuthPromptWrapper } from './GithubAuthPromptWrapper';

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -21,6 +21,10 @@ import { MarkdownContent } from '../index';
 import { InfoCard } from '@backstage/core-components';
 import { makeStyles } from '@material-ui/core';
 import { useEntityGithubScmIntegration } from '../../../hooks/useEntityGithubScmIntegration';
+import {
+  GithubAuthPromptWrapper,
+  PromptableLoginProps,
+} from '../../AuthPromptWrapper';
 
 const useStyles = makeStyles(theme => ({
   infoCard: {
@@ -57,10 +61,33 @@ type ReadMeCardProps = {
   title?: string;
 };
 
-const ReadMeCard = (props: ReadMeCardProps) => {
+const ReadmeCardContent = (props: ReadMeCardProps) => {
   const { entity } = useEntity();
   const { owner, repo, readmePath } = useProjectEntity(entity);
-  const { hostname, baseUrl } = useEntityGithubScmIntegration(entity);
+  const classes = useStyles();
+  const { baseUrl } = useEntityGithubScmIntegration(entity);
+  return (
+    <div
+      className={classes.readMe}
+      style={{
+        maxHeight: `${props.maxHeight}px`,
+      }}
+    >
+      <MarkdownContent
+        baseUrl={baseUrl}
+        owner={owner}
+        repo={repo}
+        path={readmePath}
+      />
+    </div>
+  );
+};
+
+const ReadMeCard = (props: PromptableLoginProps<ReadMeCardProps>) => {
+  const { autoPromptLogin = true } = props;
+  const { entity } = useEntity();
+  const { owner, repo, readmePath } = useProjectEntity(entity);
+  const { hostname } = useEntityGithubScmIntegration(entity);
   const classes = useStyles();
 
   const linkPath = readmePath || 'README.md';
@@ -78,19 +105,9 @@ const ReadMeCard = (props: ReadMeCardProps) => {
         },
       }}
     >
-      <div
-        className={classes.readMe}
-        style={{
-          maxHeight: `${props.maxHeight}px`,
-        }}
-      >
-        <MarkdownContent
-          baseUrl={baseUrl}
-          owner={owner}
-          repo={repo}
-          path={readmePath}
-        />
-      </div>
+      <GithubAuthPromptWrapper autoPrompt={autoPromptLogin} scope={['repo']}>
+        <ReadmeCardContent {...props} />
+      </GithubAuthPromptWrapper>
     </InfoCard>
   );
 };


### PR DESCRIPTION
do not require github insights widgets to prompt login

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
