### PR TITLE
Enable dry runs for actions which support it without modification

### DIFF
--- a/.changeset/tricky-radios-remember.md
+++ b/.changeset/tricky-radios-remember.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': minor
+---
+
+Enable dry runs for actions which support it without modification

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/parseFile.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/parseFile.ts
@@ -31,6 +31,7 @@ export function createParseFileAction() {
   }>({
     id: 'roadiehq:utils:fs:parse',
     description: 'Reads a file from the workspace and optionally parses it',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/writeFile.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/writeFile.ts
@@ -22,6 +22,7 @@ export function createWriteFileAction() {
   return createTemplateAction<{ path: string; content: string }>({
     id: 'roadiehq:utils:fs:write',
     description: 'Creates a file with the content on the given path',
+    supportsDryRun: true,
     schema: {
       input: {
         required: ['path', 'content'],

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
@@ -27,7 +27,8 @@ export function createJsonJSONataTransformAction() {
   }>({
     id: 'roadiehq:utils:jsonata:json:transform',
     description:
-      'Allows performing jsonata opterations and transformations on a JSON file in the workspace. The result can be read from the `result` step output.',
+      'Allows performing jsonata operations and transformations on a JSON file in the workspace. The result can be read from the `result` step output.',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -30,6 +30,7 @@ export function createYamlJSONataTransformAction() {
     id: 'roadiehq:utils:jsonata:yaml:transform',
     description:
       'Allows performing jsonata opterations and transformations on a YAML file in the workspace. The result can be read from the `result` step output.',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -25,6 +25,7 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
   return createTemplateAction<{ path: string; content: any }>({
     id: actionId || 'roadiehq:utils:json:merge',
     description: 'Merge new data into an existing JSON file.',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',
@@ -89,6 +90,7 @@ export function createMergeAction() {
   return createTemplateAction<{ path: string; content: any }>({
     id: 'roadiehq:utils:merge',
     description: 'Merges data into an existing structured file.',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/json.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/json.ts
@@ -23,6 +23,7 @@ export function createSerializeJsonAction() {
   }>({
     id: 'roadiehq:utils:serialize:json',
     description: 'Allows performing serialization on an object',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
@@ -25,6 +25,7 @@ export function createSerializeYamlAction() {
   }>({
     id: 'roadiehq:utils:serialize:yaml',
     description: 'Allows performing serialization on an object',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/sleep.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/sleep.ts
@@ -21,6 +21,7 @@ export function createSleepAction(options?: { maxSleep?: number }) {
   return createTemplateAction<{ amount: number }>({
     id: 'roadiehq:utils:sleep',
     description: 'Halts the scaffolding for the given amount of seconds',
+    supportsDryRun: true,
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/zip.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/zip.ts
@@ -24,6 +24,7 @@ export function createZipAction() {
   return createTemplateAction<{ path: string; outputPath: string }>({
     id: 'roadiehq:utils:zip',
     description: 'Zips the content of the path',
+    supportsDryRun: true,
     schema: {
       input: {
         required: ['path'],


### PR DESCRIPTION
In many cases all that's needed to support dry runs is to set the `supportsDryRun` flag. Where the action itself operates only on the workspace no changes are needed.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
