### PR TITLE
feat: add option to disable request path logging

### DIFF
--- a/.changeset/many-paws-refuse.md
+++ b/.changeset/many-paws-refuse.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Add option to disable request path logging.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -356,15 +356,18 @@ describe('http:backstage:request', () => {
           headers: {},
           body: {},
         });
+        const expectedLog =
+          'Creating GET request with http:backstage:request scaffolder action';
         await action.handler({
           ...mockContext,
           input: {
             path: '/api/proxy/foo',
             method: 'GET',
-            logging: false,
+            logRequestPath: false,
           },
         });
-        expect(loggerSpy).toBeCalledTimes(0);
+        expect(loggerSpy).toBeCalledTimes(1);
+        expect(loggerSpy.mock.calls[0]).toContain(expectedLog);
         expect(http).toBeCalledWith(
           {
             url: 'http://backstage.tests/api/proxy/foo',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -29,6 +29,7 @@ describe('http:backstage:request', () => {
   let action: any;
   const mockBaseUrl = 'http://backstage.tests';
   const logger = getVoidLogger();
+  const loggerSpy = jest.spyOn(logger, 'info');
   const discovery = UrlPatternDiscovery.compile(`${mockBaseUrl}/{{pluginId}}`);
 
   beforeEach(() => {
@@ -313,6 +314,62 @@ describe('http:backstage:request', () => {
             headers: {
               authorization: 'Bearer some-token',
             },
+          },
+          logger,
+        );
+      });
+    });
+
+    describe('with logging enabled', () => {
+      it('should create a request with logging', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        const expectedLog =
+          'Creating GET request with http:backstage:request scaffolder action against /api/proxy/foo';
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'GET',
+          },
+        });
+        expect(loggerSpy).toBeCalledTimes(1);
+        expect(loggerSpy.mock.calls[0]).toContain(expectedLog);
+        expect(http).toBeCalledWith(
+          {
+            url: 'http://backstage.tests/api/proxy/foo',
+            method: 'GET',
+            headers: {},
+          },
+          logger,
+        );
+      });
+    });
+
+    describe('with logging turned off', () => {
+      it('should create a request without logging', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'GET',
+            logging: false,
+          },
+        });
+        expect(loggerSpy).toBeCalledTimes(0);
+        expect(http).toBeCalledWith(
+          {
+            url: 'http://backstage.tests/api/proxy/foo',
+            method: 'GET',
+            headers: {},
           },
           logger,
         );

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -33,6 +33,7 @@ export function createHttpBackstageAction(options: {
     headers?: Headers;
     params?: Params;
     body?: any;
+    logging?: boolean;
   }>({
     id: 'http:backstage:request',
     description:
@@ -78,6 +79,12 @@ export function createHttpBackstageAction(options: {
             description: 'The body you would like to pass to your request',
             type: ['object', 'string'],
           },
+          logging: {
+            title: 'Request path logging',
+            description:
+              'Option to turn request path logging off. On by default',
+            type: 'boolean',
+          },
         },
       },
       output: {
@@ -103,11 +110,15 @@ export function createHttpBackstageAction(options: {
       const { input } = ctx;
       const token = ctx.secrets?.backstageToken;
       const { method, params } = input;
+      const logging = input.logging ?? true;
       const url = await generateBackstageUrl(discovery, input.path);
 
-      ctx.logger.info(
-        `Creating ${method} request with ${this.id} scaffolder action against ${input.path}`,
-      );
+      if (logging === true) {
+        console.debug(`Inside function | Logging is: ${logging}`);
+        ctx.logger.info(
+          `Creating ${method} request with ${this.id} scaffolder action against ${input.path}`,
+        );
+      }
 
       const queryParams: string = params
         ? new URLSearchParams(params).toString()

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -33,7 +33,7 @@ export function createHttpBackstageAction(options: {
     headers?: Headers;
     params?: Params;
     body?: any;
-    logging?: boolean;
+    logRequestPath?: boolean;
   }>({
     id: 'http:backstage:request',
     description:
@@ -79,7 +79,7 @@ export function createHttpBackstageAction(options: {
             description: 'The body you would like to pass to your request',
             type: ['object', 'string'],
           },
-          logging: {
+          logRequestPath: {
             title: 'Request path logging',
             description:
               'Option to turn request path logging off. On by default',
@@ -110,12 +110,16 @@ export function createHttpBackstageAction(options: {
       const { input } = ctx;
       const token = ctx.secrets?.backstageToken;
       const { method, params } = input;
-      const logging = input.logging ?? true;
+      const logRequestPath = input.logRequestPath ?? true;
       const url = await generateBackstageUrl(discovery, input.path);
 
-      if (logging === true) {
+      if (logRequestPath) {
         ctx.logger.info(
           `Creating ${method} request with ${this.id} scaffolder action against ${input.path}`,
+        );
+      } else {
+        ctx.logger.info(
+          `Creating ${method} request with ${this.id} scaffolder action`,
         );
       }
 

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -114,7 +114,6 @@ export function createHttpBackstageAction(options: {
       const url = await generateBackstageUrl(discovery, input.path);
 
       if (logging === true) {
-        console.debug(`Inside function | Logging is: ${logging}`);
         ctx.logger.info(
           `Creating ${method} request with ${this.id} scaffolder action against ${input.path}`,
         );


### PR DESCRIPTION
This change allows to disable request path logging in http:backstage:request-action.
Logging is on by default.

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
