### PR TITLE
Remove /api from readme for scaffolder-backend-module-http-request

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
@@ -84,7 +84,7 @@ spec:
       action: http:backstage:request
       input:
         method: 'GET'
-        path: '/api/proxy/snyk/org/org/project/project-id/aggregated-issues'
+        path: '/proxy/snyk/org/org/project/project-id/aggregated-issues'
         headers:
           test: 'hello'
           foo: 'bar'
@@ -109,7 +109,7 @@ steps:
     action: http:backstage:request
     input:
       method: 'POST'
-      path: '/api/proxy/snyk/org/org/project/project-id/aggregated-issues'
+      path: '/proxy/snyk/org/org/project/project-id/aggregated-issues'
       headers:
         content-type: 'application/json'
       body:


### PR DESCRIPTION
`/api` is duplicated in the request since the baseUrl is now being set using the discovery API (calling `discovery.getBaseUrl()`) which adds `/api` to the URL anyway.