### PR TITLE
add ability to configure a custom group/user names and hierarchy

### DIFF
--- a/.changeset/rotten-wombats-complain.md
+++ b/.changeset/rotten-wombats-complain.md
@@ -2,4 +2,4 @@
 '@roadiehq/catalog-backend-module-okta': minor
 ---
 
-Add ability to configure a custom group/user names.
+Add ability to configure a custom group/user names, and provide the name of the parent group to create a hierarchy of groups.

--- a/.changeset/rotten-wombats-complain.md
+++ b/.changeset/rotten-wombats-complain.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': minor
+---
+
+Add ability to configure a custom group/user names.

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -113,6 +113,37 @@ export default async function createPlugin(
 }
 ```
 
+You can optionally provide the ability to create a hierarchy of groups by providing the `parentGroupField`.
+
+```typescript
+import { OktaOrgEntityProvider } from '@roadiehq/catalog-backend-module-okta';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+
+  const orgProvider = OktaOrgEntityProvider.fromConfig(env.config, {
+    logger: env.logger,
+    parentGroupField: 'parent_org_id',
+    userNamingStrategy: 'strip-domain-email',
+    groupNamingStrategy: 'kebab-case-name',
+  });
+
+  builder.addEntityProvider(orgProvider);
+
+  const { processingEngine, router } = await builder.build();
+
+  orgProvider.run();
+
+  await processingEngine.start();
+
+  // ...
+
+  return router;
+}
+```
+
 ## Load Users and Groups Separately
 
 ### OktaUserEntityProvider
@@ -183,6 +214,49 @@ export default async function createPlugin(
   });
   const groupProvider = OktaGroupEntityProvider.fromConfig(oktaConfig[0], {
     logger: env.logger,
+    userNamingStrategy: 'strip-domain-email',
+    groupNamingStrategy: 'kebab-case-name',
+  });
+
+  builder.addEntityProvider(userProvider);
+  builder.addEntityProvider(groupProvider);
+
+  const { processingEngine, router } = await builder.build();
+
+  userProvider.run();
+  groupProvider.run();
+
+  await processingEngine.start();
+
+  // ...
+
+  return router;
+}
+```
+
+You can optionally provide the ability to create a hierarchy of groups by providing the `parentGroupField`.
+
+```typescript
+import {
+  OktaUserEntityProvider,
+  OktaGroupEntityProvider,
+} from '@roadiehq/catalog-backend-module-okta';
+
+export default async function createPlugin(
+  env: PluginEnvironment,
+): Promise<Router> {
+  const builder = await CatalogBuilder.create(env);
+
+  const oktaConfig = env.config.getOptionalConfigArray(
+    'catalog.providers.okta',
+  );
+  const userProvider = OktaUserEntityProvider.fromConfig(oktaConfig[0], {
+    logger: env.logger,
+    namingStrategy: 'strip-domain-email',
+  });
+  const groupProvider = OktaGroupEntityProvider.fromConfig(oktaConfig[0], {
+    logger: env.logger,
+    parentGroupField: 'parent_org_id',
     userNamingStrategy: 'strip-domain-email',
     groupNamingStrategy: 'kebab-case-name',
   });

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -64,10 +64,24 @@ User naming stategies:
 - kebab-case-email | User entities will be named by their profile email converted to kebab case.
 - strip-domain-email | User entities will be named by their profile email without the domain part.
 
+You may also choose to implement a custom naming strategy by providing a function.
+
+```typescript jsx
+export const customUserNamingStrategy: UserNamingStrategy = user =>
+  user.profile.customField;
+```
+
 Group naming strategies:
 
 - id (default) | Group entities will be named by the group id.
 - kebab-case-name | Group entities will be named by their group profile name converted to kebab case.
+
+You may also choose to implement a custom naming strategy by providing a function.
+
+```typescript jsx
+export const customGroupNamingStrategy: GroupNamingStrategy = group =>
+  group.profile.customField;
+```
 
 ### Example configuration:
 
@@ -109,6 +123,13 @@ You can configure the provider with different naming strategies. The configured 
 - kebab-case-email | User entities will be named by their profile email converted to kebab case.
 - strip-domain-email | User entities will be named by their profile email without the domain part.
 
+You may also choose to implement a custom naming strategy by providing a function.
+
+```typescript jsx
+export const customUserNamingStrategy: UserNamingStrategy = user =>
+  user.profile.customField;
+```
+
 ### OktaGroupEntityProvider
 
 You can configure the provider with different naming strategies. The configured strategy will be used to generate the discovered entities `metadata.name` field. The currently supported strategies are the following:
@@ -119,10 +140,24 @@ User naming stategies:
 - kebab-case-email | User entities will be named by their profile email converted to kebab case.
 - strip-domain-email | User entities will be named by their profile email without the domain part.
 
+You may also choose to implement a custom naming strategy by providing a function.
+
+```typescript jsx
+export const customUserNamingStrategy: UserNamingStrategy = user =>
+  user.profile.customField;
+```
+
 Group naming strategies:
 
 - id (default) | Group entities will be named by the group id.
 - kebab-case-name | Group entities will be named by their group profile name converted to kebab case.
+
+You may also choose to implement a custom naming strategy by providing a function.
+
+```typescript jsx
+export const customGroupNamingStrategy: GroupNamingStrategy = group =>
+  group.profile.customField;
+```
 
 Make sure you use the OktaUserEntityProvider's naming strategy for the OktaGroupEntityProvider's user naming strategy.
 

--- a/plugins/backend/catalog-backend-module-okta/package.json
+++ b/plugins/backend/catalog-backend-module-okta/package.json
@@ -40,7 +40,7 @@
     "@backstage/errors": "^1.1.4",
     "@backstage/plugin-catalog-backend": "^1.7.2",
     "@backstage/types": "^1.0.2",
-    "@okta/okta-sdk-nodejs": "^6.5.0",
+    "@okta/okta-sdk-nodejs": "^6.6.0",
     "crypto-js": "^4.1.1",
     "lodash": "^4.17.21",
     "p-limit": "^3.0.2",

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -22,15 +22,16 @@ import {
   GroupNamingStrategies,
   GroupNamingStrategy,
   groupNamingStrategyFactory,
-} from './groupNamingStrategyFactory';
+} from './groupNamingStrategies';
 import {
   UserNamingStrategies,
   UserNamingStrategy,
   userNamingStrategyFactory,
-} from './userNamingStrategyFactory';
+} from './userNamingStrategies';
 import { AccountConfig } from '../types';
 import { groupEntityFromOktaGroup } from './groupEntityFromOktaGroup';
 import { getAccountConfig } from './accountConfig';
+import { assertError } from '@backstage/errors';
 
 /**
  * Provides entities from Okta Group service.
@@ -45,8 +46,8 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     config: Config,
     options: {
       logger: winston.Logger;
-      namingStrategy?: GroupNamingStrategies;
-      userNamingStrategy?: UserNamingStrategies;
+      namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
+      userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
     },
   ) {
     const accountConfig = getAccountConfig(config);
@@ -58,8 +59,8 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     accountConfig: AccountConfig,
     options: {
       logger: winston.Logger;
-      namingStrategy?: GroupNamingStrategies;
-      userNamingStrategy?: UserNamingStrategies;
+      namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
+      userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
     },
   ) {
     super([accountConfig], options);
@@ -90,15 +91,29 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     await client.listGroups({ search: this.groupFilter }).each(async group => {
       const members: string[] = [];
       await group.listUsers().each(user => {
-        members.push(this.userNamingStrategy(user));
+        try {
+          const userName = this.userNamingStrategy(user);
+          members.push(userName);
+        } catch (e) {
+          assertError(e);
+          this.logger.warn(`failed to add user to group: ${e.message}`);
+        }
       });
 
-      const groupEntity = groupEntityFromOktaGroup(group, this.namingStrategy, {
-        annotations: defaultAnnotations,
-        members,
-      });
-
-      groupResources.push(groupEntity);
+      try {
+        const groupEntity = groupEntityFromOktaGroup(
+          group,
+          this.namingStrategy,
+          {
+            annotations: defaultAnnotations,
+            members,
+          },
+        );
+        groupResources.push(groupEntity);
+      } catch (e) {
+        assertError(e);
+        this.logger.warn(`failed to add group: ${e.message}`);
+      }
     });
 
     await this.connection.applyMutation({

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -40,12 +40,14 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
   private readonly namingStrategy: GroupNamingStrategy;
   private readonly userNamingStrategy: UserNamingStrategy;
   private readonly groupFilter: string | undefined;
-  private orgUrl: string;
+  private readonly orgUrl: string;
+  private readonly parentGroupField: string | undefined;
 
   static fromConfig(
     config: Config,
     options: {
       logger: winston.Logger;
+      parentGroupField?: string;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
     },
@@ -59,11 +61,13 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     accountConfig: AccountConfig,
     options: {
       logger: winston.Logger;
+      parentGroupField?: string;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
     },
   ) {
     super([accountConfig], options);
+    this.parentGroupField = options.parentGroupField;
     this.namingStrategy = groupNamingStrategyFactory(options.namingStrategy);
     this.userNamingStrategy = userNamingStrategyFactory(
       options.userNamingStrategy,
@@ -107,6 +111,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
           {
             annotations: defaultAnnotations,
             members,
+            parentGroupField: this.parentGroupField,
           },
         );
         groupResources.push(groupEntity);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
@@ -19,6 +19,7 @@ import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
 import { MockOktaCollection } from '../test-utls';
 import { getVoidLogger } from '@backstage/backend-common';
+import { ProfileFieldGroupNamingStrategy } from './groupNamingStrategies';
 
 let listGroups: () => MockOktaCollection = () => {
   return new MockOktaCollection([]);
@@ -86,6 +87,7 @@ describe('OktaOrgEntityProvider', () => {
             profile: {
               name: 'Everyone@the-company',
               description: 'Everyone in the company',
+              org_id: '1234',
             },
             listUsers: () => {
               return new MockOktaCollection([
@@ -125,7 +127,7 @@ describe('OktaOrgEntityProvider', () => {
         refresh: jest.fn(),
       };
       const provider = OktaOrgEntityProvider.fromConfig(config, { logger });
-      provider.connect(entityProviderConnection);
+      await provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toBeCalledWith({
         type: 'full',
@@ -168,7 +170,7 @@ describe('OktaOrgEntityProvider', () => {
         groupNamingStrategy: 'kebab-case-name',
         userNamingStrategy: 'strip-domain-email',
       });
-      provider.connect(entityProviderConnection);
+      await provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toBeCalledWith({
         type: 'full',
@@ -181,6 +183,122 @@ describe('OktaOrgEntityProvider', () => {
               }),
               spec: expect.objectContaining({
                 members: ['fname'],
+              }),
+            }),
+          }),
+        ]),
+      });
+    });
+
+    it('allows selecting a custom field for the name', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const provider = OktaOrgEntityProvider.fromConfig(config, {
+        logger,
+        groupNamingStrategy: new ProfileFieldGroupNamingStrategy('org_id')
+          .nameForGroup,
+        userNamingStrategy: 'strip-domain-email',
+      });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: expect.arrayContaining([
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Group',
+              metadata: expect.objectContaining({
+                name: '1234',
+              }),
+              spec: expect.objectContaining({
+                members: ['fname'],
+              }),
+            }),
+          }),
+        ]),
+      });
+    });
+
+    it('passes over a group if I provide a broken group naming strategy', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const provider = OktaOrgEntityProvider.fromConfig(config, {
+        logger,
+        groupNamingStrategy: () => {
+          throw new Error('bork');
+        },
+        userNamingStrategy: 'strip-domain-email',
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: [],
+      });
+    });
+
+    it('passes over a user if I provide a broken user naming strategy', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+
+      listGroups = () => {
+        return new MockOktaCollection([
+          {
+            id: 'asdfwefwefwef',
+            profile: {
+              name: 'Everyone@the-company',
+              description: 'Everyone in the company',
+            },
+            listUsers: () => {
+              return new MockOktaCollection([
+                {
+                  id: 'user-1',
+                  profile: {
+                    email: 'fname@domain.com',
+                  },
+                },
+                {
+                  id: 'user-2',
+                  profile: {
+                    email: 'fname2@domain.com',
+                  },
+                },
+              ]);
+            },
+          },
+        ]);
+      };
+
+      const provider = OktaOrgEntityProvider.fromConfig(config, {
+        logger,
+        groupNamingStrategy: 'kebab-case-name',
+        userNamingStrategy: user => {
+          if (user.id === 'user-1') {
+            return user.id;
+          }
+          throw new Error('bork');
+        },
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: expect.arrayContaining([
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Group',
+              metadata: expect.objectContaining({
+                name: 'everyone-the-company',
+                title: 'Everyone@the-company',
+              }),
+              spec: expect.objectContaining({
+                members: ['user-1'],
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
@@ -201,7 +201,7 @@ describe('OktaOrgEntityProvider', () => {
           .nameForGroup,
         userNamingStrategy: 'strip-domain-email',
       });
-      provider.connect(entityProviderConnection);
+      await provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toBeCalledWith({
         type: 'full',

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -40,11 +40,13 @@ import { assertError } from '@backstage/errors';
 export class OktaOrgEntityProvider extends OktaEntityProvider {
   private readonly groupNamingStrategy: GroupNamingStrategy;
   private readonly userNamingStrategy: UserNamingStrategy;
+  private readonly parentGroupField: string | undefined;
 
   static fromConfig(
     config: Config,
     options: {
       logger: winston.Logger;
+      parentGroupField?: string;
       groupNamingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
     },
@@ -60,11 +62,13 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
     accountConfigs: AccountConfig[],
     options: {
       logger: winston.Logger;
+      parentGroupField?: string;
       groupNamingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
     },
   ) {
     super(accountConfigs, options);
+    this.parentGroupField = options.parentGroupField;
     this.groupNamingStrategy = groupNamingStrategyFactory(
       options.groupNamingStrategy,
     );
@@ -124,7 +128,11 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
               const groupEntity = groupEntityFromOktaGroup(
                 group,
                 this.groupNamingStrategy,
-                { annotations: defaultAnnotations, members },
+                {
+                  annotations: defaultAnnotations,
+                  members,
+                  parentGroupField: this.parentGroupField,
+                },
               );
               if (members.length > 0) {
                 resources.push(groupEntity);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
@@ -149,5 +149,50 @@ describe('OktaUserEntityProvider', () => {
         ],
       });
     });
+
+    it('I can customize the naming strategy', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const provider = OktaUserEntityProvider.fromConfig(config, {
+        logger,
+        namingStrategy: user => user.id,
+      });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'User',
+              metadata: expect.objectContaining({
+                name: 'asdfwefwefwef',
+              }),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('Where the naming strategy fails it passes over the user', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const provider = OktaUserEntityProvider.fromConfig(config, {
+        logger,
+        namingStrategy: () => {
+          throw new Error('bork');
+        },
+      });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: [],
+      });
+    });
   });
 });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
@@ -15,7 +15,7 @@
  */
 import { GroupEntity } from '@backstage/catalog-model';
 import { Group } from '@okta/okta-sdk-nodejs';
-import { GroupNamingStrategy } from './groupNamingStrategyFactory';
+import { GroupNamingStrategy } from './groupNamingStrategies';
 
 export const groupEntityFromOktaGroup = (
   group: Group,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
@@ -20,8 +20,17 @@ import { GroupNamingStrategy } from './groupNamingStrategies';
 export const groupEntityFromOktaGroup = (
   group: Group,
   namingStrategy: GroupNamingStrategy,
-  options: { annotations: Record<string, string>; members: string[] },
+  options: {
+    annotations: Record<string, string>;
+    members: string[];
+    parentGroupField?: string;
+  },
 ): GroupEntity => {
+  const parentFieldValue = options.parentGroupField
+    ? group.profile[options.parentGroupField]
+    : undefined;
+  const parent =
+    typeof parentFieldValue === 'string' ? parentFieldValue : undefined;
   return {
     kind: 'Group',
     apiVersion: 'backstage.io/v1alpha1',
@@ -35,6 +44,7 @@ export const groupEntityFromOktaGroup = (
     },
     spec: {
       members: options.members,
+      parent,
       type: 'group',
       children: [],
     },

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ProfileFieldGroupNamingStrategy } from './ProfileFieldGroupNamingStrategy';
+import { Group } from '@okta/okta-sdk-nodejs';
+
+describe('ProfileFiledGroupNamingStrategy', () => {
+  it('gets the right field from the group profile', async () => {
+    const provider = new ProfileFieldGroupNamingStrategy('org_id');
+    const testGroup: Partial<Group> = {
+      profile: {
+        name: 'group-1',
+        description: 'Group 1',
+        org_id: '1234',
+      },
+    };
+    expect(provider.nameForGroup(testGroup as Group)).toEqual('1234');
+  });
+
+  it('fails if the field is not set', async () => {
+    const provider = new ProfileFieldGroupNamingStrategy('org_id');
+    const testGroup: Partial<Group> = {
+      profile: {
+        name: 'group-1',
+        description: 'Group 1',
+      },
+    };
+    expect(() => provider.nameForGroup(testGroup as Group)).toThrow(
+      'Profile field org_id does not contain a string',
+    );
+  });
+
+  it('fails if the field is not the right type', async () => {
+    const provider = new ProfileFieldGroupNamingStrategy('org_id');
+    const testGroup: Partial<Group> = {
+      profile: {
+        name: 'group-1',
+        description: 'Group 1',
+        org_id: ['wrong', 'type'],
+      },
+    };
+    expect(() => provider.nameForGroup(testGroup as Group)).toThrow(
+      'Profile field org_id does not contain a string',
+    );
+  });
+});

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Group } from '@okta/okta-sdk-nodejs';
+import { GroupNamingStrategy } from './types';
+
+export class ProfileFieldGroupNamingStrategy {
+  private fieldName: string;
+  constructor(fieldName: string) {
+    this.fieldName = fieldName;
+  }
+
+  nameForGroup: GroupNamingStrategy = (group: Group) => {
+    const groupName = group.profile[this.fieldName];
+    if (typeof groupName !== 'string') {
+      throw new Error(
+        `Profile field ${this.fieldName} does not contain a string for ${group.profile.name}`,
+      );
+    }
+    return groupName;
+  };
+}

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/groupNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/groupNamingStrategyFactory.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import { Group } from '@okta/okta-sdk-nodejs';
-import { kebabCase } from 'lodash';
-
-export type GroupNamingStrategy = (group: Group) => string;
-export type GroupNamingStrategies = 'id' | 'kebab-case-name' | undefined;
+import { idGroupNamingStrategy, kebabCaseGroupNamingStrategy } from './index';
+import { GroupNamingStrategies, GroupNamingStrategy } from './types';
 
 export const groupNamingStrategyFactory = (
-  name: GroupNamingStrategies = 'id',
+  strategy: GroupNamingStrategies | GroupNamingStrategy = 'id',
 ): GroupNamingStrategy => {
-  switch (name) {
+  if (typeof strategy === 'function') {
+    return strategy;
+  }
+  switch (strategy) {
     case 'id':
-      return group => group.id;
+      return idGroupNamingStrategy;
     case 'kebab-case-name':
-      return group => kebabCase(group.profile.name);
+      return kebabCaseGroupNamingStrategy;
     default:
-      throw new Error(`Unknown naming strategy ${name}`);
+      throw new Error(`Unknown naming strategy ${strategy}`);
   }
 };

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/idGroupNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/idGroupNamingStrategy.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupNamingStrategy } from './types';
+
+export const idGroupNamingStrategy: GroupNamingStrategy = group => group.id;

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { kebabCaseGroupNamingStrategy } from './kebabCaseGroupNamingStrategy';
+export { idGroupNamingStrategy } from './idGroupNamingStrategy';
+export { ProfileFieldGroupNamingStrategy } from './ProfileFieldGroupNamingStrategy';
+export { groupNamingStrategyFactory } from './groupNamingStrategyFactory';
+export type { GroupNamingStrategy, GroupNamingStrategies } from './types';

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/kebabCaseGroupNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/kebabCaseGroupNamingStrategy.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { kebabCase } from 'lodash';
+import { GroupNamingStrategy } from './types';
+
+export const kebabCaseGroupNamingStrategy: GroupNamingStrategy = group =>
+  kebabCase(group.profile.name);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/types.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Group } from '@okta/okta-sdk-nodejs';
+
+export type GroupNamingStrategy = (group: Group) => string;
+export type GroupNamingStrategies = 'id' | 'kebab-case-name' | undefined;

--- a/plugins/backend/catalog-backend-module-okta/src/providers/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/index.ts
@@ -17,3 +17,5 @@
 export { OktaGroupEntityProvider } from './OktaGroupEntityProvider';
 export { OktaUserEntityProvider } from './OktaUserEntityProvider';
 export { OktaOrgEntityProvider } from './OktaOrgEntityProvider';
+export * from './groupNamingStrategies';
+export * from './userNamingStrategies';

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userEntityFromOktaUser.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userEntityFromOktaUser.ts
@@ -15,7 +15,7 @@
  */
 import { UserEntity } from '@backstage/catalog-model';
 import { User } from '@okta/okta-sdk-nodejs';
-import { UserNamingStrategy } from './userNamingStrategyFactory';
+import { UserNamingStrategy } from './userNamingStrategies';
 
 export const userEntityFromOktaUser = (
   user: User,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/idUserNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/idUserNamingStrategy.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UserNamingStrategy } from './types';
+
+export const idUserNamingStrategy: UserNamingStrategy = user => user.id;

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './types';
+export * from './idUserNamingStrategy';
+export * from './stripEmailDomainUserNamingStrategy';
+export * from './kebabCaseEmailUserNamingStrategy';
+export * from './userNamingStrategyFactory';

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/kebabCaseEmailUserNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/kebabCaseEmailUserNamingStrategy.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UserNamingStrategy } from './types';
+import { kebabCase } from 'lodash';
+
+export const kebabCaseEmailUserNamingStrategy: UserNamingStrategy = user =>
+  kebabCase(user.profile.email);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/stripEmailDomainUserNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/stripEmailDomainUserNamingStrategy.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { UserNamingStrategy } from './types';
+
+export const stripEmailDomainUserNamingStrategy: UserNamingStrategy = user =>
+  user.profile.email.substring(0, user.profile.email.indexOf('@'));

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Larder Software Limited
+ * Copyright 2023 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { User } from '@okta/okta-sdk-nodejs';
-import { kebabCase } from 'lodash';
 
 export type UserNamingStrategy = (user: User) => string;
 export type UserNamingStrategies =
@@ -23,19 +21,3 @@ export type UserNamingStrategies =
   | 'kebab-case-email'
   | 'strip-domain-email'
   | undefined;
-
-export const userNamingStrategyFactory = (
-  name: UserNamingStrategies = 'id',
-): UserNamingStrategy => {
-  switch (name) {
-    case 'id':
-      return user => user.id;
-    case 'kebab-case-email':
-      return user => kebabCase(user.profile.email);
-    case 'strip-domain-email':
-      return user =>
-        user.profile.email.substring(0, user.profile.email.indexOf('@'));
-    default:
-      throw new Error(`Unknown naming strategy ${name}`);
-  }
-};

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/userNamingStrategyFactory.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/userNamingStrategyFactory.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UserNamingStrategies, UserNamingStrategy } from './types';
+import { idUserNamingStrategy } from './idUserNamingStrategy';
+import { stripEmailDomainUserNamingStrategy } from './stripEmailDomainUserNamingStrategy';
+import { kebabCaseEmailUserNamingStrategy } from './kebabCaseEmailUserNamingStrategy';
+
+export const userNamingStrategyFactory = (
+  strategy: UserNamingStrategies | UserNamingStrategy = 'id',
+): UserNamingStrategy => {
+  if (typeof strategy === 'function') {
+    return strategy;
+  }
+  switch (strategy) {
+    case 'id':
+      return idUserNamingStrategy;
+    case 'kebab-case-email':
+      return kebabCaseEmailUserNamingStrategy;
+    case 'strip-domain-email':
+      return stripEmailDomainUserNamingStrategy;
+    default:
+      throw new Error(`Unknown naming strategy ${strategy}`);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9017,10 +9017,10 @@
     "@octokit/webhooks-types" "6.2.4"
     aggregate-error "^3.1.0"
 
-"@okta/okta-sdk-nodejs@^6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.5.0.tgz#6f9a1cf3b27ff24eb42b9dd75639492c57603f90"
-  integrity sha512-zqhWzeUi2NY9ERAktJXT/v45Q6x8EU7tew4Fau94Y9/etsrPmHloyXgHHcCSy6i+ApgzN1cCBe+e7k51upLLng==
+"@okta/okta-sdk-nodejs@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.6.0.tgz#fd7ab0122ca1bf9fa4c8b71c594fd439e5e18d01"
+  integrity sha512-2dxvZlEh4v1/L9vnRZ3tPT94+8VyxXwplfcl6nm84rQjENpHWf34XO5SnZYy9kvuabIdHYtq4wfRqaEyJnzpyA==
   dependencies:
     deep-copy "^1.4.2"
     eckles "^1.4.1"


### PR DESCRIPTION
Add ability to configure a custom group/user names, and provide the name of the parent group to create a hierarchy of groups.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
