### PR TITLE
convert number parent org id to a string

### DIFF
--- a/.changeset/quiet-pets-brake.md
+++ b/.changeset/quiet-pets-brake.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Support number as parent org id.

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.test.ts
@@ -84,4 +84,37 @@ describe('groupEntityFromOktaGroup', () => {
       spec: { children: [], members: [], parent: '1', type: 'group' },
     });
   });
+
+  it('sets a number parent id string', async () => {
+    const group: Partial<Group> = {
+      profile: {
+        name: 'group-2',
+        description: 'Group 2',
+        parent_org_id: 1,
+        org_id: '2',
+      },
+    };
+    const options = {
+      annotations: {},
+      members: [],
+      parentGroupField: 'parent_org_id',
+    };
+    expect(
+      groupEntityFromOktaGroup(
+        group as Group,
+        new ProfileFieldGroupNamingStrategy('org_id').nameForGroup,
+        options,
+      ),
+    ).toEqual({
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: {
+        annotations: {},
+        description: 'Group 2',
+        name: '2',
+        title: 'group-2',
+      },
+      spec: { children: [], members: [], parent: '1', type: 'group' },
+    });
+  });
 });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
@@ -29,8 +29,13 @@ export const groupEntityFromOktaGroup = (
   const parentFieldValue = options.parentGroupField
     ? group.profile[options.parentGroupField]
     : undefined;
-  const parent =
-    typeof parentFieldValue === 'string' ? parentFieldValue : undefined;
+  let parent: string | undefined = undefined;
+  if (typeof parentFieldValue === 'string') {
+    parent = parentFieldValue;
+  }
+  if (typeof parentFieldValue === 'number') {
+    parent = parentFieldValue.toString();
+  }
   return {
     kind: 'Group',
     apiVersion: 'backstage.io/v1alpha1',


### PR DESCRIPTION
convert number parent org id to a string

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
