### PR TITLE
Export `EntityDependabotAlertsTable` and `EntitySecurityInsightsTable` from security insights plugin

### DIFF
--- a/.changeset/serious-points-cry.md
+++ b/.changeset/serious-points-cry.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': minor
+---
+
+Export `EntityDependabotAlertsTable` and `EntitySecurityInsightsTable` components allowing users to build custom integrations.

--- a/.changeset/serious-points-cry.md
+++ b/.changeset/serious-points-cry.md
@@ -2,4 +2,4 @@
 '@roadiehq/backstage-plugin-security-insights': minor
 ---
 
-Export `EntityDependabotAlertsTable` and `EntitySecurityInsightsTable` components allowing users to build custom integrations.
+Export `DependabotAlertsTable` and `SecurityInsightsTable` components allowing users to build custom integrations.

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/Router.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/Router.tsx
@@ -31,7 +31,7 @@ export const Router = () => {
     <MissingAnnotationEmptyState annotation={GITHUB_REPO_ANNOTATION} />
   ) : (
     <Routes>
-      <Route element={<SecurityInsightsTab entity={entity} />} />
+      <Route element={<SecurityInsightsTab />} />
     </Routes>
   );
 };

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTab/SecurityInsightsTab.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTab/SecurityInsightsTab.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC } from 'react';
+import React from 'react';
 import { Grid } from '@material-ui/core';
 import {
   Page,
@@ -23,9 +23,8 @@ import {
   SupportButton,
 } from '@backstage/core-components';
 import { SecurityInsightsTable } from '../SecurityInsightsTable';
-import { Entity } from '@backstage/catalog-model';
 
-const SecurityInsightsTab: FC<{ entity: Entity }> = ({ entity }) => (
+const SecurityInsightsTab = () => (
   <Page themeId="tool">
     <Content>
       <ContentHeader title="Security Insights">
@@ -33,7 +32,7 @@ const SecurityInsightsTab: FC<{ entity: Entity }> = ({ entity }) => (
       </ContentHeader>
       <Grid container spacing={3} direction="column">
         <Grid item>
-          <SecurityInsightsTable entity={entity} />
+          <SecurityInsightsTable />
         </Grid>
       </Grid>
     </Content>

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { FC, useState } from 'react';
+import React, { useState } from 'react';
 import { Typography, Box, Grid } from '@material-ui/core';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import { useApi, githubAuthApiRef } from '@backstage/core-plugin-api';
@@ -29,25 +29,21 @@ import { UpdateSeverityStatusModal } from '../UpdateSeverityStatusModal';
 import { StateFilterComponent } from './components/StateFilterComponent';
 import { useUrl } from '../useUrl';
 import { getSeverityBadge } from '../utils';
-import {
-  SecurityInsightsTabProps,
-  SecurityInsight,
-  SecurityInsightFilterState,
-} from '../../types';
+import { SecurityInsight, SecurityInsightFilterState } from '../../types';
+import { useEntity } from '@backstage/plugin-catalog-react';
 
 const getElapsedTime = (start: string) => {
   return moment(start).fromNow();
 };
 
-export const SecurityInsightsTable: FC<SecurityInsightsTabProps> = ({
-  entity,
-}) => {
+export const SecurityInsightsTable = () => {
   const [insightsStatusFilter, setInsightsStatusFilter] =
     useState<SecurityInsightFilterState>(null);
   const [filteredTableData, setFilteredTableData] = useState<SecurityInsight[]>(
     [],
   );
   const [tableData, setTableData] = useState<SecurityInsight[]>([]);
+  const { entity } = useEntity();
   const { owner, repo } = useProjectEntity(entity);
   const projectName = useProjectName(entity);
   const auth = useApi(githubAuthApiRef);

--- a/plugins/frontend/backstage-plugin-security-insights/src/index.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/index.ts
@@ -22,11 +22,11 @@ export {
   securityInsightsPlugin,
   EntitySecurityInsightsContent,
   EntityGithubDependabotContent,
-  EntitySecurityInsightsCard,
-  EntityDependabotAlertsCard,
 } from './plugin';
 export { SecurityInsightsWidget } from './components/SecurityInsightsWidget';
+export { SecurityInsightsTable } from './components/SecurityInsightsTable';
 export { DependabotAlertsWidget } from './components/DependabotAlertsWidget';
+export { DependabotAlertsTable } from './components/DependabotAlertsTable';
 export {
   /**
    * @deprecated From 0.2.0 composability API should be used

--- a/plugins/frontend/backstage-plugin-security-insights/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/plugin.ts
@@ -75,27 +75,3 @@ export const EntityDependabotAlertsCard = securityInsightsPlugin.provide(
     },
   }),
 );
-
-export const EntityDependabotAlertsTable = securityInsightsPlugin.provide(
-  createComponentExtension({
-    name: 'EntityDependabotAlertsTable',
-    component: {
-      lazy: () =>
-        import('./components/DependabotAlertsTable').then(
-          m => m.DependabotAlertsTable,
-        ),
-    },
-  }),
-);
-
-export const EntitySecurityInsightsTable = securityInsightsPlugin.provide(
-  createComponentExtension({
-    name: 'EntitySecurityInsightsTable',
-    component: {
-      lazy: () =>
-        import('./components/SecurityInsightsTable').then(
-          m => m.SecurityInsightsTable,
-        ),
-    },
-  }),
-);

--- a/plugins/frontend/backstage-plugin-security-insights/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/plugin.ts
@@ -75,3 +75,27 @@ export const EntityDependabotAlertsCard = securityInsightsPlugin.provide(
     },
   }),
 );
+
+export const EntityDependabotAlertsTable = securityInsightsPlugin.provide(
+  createComponentExtension({
+    name: 'EntityDependabotAlertsTable',
+    component: {
+      lazy: () =>
+        import('./components/DependabotAlertsTable').then(
+          m => m.DependabotAlertsTable,
+        ),
+    },
+  }),
+);
+
+export const EntitySecurityInsightsTable = securityInsightsPlugin.provide(
+  createComponentExtension({
+    name: 'EntitySecurityInsightsTable',
+    component: {
+      lazy: () =>
+        import('./components/SecurityInsightsTable').then(
+          m => m.SecurityInsightsTable,
+        ),
+    },
+  }),
+);

--- a/plugins/frontend/backstage-plugin-security-insights/src/types.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/types.ts
@@ -19,10 +19,6 @@ export type SecurityInsight = {
   created_at: string;
 };
 
-export type SecurityInsightsTabProps = {
-  entity: Entity;
-};
-
 export type StateFilterComponentProps = {
   insightsStatusFilter: SecurityInsightFilterState;
   value: SecurityInsight[];


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

This PR takes the existing `DependabotAlertsTable` and `SecurityInsightsTable` components from the security insights plugin and exports them. This will allow users to build their own views by using the tables directly.

I have a use case for this. I want to have a "Security" tab that holds both information about the dependabot alerts and the security insights. This will allow me to do that.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
