### PR TITLE
allow okta plugin to provide empty groups

### DIFF
--- a/.changeset/healthy-baboons-change.md
+++ b/.changeset/healthy-baboons-change.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Allow the okta provider to include groups that have no members.

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
@@ -117,6 +117,16 @@ describe('OktaOrgEntityProvider', () => {
               ]);
             },
           },
+          {
+            id: 'group-with-no-members',
+            profile: {
+              name: 'no-members@the-company',
+              description: null,
+            },
+            listUsers: () => {
+              return new MockOktaCollection([]);
+            },
+          },
         ]);
       };
     });
@@ -153,6 +163,32 @@ describe('OktaOrgEntityProvider', () => {
               }),
               spec: expect.objectContaining({
                 members: ['asdfwefwefwef'],
+              }),
+            }),
+          }),
+        ]),
+      });
+    });
+
+    it('optionally creates okta groups with no members', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const provider = OktaOrgEntityProvider.fromConfig(config, {
+        logger,
+        includeEmptyGroups: true,
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: expect.arrayContaining([
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Group',
+              metadata: expect.objectContaining({
+                name: 'group-with-no-members',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -41,6 +41,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
   private readonly groupNamingStrategy: GroupNamingStrategy;
   private readonly userNamingStrategy: UserNamingStrategy;
   private readonly parentGroupField: string | undefined;
+  private readonly includeEmptyGroups: boolean;
 
   static fromConfig(
     config: Config,
@@ -49,6 +50,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       parentGroupField?: string;
       groupNamingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
+      includeEmptyGroups?: boolean;
     },
   ) {
     const oktaConfigs = config
@@ -65,6 +67,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       parentGroupField?: string;
       groupNamingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
+      includeEmptyGroups?: boolean;
     },
   ) {
     super(accountConfigs, options);
@@ -75,6 +78,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
     this.userNamingStrategy = userNamingStrategyFactory(
       options.userNamingStrategy,
     );
+    this.includeEmptyGroups = !!options.includeEmptyGroups;
   }
 
   getProviderName(): string {
@@ -134,7 +138,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
                   parentGroupField: this.parentGroupField,
                 },
               );
-              if (members.length > 0) {
+              if (this.includeEmptyGroups || members.length > 0) {
                 resources.push(groupEntity);
               }
             } catch (e: unknown) {


### PR DESCRIPTION
allow okta plugin to provide empty groups

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
