### PR TITLE
rewrite the group hierarchy logic.

### DIFF
--- a/.changeset/late-falcons-hope.md
+++ b/.changeset/late-falcons-hope.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': minor
+---
+
+Rewrite the configuration and logic for creating a hierarchy of groups. Now it does not insist on the group name matching the parent key.

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -128,8 +128,8 @@ export default async function createPlugin(
     userNamingStrategy: 'strip-domain-email',
     groupNamingStrategy: 'kebab-case-name',
     hierarchyConfig: {
-      key: 'profile.org_id',
-      parentKey: 'profile.parent_org_id',
+      key: 'profile.orgId',
+      parentKey: 'profile.parentOrgId',
     },
   });
 
@@ -237,7 +237,7 @@ export default async function createPlugin(
 }
 ```
 
-You can optionally provide the ability to create a hierarchy of groups by providing the `parentGroupField`.
+You can optionally provide the ability to create a hierarchy of groups by providing the `hierarchyConfig`.
 
 ```typescript
 import {
@@ -259,9 +259,12 @@ export default async function createPlugin(
   });
   const groupProvider = OktaGroupEntityProvider.fromConfig(oktaConfig[0], {
     logger: env.logger,
-    parentGroupField: 'parent_org_id',
     userNamingStrategy: 'strip-domain-email',
     groupNamingStrategy: 'kebab-case-name',
+    hierarchyConfig: {
+      key: 'profile.orgId',
+      parentKey: 'profile.parentOrgId',
+    },
   });
 
   builder.addEntityProvider(userProvider);

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -113,7 +113,7 @@ export default async function createPlugin(
 }
 ```
 
-You can optionally provide the ability to create a hierarchy of groups by providing the `parentGroupField`.
+You can optionally provide the ability to create a hierarchy of groups by providing `hierarchyConfig`.
 
 ```typescript
 import { OktaOrgEntityProvider } from '@roadiehq/catalog-backend-module-okta';
@@ -125,9 +125,12 @@ export default async function createPlugin(
 
   const orgProvider = OktaOrgEntityProvider.fromConfig(env.config, {
     logger: env.logger,
-    parentGroupField: 'parent_org_id',
     userNamingStrategy: 'strip-domain-email',
     groupNamingStrategy: 'kebab-case-name',
+    hierarchyConfig: {
+      key: 'profile.org_id',
+      parentKey: 'profile.parent_org_id',
+    },
   });
 
   builder.addEntityProvider(orgProvider);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
@@ -216,9 +216,12 @@ describe('OktaGroupProvider', () => {
       };
       const provider = OktaGroupEntityProvider.fromConfig(config, {
         logger,
-        parentGroupField: 'parent_org_id',
         namingStrategy: new ProfileFieldGroupNamingStrategy('org_id')
           .nameForGroup,
+        hierarchyConfig: {
+          parentKey: 'profile.parent_org_id',
+          key: 'profile.org_id',
+        },
         userNamingStrategy: 'strip-domain-email',
       });
       await provider.connect(entityProviderConnection);
@@ -247,6 +250,52 @@ describe('OktaGroupProvider', () => {
               spec: expect.objectContaining({
                 members: ['fname'],
                 parent: '1234',
+              }),
+            }),
+          }),
+        ]),
+      });
+    });
+
+    it('allows creating a hierarchy for groups without a naming strategy', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const provider = OktaGroupEntityProvider.fromConfig(config, {
+        logger,
+        hierarchyConfig: {
+          parentKey: 'profile.parent_org_id',
+          key: 'profile.org_id',
+        },
+        userNamingStrategy: 'strip-domain-email',
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toBeCalledWith({
+        type: 'full',
+        entities: expect.arrayContaining([
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Group',
+              metadata: expect.objectContaining({
+                name: 'asdfwefwefwef',
+              }),
+              spec: expect.objectContaining({
+                members: ['fname'],
+                parent: 'asdfwefwefwef',
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Group',
+              metadata: expect.objectContaining({
+                name: 'group-with-null-description',
+              }),
+              spec: expect.objectContaining({
+                members: ['fname'],
+                parent: 'asdfwefwefwef',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -32,6 +32,8 @@ import { AccountConfig } from '../types';
 import { groupEntityFromOktaGroup } from './groupEntityFromOktaGroup';
 import { getAccountConfig } from './accountConfig';
 import { assertError } from '@backstage/errors';
+import { Group } from '@okta/okta-sdk-nodejs';
+import get from 'lodash/get';
 
 /**
  * Provides entities from Okta Group service.
@@ -41,15 +43,18 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
   private readonly userNamingStrategy: UserNamingStrategy;
   private readonly groupFilter: string | undefined;
   private readonly orgUrl: string;
-  private readonly parentGroupField: string | undefined;
+  private hierarchyConfig: { parentKey: string; key?: string } | undefined;
 
   static fromConfig(
     config: Config,
     options: {
       logger: winston.Logger;
-      parentGroupField?: string;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
+      hierarchyConfig?: {
+        parentKey: string;
+        key?: string;
+      };
     },
   ) {
     const accountConfig = getAccountConfig(config);
@@ -61,19 +66,22 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     accountConfig: AccountConfig,
     options: {
       logger: winston.Logger;
-      parentGroupField?: string;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
+      hierarchyConfig?: {
+        parentKey: string;
+        key?: string;
+      };
     },
   ) {
     super([accountConfig], options);
-    this.parentGroupField = options.parentGroupField;
     this.namingStrategy = groupNamingStrategyFactory(options.namingStrategy);
     this.userNamingStrategy = userNamingStrategyFactory(
       options.userNamingStrategy,
     );
     this.orgUrl = accountConfig.orgUrl;
     this.groupFilter = accountConfig.groupFilter;
+    this.hierarchyConfig = options.hierarchyConfig;
   }
 
   getProviderName(): string {
@@ -91,35 +99,68 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     const client = this.getClient(this.orgUrl, ['okta.groups.read']);
 
     const defaultAnnotations = await this.buildDefaultAnnotations();
+    const oktaGroups: Record<string, Group> = {};
 
-    await client.listGroups({ search: this.groupFilter }).each(async group => {
-      const members: string[] = [];
-      await group.listUsers().each(user => {
-        try {
-          const userName = this.userNamingStrategy(user);
-          members.push(userName);
-        } catch (e) {
-          assertError(e);
-          this.logger.warn(`failed to add user to group: ${e.message}`);
+    await client.listGroups({ search: this.groupFilter }).each(group => {
+      if (this.hierarchyConfig?.key) {
+        const id = get(group, this.hierarchyConfig?.key);
+        if (typeof id === 'string') {
+          oktaGroups[id] = group;
         }
-      });
-
+        if (typeof id === 'number') {
+          oktaGroups[id.toString()] = group;
+        }
+      }
       try {
-        const groupEntity = groupEntityFromOktaGroup(
-          group,
-          this.namingStrategy,
-          {
-            annotations: defaultAnnotations,
-            members,
-            parentGroupField: this.parentGroupField,
-          },
-        );
-        groupResources.push(groupEntity);
-      } catch (e) {
+        oktaGroups[this.namingStrategy(group)] = group;
+      } catch (e: unknown) {
         assertError(e);
-        this.logger.warn(`failed to add group: ${e.message}`);
+        this.logger.warn(`Failed to add group ${group.id}: ${e.message}`);
       }
     });
+
+    await Promise.allSettled(
+      Object.entries(oktaGroups).map(async ([_, group]) => {
+        const members: string[] = [];
+        await group.listUsers().each(user => {
+          try {
+            const userName = this.userNamingStrategy(user);
+            members.push(userName);
+          } catch (e) {
+            assertError(e);
+            this.logger.warn(`failed to add user to group: ${e.message}`);
+          }
+        });
+
+        let parentGroup: Group | undefined = undefined;
+
+        if (this.hierarchyConfig?.parentKey) {
+          const parentId = get(group, this.hierarchyConfig?.parentKey);
+          if (typeof parentId === 'string') {
+            parentGroup = oktaGroups[parentId];
+          }
+          if (typeof parentId === 'number') {
+            parentGroup = oktaGroups[parentId.toString()];
+          }
+        }
+
+        try {
+          const groupEntity = groupEntityFromOktaGroup(
+            group,
+            this.namingStrategy,
+            parentGroup,
+            {
+              annotations: defaultAnnotations,
+              members,
+            },
+          );
+          groupResources.push(groupEntity);
+        } catch (e) {
+          assertError(e);
+          this.logger.warn(`failed to add group: ${e.message}`);
+        }
+      }),
+    );
 
     await this.connection.applyMutation({
       type: 'full',

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -51,6 +51,10 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
       logger: winston.Logger;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
+      /*
+       * @deprecated, please use hierarchyConfig.parentKey
+       */
+      parentGroupField?: string;
       hierarchyConfig?: {
         parentKey: string;
         key?: string;
@@ -58,6 +62,12 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
     },
   ) {
     const accountConfig = getAccountConfig(config);
+
+    if (options.parentGroupField && !options.hierarchyConfig?.parentKey) {
+      options.hierarchyConfig = {
+        parentKey: options.parentGroupField,
+      };
+    }
 
     return new OktaGroupEntityProvider(accountConfig, options);
   }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -54,6 +54,10 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       groupNamingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
       includeEmptyGroups?: boolean;
+      /*
+       * @deprecated, please use hierarchyConfig.parentKey
+       */
+      parentGroupField?: string;
       hierarchyConfig?: {
         parentKey: string;
         key?: string;
@@ -64,6 +68,11 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       .getOptionalConfigArray('catalog.providers.okta')
       ?.map(getAccountConfig);
 
+    if (options.parentGroupField && !options.hierarchyConfig?.parentKey) {
+      options.hierarchyConfig = {
+        parentKey: `profile.${options.parentGroupField}`,
+      };
+    }
     return new OktaOrgEntityProvider(oktaConfigs || [], options);
   }
 

--- a/plugins/backend/catalog-backend-module-okta/src/providers/getOktaGroups.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/getOktaGroups.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import get from 'lodash/get';
+import { assertError } from '@backstage/errors';
+import { Group, Client } from '@okta/okta-sdk-nodejs';
+import { Logger } from 'winston';
+import { GroupNamingStrategy } from './groupNamingStrategies';
+
+type GetOktaGroupsOptions = {
+  client: Client;
+  groupFilter: string | undefined;
+  key: string | undefined;
+  groupNamingStrategy: GroupNamingStrategy;
+  logger: Logger;
+};
+
+export const getOktaGroups = async (opts: GetOktaGroupsOptions) => {
+  const { client, groupFilter, key, groupNamingStrategy, logger } = opts;
+
+  const oktaGroups: Record<string, Group> = {};
+
+  await client.listGroups({ search: groupFilter }).each(group => {
+    if (key) {
+      const id = get(group, key);
+      if (typeof id === 'string') {
+        oktaGroups[id] = group;
+      }
+      if (typeof id === 'number') {
+        oktaGroups[id.toString()] = group;
+      }
+    } else {
+      try {
+        oktaGroups[groupNamingStrategy(group)] = group;
+      } catch (e: unknown) {
+        assertError(e);
+        logger.warn(`Failed to add group ${group.id}: ${e.message}`);
+      }
+    }
+  });
+  return oktaGroups;
+};

--- a/plugins/backend/catalog-backend-module-okta/src/providers/getParentGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/getParentGroup.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Group } from '@okta/okta-sdk-nodejs';
+import get from 'lodash/get';
+
+type GetParentGroupsOptions = {
+  parentKey?: string;
+  group: Group;
+  oktaGroups: Record<string, Group>;
+};
+
+export const getParentGroup = (opts: GetParentGroupsOptions) => {
+  const { parentKey, group, oktaGroups } = opts;
+  let parentGroup: Group | undefined = undefined;
+
+  if (parentKey) {
+    const parentId = get(group, parentKey);
+    if (typeof parentId === 'string') {
+      parentGroup = oktaGroups[parentId];
+    }
+    if (typeof parentId === 'number') {
+      parentGroup = oktaGroups[parentId.toString()];
+    }
+  }
+
+  return parentGroup;
+};

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.test.ts
@@ -19,7 +19,7 @@ import { Group } from '@okta/okta-sdk-nodejs';
 import { ProfileFieldGroupNamingStrategy } from './groupNamingStrategies';
 
 describe('groupEntityFromOktaGroup', () => {
-  it('ignores an empty parent id string', async () => {
+  it('ignores an empty parent', async () => {
     const group: Partial<Group> = {
       profile: {
         name: 'group-1',
@@ -28,15 +28,16 @@ describe('groupEntityFromOktaGroup', () => {
         org_id: '1',
       },
     };
+    const parentGroup = undefined;
     const options = {
       annotations: {},
       members: [],
-      parentGroupField: 'parent_org_id',
     };
     expect(
       groupEntityFromOktaGroup(
         group as Group,
         new ProfileFieldGroupNamingStrategy('org_id').nameForGroup,
+        parentGroup,
         options,
       ),
     ).toEqual({
@@ -61,48 +62,22 @@ describe('groupEntityFromOktaGroup', () => {
         org_id: '2',
       },
     };
-    const options = {
-      annotations: {},
-      members: [],
-      parentGroupField: 'parent_org_id',
-    };
-    expect(
-      groupEntityFromOktaGroup(
-        group as Group,
-        new ProfileFieldGroupNamingStrategy('org_id').nameForGroup,
-        options,
-      ),
-    ).toEqual({
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'Group',
-      metadata: {
-        annotations: {},
-        description: 'Group 2',
-        name: '2',
-        title: 'group-2',
-      },
-      spec: { children: [], members: [], parent: '1', type: 'group' },
-    });
-  });
-
-  it('sets a number parent id string', async () => {
-    const group: Partial<Group> = {
+    const parentGroup: Partial<Group> = {
       profile: {
-        name: 'group-2',
-        description: 'Group 2',
-        parent_org_id: 1,
-        org_id: '2',
+        name: 'group-1',
+        description: 'Group 1',
+        org_id: '1',
       },
     };
     const options = {
       annotations: {},
       members: [],
-      parentGroupField: 'parent_org_id',
     };
     expect(
       groupEntityFromOktaGroup(
         group as Group,
         new ProfileFieldGroupNamingStrategy('org_id').nameForGroup,
+        parentGroup as Group,
         options,
       ),
     ).toEqual({

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
@@ -20,22 +20,17 @@ import { GroupNamingStrategy } from './groupNamingStrategies';
 export const groupEntityFromOktaGroup = (
   group: Group,
   namingStrategy: GroupNamingStrategy,
+  parentGroup: Group | undefined,
   options: {
     annotations: Record<string, string>;
     members: string[];
-    parentGroupField?: string;
   },
 ): GroupEntity => {
-  const parentFieldValue = options.parentGroupField
-    ? group.profile[options.parentGroupField]
-    : undefined;
-  let parent: string | undefined = undefined;
-  if (typeof parentFieldValue === 'string') {
-    parent = parentFieldValue;
+  let parentGroupName = undefined;
+  if (parentGroup) {
+    parentGroupName = namingStrategy(parentGroup);
   }
-  if (typeof parentFieldValue === 'number') {
-    parent = parentFieldValue.toString();
-  }
+
   const groupEntity: GroupEntity = {
     kind: 'Group',
     apiVersion: 'backstage.io/v1alpha1',
@@ -53,8 +48,8 @@ export const groupEntityFromOktaGroup = (
       children: [],
     },
   };
-  if (parent !== '') {
-    groupEntity.spec.parent = parent;
+  if (parentGroupName) {
+    groupEntity.spec.parent = parentGroupName;
   }
   return groupEntity;
 };

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
@@ -26,11 +26,6 @@ export const groupEntityFromOktaGroup = (
     members: string[];
   },
 ): GroupEntity => {
-  let parentGroupName = undefined;
-  if (parentGroup) {
-    parentGroupName = namingStrategy(parentGroup);
-  }
-
   const groupEntity: GroupEntity = {
     kind: 'Group',
     apiVersion: 'backstage.io/v1alpha1',
@@ -48,8 +43,9 @@ export const groupEntityFromOktaGroup = (
       children: [],
     },
   };
-  if (parentGroupName) {
-    groupEntity.spec.parent = parentGroupName;
+
+  if (parentGroup) {
+    groupEntity.spec.parent = namingStrategy(parentGroup);
   }
   return groupEntity;
 };


### PR DESCRIPTION
rewrite the group hierarchy logic.

Previously the hierarchy logic was forcing the the name of the entity to match the key used for the purposes of the hierarchy.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
