### PR TITLE
add lineWidth option to yaml.dump for JSONata and serialization actions

### DIFF
--- a/.changeset/late-ducks-heal.md
+++ b/.changeset/late-ducks-heal.md
@@ -2,4 +2,4 @@
 '@roadiehq/scaffolder-backend-module-utils': patch
 ---
 
-Added lineLength option to serialize:yaml and jsonata actions to allow for control of line wrapping
+Added most yaml.dump options to serialize, merge, and jsonata actions

--- a/.changeset/late-ducks-heal.md
+++ b/.changeset/late-ducks-heal.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+Added lineLength option to serialize:yaml and jsonata actions to allow for control of line wrapping

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
@@ -55,4 +55,30 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
       yaml.dump({ hello: ['world', 'item2'] }),
     );
   });
+
+  it('should use lineWidth to control wrapping lines', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': '',
+      },
+    });
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        expression:
+          '{ "helloFrom": "anIncrediblyLongEmailAddress@anIncrediblyLongSubdomain.anIncrediblyLongDomain.com" }',
+        options: {
+          lineWidth: -1,
+        },
+      },
+    });
+
+    // No block style ( >- )
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'result',
+      'helloFrom: anIncrediblyLongEmailAddress@anIncrediblyLongSubdomain.anIncrediblyLongDomain.com\n',
+    );
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
@@ -56,29 +56,39 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
     );
   });
 
-  it('should use lineWidth to control wrapping lines', async () => {
+  it('should pass options to yaml.dump', async () => {
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': '',
       },
     });
+
+    const mockDump = jest.spyOn(yaml, 'dump');
+
+    const opts = {
+      indent: 3,
+      noArrayIndent: true,
+      skipInvalid: true,
+      flowLevel: 23,
+      sortKeys: true,
+      lineWidth: -1,
+      noRefs: true,
+      noCompatMode: true,
+      condenseFlow: true,
+      quotingType: '"' as const,
+      forceQuotes: true,
+    };
+
     await action.handler({
       ...mockContext,
       workspacePath: 'fake-tmp-dir',
       input: {
         path: 'fake-file.yaml',
-        expression:
-          '{ "helloFrom": "anIncrediblyLongEmailAddress@anIncrediblyLongSubdomain.anIncrediblyLongDomain.com" }',
-        options: {
-          lineWidth: -1,
-        },
+        expression: '{ "hello": "beautiful world" }',
+        options: opts,
       },
     });
 
-    // No block style ( >- )
-    expect(mockContext.output).toHaveBeenCalledWith(
-      'result',
-      'helloFrom: anIncrediblyLongEmailAddress@anIncrediblyLongSubdomain.anIncrediblyLongDomain.com\n',
-    );
+    expect(mockDump).toHaveBeenCalledWith({ hello: 'beautiful world' }, opts);
   });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -18,15 +18,13 @@ import jsonata from 'jsonata';
 import { resolveSafeChildPath } from '@backstage/backend-common';
 import fs from 'fs-extra';
 import yaml from 'js-yaml';
+import { supportedDumpOptions, yamlOptionsSchema } from '../../types';
 
 export function createYamlJSONataTransformAction() {
   return createTemplateAction<{
     path: string;
     expression: string;
-    options?: {
-      indent?: number;
-      lineWidth?: number;
-    };
+    options?: supportedDumpOptions;
   }>({
     id: 'roadiehq:utils:jsonata:yaml:transform',
     description:
@@ -47,19 +45,7 @@ export function createYamlJSONataTransformAction() {
             description: 'JSONata expression to perform on the input',
             type: 'string',
           },
-          options: {
-            title: 'Options',
-            description: 'YAML stringify options',
-            type: 'object',
-            properties: {
-              indent: {
-                type: 'number',
-              },
-              lineWidth: {
-                type: 'number',
-              },
-            },
-          },
+          options: yamlOptionsSchema,
         },
       },
       output: {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -24,7 +24,8 @@ export function createYamlJSONataTransformAction() {
     path: string;
     expression: string;
     options?: {
-      indent: number;
+      indent?: number;
+      lineWidth?: number;
     };
   }>({
     id: 'roadiehq:utils:jsonata:yaml:transform',
@@ -52,6 +53,9 @@ export function createYamlJSONataTransformAction() {
             type: 'object',
             properties: {
               indent: {
+                type: 'number',
+              },
+              lineWidth: {
                 type: 'number',
               },
             },

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -301,6 +301,42 @@ scripts:
     });
   });
 
+  it('can pass options to yaml.dump', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': '',
+      },
+    });
+
+    const mockDump = jest.spyOn(yaml, 'dump');
+
+    const opts = {
+      indent: 3,
+      noArrayIndent: true,
+      skipInvalid: true,
+      flowLevel: 23,
+      sortKeys: true,
+      lineWidth: -1,
+      noRefs: true,
+      noCompatMode: true,
+      condenseFlow: true,
+      quotingType: '"' as const,
+      forceQuotes: true,
+    };
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        content: '',
+        options: opts,
+      },
+    });
+
+    expect(mockDump).toHaveBeenCalledWith({}, opts);
+  });
+
   it('should put path on the output property', async () => {
     mock({
       'fake-tmp-dir': {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -20,6 +20,7 @@ import fs from 'fs-extra';
 import { extname } from 'path';
 import { merge } from 'lodash';
 import yaml from 'js-yaml';
+import { supportedDumpOptions, yamlOptionsSchema } from '../../types';
 
 export function createMergeJSONAction({ actionId }: { actionId?: string }) {
   return createTemplateAction<{ path: string; content: any }>({
@@ -87,7 +88,11 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
 }
 
 export function createMergeAction() {
-  return createTemplateAction<{ path: string; content: any }>({
+  return createTemplateAction<{
+    path: string;
+    content: any;
+    options?: supportedDumpOptions;
+  }>({
     id: 'roadiehq:utils:merge',
     description: 'Merges data into an existing structured file.',
     supportsDryRun: true,
@@ -106,6 +111,10 @@ export function createMergeAction() {
               'This will be merged into to the file. Can be either an object or a string.',
             title: 'Content',
             type: ['string', 'object'],
+          },
+          options: {
+            ...yamlOptionsSchema,
+            description: `${yamlOptionsSchema.description}  (for YAML output only)`,
           },
         },
       },
@@ -153,6 +162,7 @@ export function createMergeAction() {
               : ctx.input.content; // This supports the case where dynamic keys are required
           mergedContent = yaml.dump(
             merge(yaml.load(originalContent), newContent),
+            ctx.input.options,
           );
           break;
         }

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.test.ts
@@ -61,21 +61,32 @@ describe('roadiehq:utils:serialize:yaml', () => {
     );
   });
 
-  it('should write file to the worskspacePath with line width', async () => {
+  it('should pass options to yaml.dump', async () => {
+    const mockDump = jest.spyOn(yaml, 'dump');
+
+    const opts = {
+      indent: 3,
+      noArrayIndent: true,
+      skipInvalid: true,
+      flowLevel: 23,
+      sortKeys: true,
+      lineWidth: -1,
+      noRefs: true,
+      noCompatMode: true,
+      condenseFlow: true,
+      quotingType: '"' as const,
+      forceQuotes: true,
+    };
+
     await action.handler({
       ...mockContext,
       workspacePath: 'fake-tmp-dir',
       input: {
         data: { hello3: 'world3' },
-        options: {
-          lineWidth: -1,
-        },
+        options: opts,
       },
     });
 
-    expect(mockContext.output).toHaveBeenCalledWith(
-      'serialized',
-      yaml.dump({ hello3: 'world3' }, { lineWidth: -1 }),
-    );
+    expect(mockDump).toHaveBeenCalledWith({ hello3: 'world3' }, opts);
   });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.test.ts
@@ -60,4 +60,22 @@ describe('roadiehq:utils:serialize:yaml', () => {
       yaml.dump({ hello1: 'world1', hello2: { asdf: 'blah' } }, { indent: 10 }),
     );
   });
+
+  it('should write file to the worskspacePath with line width', async () => {
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        data: { hello3: 'world3' },
+        options: {
+          lineWidth: -1,
+        },
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'serialized',
+      yaml.dump({ hello3: 'world3' }, { lineWidth: -1 }),
+    );
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
@@ -15,14 +15,12 @@
  */
 import { createTemplateAction } from '@backstage/plugin-scaffolder-backend';
 import yaml from 'js-yaml';
+import { supportedDumpOptions, yamlOptionsSchema } from '../../types';
 
 export function createSerializeYamlAction() {
   return createTemplateAction<{
     data: any;
-    options?: {
-      indent?: number;
-      lineWidth?: number;
-    };
+    options?: supportedDumpOptions;
   }>({
     id: 'roadiehq:utils:serialize:yaml',
     description: 'Allows performing serialization on an object',
@@ -45,19 +43,7 @@ export function createSerializeYamlAction() {
               type: 'string',
             },
           },
-          options: {
-            title: 'Options',
-            description: 'YAML stringify options',
-            type: 'object',
-            properties: {
-              indent: {
-                type: 'number',
-              },
-              lineWidth: {
-                type: 'number',
-              },
-            },
-          },
+          options: yamlOptionsSchema,
         },
       },
       output: {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.ts
@@ -20,7 +20,8 @@ export function createSerializeYamlAction() {
   return createTemplateAction<{
     data: any;
     options?: {
-      indent: number;
+      indent?: number;
+      lineWidth?: number;
     };
   }>({
     id: 'roadiehq:utils:serialize:yaml',
@@ -50,6 +51,9 @@ export function createSerializeYamlAction() {
             type: 'object',
             properties: {
               indent: {
+                type: 'number',
+              },
+              lineWidth: {
                 type: 'number',
               },
             },

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/types.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/types.ts
@@ -27,36 +27,57 @@ export const yamlOptionsSchema = {
   type: 'object',
   properties: {
     indent: {
+      description: '(default: 2) - indentation width to use (in spaces)',
       type: 'number',
     },
     noArrayIndent: {
+      description:
+        '(default: false) - when true, will not add an indentation level to array elements',
       type: 'boolean',
     },
     skipInvalid: {
+      description:
+        '(default: false) - do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types',
       type: 'boolean',
     },
     flowLevel: {
+      description:
+        '(default: -1) - specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everwhere',
       type: 'number',
     },
     sortKeys: {
+      description:
+        '(default: false) - if true, sort keys when dumping YAML. If a function, use the function to sort the keys',
       type: 'boolean',
     },
     lineWidth: {
+      description:
+        '(default: 80) - set max line width. Set -1 for unlimited width',
       type: 'number',
     },
     noRefs: {
+      description:
+        "(default: false) - if true, don't convert duplicate objects into references",
       type: 'boolean',
     },
     noCompatMode: {
+      description:
+        '(default: false) - if true don\'t try to be compatible with older yaml versions. Currently: don\'t quote "yes", "no" and so on, as required for YAML 1.1',
       type: 'boolean',
     },
     condenseFlow: {
+      description:
+        "(default: false) - if true flow sequences will be condensed, omitting the space between a, b. Eg. '[a,b]', and omitting the space between key: value and quoting the key. Eg. '{\"a\":b}' Can be useful when using yaml for pretty URL query params as spaces are %-encoded.",
       type: 'boolean',
     },
     quotingType: {
+      description:
+        "(' or \", default: ') - strings will be quoted using this quoting style. If you specify single quotes, double quotes will still be used for non-printable characters.",
       type: 'string',
     },
     forceQuotes: {
+      description:
+        "(default: false) - if true, all non-key strings will be quoted even if they normally don't need to.",
       type: 'boolean',
     },
   },

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/types.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/types.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DumpOptions } from 'js-yaml';
+
+export type supportedDumpOptions = Omit<
+  DumpOptions,
+  'styles' | 'schema' | 'replacer'
+>;
+
+export const yamlOptionsSchema = {
+  title: 'Options',
+  description: 'YAML stringify options',
+  type: 'object',
+  properties: {
+    indent: {
+      type: 'number',
+    },
+    noArrayIndent: {
+      type: 'boolean',
+    },
+    skipInvalid: {
+      type: 'boolean',
+    },
+    flowLevel: {
+      type: 'number',
+    },
+    sortKeys: {
+      type: 'boolean',
+    },
+    lineWidth: {
+      type: 'number',
+    },
+    noRefs: {
+      type: 'boolean',
+    },
+    noCompatMode: {
+      type: 'boolean',
+    },
+    condenseFlow: {
+      type: 'boolean',
+    },
+    quotingType: {
+      type: 'string',
+    },
+    forceQuotes: {
+      type: 'boolean',
+    },
+  },
+};


### PR DESCRIPTION
The JSONata action is very useful for modifying an existing YAML file. However, it fails to match the style of the destination YAML, creating large diffs. If you have a file that looks like this:

```yaml
someKey: moreThan80Chars
```

and run a transformation on it (`$ ~> | $ | { "newKey": "newVal" } |`), the end result is something like:

```yaml
someKey: >-
  moreThan80Chars
newKey: newval
```

For a file with many such lines (in our case, AWS ARNs), this creates a massive diff against the file, when only a small transformation was performed.

This change allows for setting the `lineWidth` property of [`js-yaml.dump`][0], which when set to `-1`, disables auto-wrapping. This would allow us to use JSONata transformations without enforcing the default `js-yaml` style on the destination YAML.

#### Looking for Feedback On

1. I wasn't sure which style of test is preferred -- testing that the option was passed to `yaml.dump`, or testing that the output actually didn't wrap. I left in one of each style, and can change the other to the preferred, if this change is something you would like merged.
   1. If "test expected output", should there be a negative test, that without the option passed, line wrapping is performed?
1. The JSONata transformation is very simple, replacing the (empty) file wholesale. Should this be more complex?
1. Should I add the other relevant `dump` options while I'm in here? `noArrayIndent`, `skipInvalid`, `flowLevel`, `sortKeys`, `noRefs`, `noCompatMode`, `condenseFlow`, `quotingType`, and `forceQuotes` all seem potentially useful.
    1. Should I add them to `utils:merge` as well?
    1. I'm new to Typescript, but would this be a case for `pick`/`omit` on the `yaml.dump` parameters? Or would that be too complicated, because each option needs to be specified in the JSON Schema as well?


<details>
<summary>Test in a real template</summary>

With this template:

```yaml
apiVersion: scaffolder.backstage.io/v1beta3
kind: Template

metadata:
  name: test-template
  title: Test template

spec:
  owner: myTeam
  type: service

  parameters:
    - title: Test
      properties:
        test:
          title: Test
          type: string

  steps:
    - id: fetch-base
      name: Fetch Base
      action: fetch:template
      input:
        url: ./skeleton

    - id: update-base
      name: Update Base
      action: roadiehq:utils:jsonata:yaml:transform
      input:
        path: test.yaml
        expression: |-
          $ ~> | $ | {
            "some_super_long_key": "some super super super super super super super super super super super super long value"
          } |

    - id: log-message
      name: Log Message
      action: debug:log
      input:
        message: ${{ steps['update-base'].output.result }}
```

and `skeleton/test.yaml` containing `hello: world`, I ran the template with the suggested plugin changes in a backstage instance, and got this (expected, unwanted result):

```console
12023-03-28T00:37:47.364Z Beginning step Log Message
22023-03-28T00:37:47.367Z info: {
3  "message": "hello: world\nsome_super_long_key: >-\n  some super super super super super super super super super super super super\n  long value\n"
4}
52023-03-28T00:37:47.367Z hello: world
6some_super_long_key: >-
7  some super super super super super super super super super super super super
8  long value
92023-03-28T00:37:47.368Z Finished step Log Message
```

(See the `>-`.) I added `options.lineWidth: -1` to the JSONata step and got this (expected, desired result):

```console
12023-03-28T00:41:15.878Z Beginning step Log Message
22023-03-28T00:41:15.882Z info: {
3  "message": "hello: world\nsome_super_long_key: some super super super super super super super super super super super super long value\n"
4}
52023-03-28T00:41:15.885Z hello: world
6some_super_long_key: some super super super super super super super super super super super super long value
72023-03-28T00:41:15.886Z Finished step Log Message
```
</details>

[0]: https://www.npmjs.com/package/js-yaml

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
   - N/A, no UI changes
- [x] Added or updated documentation (if applicable)
  - no existing docs for `indent` option; assuming auto-generated backstage `/create/action` docs are OK
