### PR TITLE
add smarter pruning of empty groups

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -32,7 +32,6 @@ export default async function createPlugin(
   const orgProvider = OktaOrgEntityProvider.fromConfig(env.config, {
     ...env,
     groupNamingStrategy: 'kebab-case-name',
-    userNamingStrategy: 'strip-domain-email',
   });
   builder.addEntityProvider(orgProvider);
   providers.push(orgProvider);
@@ -82,7 +81,7 @@ export default async function createPlugin(
       fn: async () => {
         await provider.run();
       },
-      frequency: Duration.fromObject({ minutes: 5 }),
+      frequency: Duration.fromObject({ minutes: 1 }),
       timeout: Duration.fromObject({ minutes: 10 }),
     });
   }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupEntity } from '@backstage/catalog-model';
+
+interface GroupNode {
+  group: GroupEntity;
+  children: GroupNode[];
+}
+
+export class GroupTree {
+  private groupDict: Record<string, GroupNode> = {};
+
+  constructor(private groups: GroupEntity[]) {
+    for (const group of groups) {
+      this.groupDict[group.metadata.name] = { group, children: [] };
+    }
+    for (const group of groups) {
+      const parentName = group.spec.parent;
+      if (parentName) {
+        this.groupDict[parentName].children.push(
+          this.groupDict[group.metadata.name],
+        );
+      }
+    }
+  }
+
+  public getGroups(opts: { pruneEmptyMembers: boolean }): GroupEntity[] {
+    const { pruneEmptyMembers } = opts;
+    const result: GroupEntity[] = [];
+    const tree = this.createTree({ pruneEmptyMembers });
+    for (const node of tree) {
+      this.addSubtreeNodes(node, result);
+    }
+    return result;
+  }
+
+  private addSubtreeNodes(node: GroupNode, result: GroupEntity[]): void {
+    result.push(node.group);
+    for (const child of node.children) {
+      this.addSubtreeNodes(child, result);
+    }
+  }
+
+  private pruneEmptyMembers(nodes: GroupNode[]): void {
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const node = nodes[i];
+      this.pruneEmptyMembers(node.children);
+      if (node.group.spec.members?.length === 0 && node.children.length === 0) {
+        nodes.splice(i, 1);
+      }
+    }
+  }
+
+  private createTree(opts: { pruneEmptyMembers: boolean }): GroupNode[] {
+    const { pruneEmptyMembers } = opts;
+    const rootNodes: GroupNode[] = [];
+    for (const group of this.groups) {
+      if (!group.spec.parent) {
+        rootNodes.push(this.groupDict[group.metadata.name]);
+      }
+    }
+    if (pruneEmptyMembers) {
+      this.pruneEmptyMembers(rootNodes);
+    }
+    return rootNodes;
+  }
+}

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -35,6 +35,7 @@ import { getAccountConfig } from './accountConfig';
 import { assertError } from '@backstage/errors';
 import { getOktaGroups } from './getOktaGroups';
 import { getParentGroup } from './getParentGroup';
+import { GroupTree } from './GroupTree';
 
 /**
  * Provides entities from Okta Org service.
@@ -110,7 +111,8 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
     }
 
     this.logger.info('Providing user and group resources from okta');
-    const resources: (GroupEntity | UserEntity)[] = [];
+    let groupResources: GroupEntity[] = [];
+    const userResources: Record<string, UserEntity> = {};
     let providedUserCount = 0;
     let providedGroupCount = 0;
 
@@ -124,14 +126,17 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
         const defaultAnnotations = await this.buildDefaultAnnotations();
 
         await client.listUsers({ search: account.userFilter }).each(user => {
-          resources.push(
-            userEntityFromOktaUser(user, this.userNamingStrategy, {
+          const userName = this.userNamingStrategy(user);
+          userResources[userName] = userEntityFromOktaUser(
+            user,
+            this.userNamingStrategy,
+            {
               annotations: defaultAnnotations,
-            }),
+            },
           );
         });
 
-        providedUserCount = resources.length;
+        providedUserCount = Object.values(userResources).length;
 
         const oktaGroups = await getOktaGroups({
           client,
@@ -147,7 +152,9 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
             await group.listUsers().each(user => {
               try {
                 const userName = this.userNamingStrategy(user);
-                members.push(userName);
+                if (userResources[userName]) {
+                  members.push(userName);
+                }
               } catch (e: unknown) {
                 assertError(e);
                 this.logger.warn(`failed to add user to group: ${e.message}`);
@@ -170,9 +177,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
                   members,
                 },
               );
-              if (this.includeEmptyGroups || members.length > 0) {
-                resources.push(groupEntity);
-              }
+              groupResources.push(groupEntity);
             } catch (e: unknown) {
               assertError(e);
               this.logger.warn(`failed to add group: ${e.message}`);
@@ -182,13 +187,21 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       }),
     );
 
-    providedGroupCount = resources.length - providedUserCount;
+    if (!this.includeEmptyGroups) {
+      groupResources = new GroupTree(groupResources).getGroups({
+        pruneEmptyMembers: true,
+      });
+    }
+
+    providedGroupCount = groupResources.length;
     await this.connection.applyMutation({
       type: 'full',
-      entities: resources.map(entity => ({
-        entity,
-        locationKey: this.getProviderName(),
-      })),
+      entities: [...Object.values(userResources), ...groupResources].map(
+        entity => ({
+          entity,
+          locationKey: this.getProviderName(),
+        }),
+      ),
     });
 
     this.logger.info(


### PR DESCRIPTION
add smarter pruning of empty groups

Previously, parent groups of groups with members were being pruned. This change includes parent groups if their decendants have members.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
