### PR TITLE
add a log line when groups are being pruned from okta

### DIFF
--- a/.changeset/quick-bats-accept.md
+++ b/.changeset/quick-bats-accept.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Adding a log line to indicate that empty groups will be pruned.

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -200,6 +200,9 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
     );
 
     if (!this.includeEmptyGroups) {
+      this.logger.debug(
+        `Found ${groupResources.length}, pruning the empty ones`,
+      );
       groupResources = new GroupTree(groupResources).getGroups({
         pruneEmptyMembers: true,
       });


### PR DESCRIPTION
add a log line when groups are being pruned from okta
#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
