### PR TITLE
add debug logging to the group tree pruning okta

### DIFF
--- a/.changeset/fresh-carpets-joke.md
+++ b/.changeset/fresh-carpets-joke.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Add debug logging to the okta tree pruning.

--- a/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { GroupEntity } from '@backstage/catalog-model';
+import { Logger } from 'winston';
 
 interface GroupNode {
   group: GroupEntity;
@@ -23,9 +24,11 @@ interface GroupNode {
 export class GroupTree {
   private groupDict: Record<string, GroupNode> = {};
   private groups: GroupEntity[];
+  private logger: Logger;
 
-  constructor(groups: GroupEntity[]) {
+  constructor(groups: GroupEntity[], logger: Logger) {
     this.groups = groups;
+    this.logger = logger;
     for (const group of groups) {
       this.groupDict[group.metadata.name] = { group, children: [] };
     }
@@ -62,7 +65,11 @@ export class GroupTree {
   private pruneEmptyMembers(nodes: GroupNode[]): void {
     for (const node of nodes) {
       this.pruneEmptyMembers(node.children);
+      this.logger.debug(
+        `${node.group.metadata.name}: members=${node.group.spec.members?.length} children=${node.children.length} `,
+      );
       if (node.group.spec.members?.length === 0 && node.children.length === 0) {
+        this.logger.debug(`pruning ${node.group.metadata.name}`);
         const index = nodes.indexOf(node);
         nodes.splice(index, 1);
       }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -203,7 +203,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       this.logger.info(
         `Found ${groupResources.length}, pruning the empty ones`,
       );
-      groupResources = new GroupTree(groupResources).getGroups({
+      groupResources = new GroupTree(groupResources, this.logger).getGroups({
         pruneEmptyMembers: true,
       });
     }


### PR DESCRIPTION
add debug logging to the group tree pruning okta

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
