### PR TITLE
Security Insights: Fix accidental export removal

### DIFF
--- a/.changeset/cuddly-toes-wash.md
+++ b/.changeset/cuddly-toes-wash.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': patch
+---
+
+Fix issue where EntitySecurityInsightsCard and EntityDependabotAlertsCard were no longer exported.

--- a/plugins/frontend/backstage-plugin-security-insights/src/index.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/index.ts
@@ -22,6 +22,8 @@ export {
   securityInsightsPlugin,
   EntitySecurityInsightsContent,
   EntityGithubDependabotContent,
+  EntitySecurityInsightsCard,
+  EntityDependabotAlertsCard,
 } from './plugin';
 export { SecurityInsightsWidget } from './components/SecurityInsightsWidget';
 export { SecurityInsightsTable } from './components/SecurityInsightsTable';


### PR DESCRIPTION
Back in #910 I accidentally removed two existing exports. We didn't catch this in the review. I tried to update on my end and I got a build failure because these were no longer exported.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
