### PR TITLE
refactor and add tests

### DIFF
--- a/.changeset/smooth-cheetahs-destroy.md
+++ b/.changeset/smooth-cheetahs-destroy.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Refactor and add tests to okta group tree.

--- a/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupTree } from './GroupTree';
+import { GroupEntity } from '@backstage/catalog-model';
+
+const noMembers: Partial<GroupEntity>[] = [
+  {
+    metadata: {
+      name: 'group-1',
+    },
+    spec: {
+      type: 'group',
+      members: [],
+      children: [],
+    },
+  },
+];
+
+const withMembersTree: Partial<GroupEntity>[] = [
+  {
+    metadata: {
+      name: 'group-1',
+    },
+    spec: {
+      type: 'group',
+      members: [],
+      children: ['group-2', 'group-3'],
+    },
+  },
+  {
+    metadata: {
+      name: 'group-2',
+    },
+    spec: {
+      type: 'group',
+      parent: 'group-1',
+      members: [],
+      children: [],
+    },
+  },
+  {
+    metadata: {
+      name: 'group-4',
+    },
+    spec: {
+      type: 'group',
+      parent: 'group-2',
+      members: ['member-1'],
+      children: [],
+    },
+  },
+  {
+    metadata: {
+      name: 'group-3',
+    },
+    spec: {
+      type: 'group',
+      parent: 'group-1',
+      members: [],
+      children: [],
+    },
+  },
+];
+
+describe('group tree', () => {
+  it('returns an empty list of groups the groups', () => {
+    const groups = new GroupTree([]).getGroups({ pruneEmptyMembers: false });
+    expect(groups.length).toEqual(0);
+  });
+
+  it('returns items with no members', () => {
+    const filteredGroups = new GroupTree(noMembers as GroupEntity[]).getGroups({
+      pruneEmptyMembers: false,
+    });
+    expect(filteredGroups.length).toEqual(1);
+  });
+
+  it('removes items with no members', () => {
+    const filteredGroups = new GroupTree(noMembers as GroupEntity[]).getGroups({
+      pruneEmptyMembers: true,
+    });
+    expect(filteredGroups.length).toEqual(0);
+  });
+
+  it('removes empty members from a tree', () => {
+    const filteredGroups = new GroupTree(
+      withMembersTree as GroupEntity[],
+    ).getGroups({ pruneEmptyMembers: true });
+    expect(filteredGroups.length).toEqual(3);
+  });
+});

--- a/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/GroupTree.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { GroupEntity } from '@backstage/catalog-model';
-import { Logger } from 'winston';
 
 interface GroupNode {
   group: GroupEntity;
@@ -23,12 +22,9 @@ interface GroupNode {
 
 export class GroupTree {
   private groupDict: Record<string, GroupNode> = {};
-  private groups: GroupEntity[];
-  private logger: Logger;
+  private rootNodes: GroupNode[] = [];
 
-  constructor(groups: GroupEntity[], logger: Logger) {
-    this.groups = groups;
-    this.logger = logger;
+  constructor(groups: GroupEntity[]) {
     for (const group of groups) {
       this.groupDict[group.metadata.name] = { group, children: [] };
     }
@@ -43,56 +39,40 @@ export class GroupTree {
         );
       }
     }
+    for (const group of Object.values(this.groupDict)) {
+      if (!this.hasParent(group)) {
+        this.rootNodes.push(group);
+      }
+    }
   }
 
   public getGroups(opts: { pruneEmptyMembers: boolean }): GroupEntity[] {
     const { pruneEmptyMembers } = opts;
     const result: GroupEntity[] = [];
-    const tree = this.createTree({ pruneEmptyMembers });
-    for (const node of tree) {
-      this.addSubtreeNodes(node, result);
+    for (const group of Object.values(this.groupDict)) {
+      if (pruneEmptyMembers) {
+        if (this.hasMembers(group)) {
+          result.push(group.group);
+        }
+      } else {
+        result.push(group.group);
+      }
     }
     return result;
   }
 
-  private addSubtreeNodes(node: GroupNode, result: GroupEntity[]): void {
-    result.push(node.group);
+  private hasMembers(node: GroupNode): boolean {
+    let hasMembers = node.group.spec.members?.length !== 0;
     for (const child of node.children) {
-      this.addSubtreeNodes(child, result);
+      const childHasMembers = this.hasMembers(child);
+      hasMembers = hasMembers || childHasMembers;
     }
+    return hasMembers;
   }
 
-  private pruneEmptyMembers(nodes: GroupNode[]): void {
-    for (const node of nodes) {
-      this.pruneEmptyMembers(node.children);
-      this.logger.debug(
-        `${node.group.metadata.name}: members=${node.group.spec.members?.length} children=${node.children.length} `,
-      );
-      if (node.group.spec.members?.length === 0 && node.children.length === 0) {
-        this.logger.debug(`pruning ${node.group.metadata.name}`);
-        const index = nodes.indexOf(node);
-        nodes.splice(index, 1);
-      }
-    }
-  }
-
-  private hasParent(group: GroupEntity): boolean {
-    return group.spec.parent === group.metadata.name
+  private hasParent(node: GroupNode): boolean {
+    return node.group.spec.parent === node.group.metadata.name
       ? false
-      : !!group.spec.parent;
-  }
-
-  private createTree(opts: { pruneEmptyMembers: boolean }): GroupNode[] {
-    const { pruneEmptyMembers } = opts;
-    const rootNodes: GroupNode[] = [];
-    for (const group of this.groups) {
-      if (!this.hasParent(group)) {
-        rootNodes.push(this.groupDict[group.metadata.name]);
-      }
-    }
-    if (pruneEmptyMembers) {
-      this.pruneEmptyMembers(rootNodes);
-    }
-    return rootNodes;
+      : !!node.group.spec.parent;
   }
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -203,7 +203,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       this.logger.info(
         `Found ${groupResources.length}, pruning the empty ones`,
       );
-      groupResources = new GroupTree(groupResources, this.logger).getGroups({
+      groupResources = new GroupTree(groupResources).getGroups({
         pruneEmptyMembers: true,
       });
     }


### PR DESCRIPTION
refactor and add tests to okta group tree

- only need to build the tree once
- simplify the pruning algorithm
- add tests for group tree

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
