### PR TITLE
Handle the "Fixed" state for dependabot alerts

### DIFF
--- a/.changeset/twelve-cherries-type.md
+++ b/.changeset/twelve-cherries-type.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': minor
+---
+
+The Dependabot Alerts table now correctly displays and filters "Fixed" alerts.

--- a/packages/app/cypress/fixtures/securityInsights/graphql.json
+++ b/packages/app/cypress/fixtures/securityInsights/graphql.json
@@ -7,7 +7,7 @@
           {
             "createdAt": "2020-10-13T14:05:11Z",
             "id": "MDI4OlJlcG9zaXRvcnlWdWxuZXJhYmlsaXR5QWxlcnQ0MDgyODM2MDY=",
-            "dismissedAt": null,
+            "state": "OPEN",
             "securityVulnerability": {
               "vulnerableVersionRange": "< 3.1.0",
               "package": {
@@ -25,7 +25,7 @@
           {
             "createdAt": "2021-05-25T15:16:23Z",
             "id": "MDI4OlJlcG9zaXRvcnlWdWxuZXJhYmlsaXR5QWxlcnQ3MTE1NjQwODQ=",
-            "dismissedAt": null,
+            "state": "OPEN",
             "securityVulnerability": {
               "vulnerableVersionRange": ">= 4.0.0, < 4.16.5",
               "package": {
@@ -43,7 +43,7 @@
           {
             "createdAt": "2021-06-12T00:22:53Z",
             "id": "MDI4OlJlcG9zaXRvcnlWdWxuZXJhYmlsaXR5QWxlcnQ3NTQwMzU5MDI=",
-            "dismissedAt": "2021-07-14T10:08:13Z",
+            "state": "DISMISSED",
             "securityVulnerability": {
               "vulnerableVersionRange": "< 5.1.2",
               "package": {

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.test.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.test.tsx
@@ -31,7 +31,6 @@ import {
   githubAuthApiRef,
   AnyApiRef,
 } from '@backstage/core-plugin-api';
-import { securityInsightsPlugin } from '../../plugin';
 
 let entity: { entity: Entity };
 
@@ -79,13 +78,7 @@ describe('Dependabot alerts overview', () => {
     jest.resetAllMocks();
   });
 
-  describe('export-security-insights-plugin', () => {
-    it('should export plugin', () => {
-      expect(securityInsightsPlugin).toBeDefined();
-    });
-  });
-
-  describe('GithubDependabotAlertsTable', () => {
+  describe('DependabotAlertsTable', () => {
     beforeEach(() => {
       entity = entityStub;
     });

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.test.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.test.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { entityStub, dependabotAlertsResponseMock } from '../../mocks/mocks';
 import { graphql } from 'msw';
 import {
@@ -98,8 +98,97 @@ describe('Dependabot alerts overview', () => {
         ),
       );
       expect(
-        await rendered.findByText('serialize-javascript'),
-      ).toBeInTheDocument();
+        await rendered.findByText('serialize-javascript-open'),
+      ).toBeVisible();
+      expect(
+        await rendered.findByText('serialize-javascript-fixed'),
+      ).toBeVisible();
+      expect(
+        await rendered.findByText('serialize-javascript-dismissed'),
+      ).toBeVisible();
+    });
+
+    it('should show open alerts only when filtering for them', async () => {
+      worker.use(
+        GRAPHQL_GITHUB_API.query('GetDependabotAlerts', (_, res, ctx) => {
+          res(ctx.data(dependabotAlertsResponseMock));
+        }),
+      );
+
+      const rendered = render(
+        wrapInTestApp(
+          <TestApiProvider apis={apis}>
+            <DependabotAlertsTable />
+          </TestApiProvider>,
+        ),
+      );
+      fireEvent.click(await rendered.findByRole('button', { name: 'OPEN' }));
+
+      expect(
+        await rendered.findByText('serialize-javascript-open'),
+      ).toBeVisible();
+      expect(await rendered.queryByText('serialize-javascript-fixed')).toBe(
+        null,
+      );
+      expect(await rendered.queryByText('serialize-javascript-dismissed')).toBe(
+        null,
+      );
+    });
+
+    it('should show fixed alerts only when filtering for them', async () => {
+      worker.use(
+        GRAPHQL_GITHUB_API.query('GetDependabotAlerts', (_, res, ctx) => {
+          res(ctx.data(dependabotAlertsResponseMock));
+        }),
+      );
+
+      const rendered = render(
+        wrapInTestApp(
+          <TestApiProvider apis={apis}>
+            <DependabotAlertsTable />
+          </TestApiProvider>,
+        ),
+      );
+      fireEvent.click(await rendered.findByRole('button', { name: 'FIXED' }));
+
+      expect(
+        await rendered.findByText('serialize-javascript-fixed'),
+      ).toBeVisible();
+      expect(await rendered.queryByText('serialize-javascript-open')).toBe(
+        null,
+      );
+      expect(await rendered.queryByText('serialize-javascript-dismissed')).toBe(
+        null,
+      );
+    });
+
+    it('should show dismissed alerts only when filtering for them', async () => {
+      worker.use(
+        GRAPHQL_GITHUB_API.query('GetDependabotAlerts', (_, res, ctx) => {
+          res(ctx.data(dependabotAlertsResponseMock));
+        }),
+      );
+
+      const rendered = render(
+        wrapInTestApp(
+          <TestApiProvider apis={apis}>
+            <DependabotAlertsTable />
+          </TestApiProvider>,
+        ),
+      );
+      fireEvent.click(
+        await rendered.findByRole('button', { name: 'DISMISSED' }),
+      );
+
+      expect(
+        await rendered.findByText('serialize-javascript-dismissed'),
+      ).toBeVisible();
+      expect(await rendered.queryByText('serialize-javascript-open')).toBe(
+        null,
+      );
+      expect(await rendered.queryByText('serialize-javascript-fixed')).toBe(
+        null,
+      );
     });
   });
 });

--- a/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
@@ -182,7 +182,7 @@ export const alertsResponseMock = [
 export const dependabotAlertsResponseMock = {
   repository: {
     vulnerabilityAlerts: {
-      totalCount: 2,
+      totalCount: 4,
       nodes: [
         {
           createdAt: '2020-10-13T14:05:11Z',
@@ -192,7 +192,7 @@ export const dependabotAlertsResponseMock = {
           securityVulnerability: {
             vulnerableVersionRange: '< 3.1.0',
             package: {
-              name: 'serialize-javascript',
+              name: 'serialize-javascript-open',
             },
             firstPatchedVersion: {
               identifier: '3.1.0',
@@ -221,6 +221,46 @@ export const dependabotAlertsResponseMock = {
             advisory: {
               description:
                 'The package browserslist from 4.0.0 and before 4.16.5 are vulnerable to Regular Expression Denial of Service (ReDoS) during parsing of queries.',
+            },
+          },
+        },
+        {
+          createdAt: '2020-10-13T14:05:11Z',
+          id: 'MDI4OlJlcddsdsfererertc5QWxlcnQ0MDgyODMyyy2MDY=',
+          state: 'FIXED',
+          vulnerableManifestPath: 'yarn.lock',
+          securityVulnerability: {
+            vulnerableVersionRange: '< 3.1.0',
+            package: {
+              name: 'serialize-javascript-fixed',
+            },
+            firstPatchedVersion: {
+              identifier: '3.1.0',
+            },
+            severity: 'HIGH',
+            advisory: {
+              description:
+                'serialize-javascript prior to 3.1.0 allows remote attackers to inject arbitrary code via the function "deleteFunctions" within "index.js". \r\n\r\nAn object such as `{"foo": /1"/, "bar": "a\\"@__R-<UID>-0__@"}` was serialized as `{"foo": /1"/, "bar": "a\\/1"/}`, which allows an attacker to escape the `bar` key. This requires the attacker to control the values of both `foo` and `bar` and guess the value of `<UID>`. The UID has a keyspace of approximately 4 billion making it a realistic network attack.\r\n\r\nThe following proof-of-concept calls `console.log()` when the running `eval()`:\r\n`eval(\'(\'+ serialize({"foo": /1" + console.log(1)/i, "bar": \'"@__R-<UID>-0__@\'}) + \')\');`',
+            },
+          },
+        },
+        {
+          createdAt: '2020-10-13T14:05:11Z',
+          id: 'MDI4OlJlcddsdsfererertc5QWxlcnQ0MDgyODMyyy2MDY=',
+          state: 'DISMISSED',
+          vulnerableManifestPath: 'yarn.lock',
+          securityVulnerability: {
+            vulnerableVersionRange: '< 3.1.0',
+            package: {
+              name: 'serialize-javascript-dismissed',
+            },
+            firstPatchedVersion: {
+              identifier: '3.1.0',
+            },
+            severity: 'HIGH',
+            advisory: {
+              description:
+                'serialize-javascript prior to 3.1.0 allows remote attackers to inject arbitrary code via the function "deleteFunctions" within "index.js". \r\n\r\nAn object such as `{"foo": /1"/, "bar": "a\\"@__R-<UID>-0__@"}` was serialized as `{"foo": /1"/, "bar": "a\\/1"/}`, which allows an attacker to escape the `bar` key. This requires the attacker to control the values of both `foo` and `bar` and guess the value of `<UID>`. The UID has a keyspace of approximately 4 billion making it a realistic network attack.\r\n\r\nThe following proof-of-concept calls `console.log()` when the running `eval()`:\r\n`eval(\'(\'+ serialize({"foo": /1" + console.log(1)/i, "bar": \'"@__R-<UID>-0__@\'}) + \')\');`',
             },
           },
         },

--- a/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/mocks/mocks.ts
@@ -187,7 +187,7 @@ export const dependabotAlertsResponseMock = {
         {
           createdAt: '2020-10-13T14:05:11Z',
           id: 'MDI4OlJlcddsdsfererertc5QWxlcnQ0MDgyODMyyy2MDY=',
-          dismissedAt: null,
+          state: 'OPEN',
           vulnerableManifestPath: 'yarn.lock',
           securityVulnerability: {
             vulnerableVersionRange: '< 3.1.0',
@@ -207,7 +207,7 @@ export const dependabotAlertsResponseMock = {
         {
           createdAt: '2021-05-25T15:16:23Z',
           id: 'MDI4OlJlcG9zaXRvcnlWdWxuuuuuuZXJhYmls12lksoiurrrQ3MTE1NjQwODQ=',
-          dismissedAt: null,
+          state: 'OPEN',
           vulnerableManifestPath: 'yarn.lock',
           securityVulnerability: {
             vulnerableVersionRange: '>= 4.0.0, < 4.16.5',

--- a/plugins/frontend/backstage-plugin-security-insights/src/plugin.test.ts
+++ b/plugins/frontend/backstage-plugin-security-insights/src/plugin.test.ts
@@ -16,7 +16,7 @@
 
 import { securityInsightsPlugin } from './plugin';
 
-describe('github-pull-requests', () => {
+describe('export-security-insights-plugin', () => {
   it('should export plugin', () => {
     expect(securityInsightsPlugin).toBeDefined();
   });


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
Related to #934 

This PR adds support for the `FIXED` state in the dependabot alerts table. To achieve this, I remove the old logic that figured out the status using the `dismissedOn` field and replaced that with the `state` field. There are really two changes here:
- The table has a new `FIXED` filter button
- The table can correctly display `FIXED` alerts

Here's what it looks like. I've had to censor quite a bit in an abundance of caution. The before and after tables contain the same vulnerabilities. The old one shows them as open while the new one shows them as fixed which is correct.

Before:

![image](https://user-images.githubusercontent.com/1874242/231157977-6b019fdc-acf1-41e5-8b53-7c6eef1ef077.png)

After:

![image](https://user-images.githubusercontent.com/1874242/231157637-367ff098-0fe5-4a4f-9ce5-b7e1392d36ec.png)

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
