### PR TITLE
extend average time PR until merge to display hours

### DIFF
--- a/.changeset/famous-islands-peel.md
+++ b/.changeset/famous-islands-peel.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+extend 'avg time PR until merge' to display hours

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
@@ -64,7 +64,9 @@ describe('PullRequestsCard', () => {
         </EntityProvider>
       </TestApiProvider>,
     );
-    expect(await screen.findByText('1 month, 27 days')).toBeInTheDocument();
+    expect(
+      await screen.findByText('1 month, 26 days, 16 hours'),
+    ).toBeInTheDocument();
     expect(await screen.findByText('67%')).toBeInTheDocument();
     expect(await screen.findByText('3309 lines')).toBeInTheDocument();
   });

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
@@ -168,7 +168,7 @@ export function usePullRequestsStatistics({
       calcResult.avgTimeUntilMerge / calcResult.mergedCount;
 
     const avgTimeUntilMerge = Duration.fromMillis(avgTimeUntilMergeDiff)
-      .shiftTo('months', 'days')
+      .shiftTo('months', 'days', 'hour')
       .toHuman({ notation: 'compact' });
     return {
       ...calcResult,


### PR DESCRIPTION
- extend 'avg time PR until merge' to include hours

<!-- Please describe what these changes achieve -->
before:
<img width="608" alt="image" src="https://user-images.githubusercontent.com/19555355/235252223-1761ee50-93fa-4db6-9205-a03b3dad0857.png">
or
<img width="633" alt="image" src="https://user-images.githubusercontent.com/19555355/235339609-b7518da6-b0f1-4fd9-a529-336b677c33d5.png">

after:
<img width="614" alt="image" src="https://user-images.githubusercontent.com/19555355/235252125-801f1932-4fd3-4b87-914a-e5ab6d785130.png">

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
