### PR TITLE
fix creator column size in pull request table

### DIFF
--- a/.changeset/hot-weeks-exercise.md
+++ b/.changeset/hot-weeks-exercise.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+fix creator column size in pull request table

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
@@ -76,7 +76,6 @@ const generatedColumns: TableColumn<PullRequest>[] = [
     title: 'Creator',
     field: 'creatorNickname',
     highlight: true,
-    width: '250px',
     render: (row: Partial<PullRequest>) => (
       <Box fontWeight="fontWeightBold">
         <a


### PR DESCRIPTION
Signed-off-by: sploschee <19555355+sploschee@users.noreply.github.com>

<!-- Please describe what these changes achieve -->
Before:  The **Creator** column was a fixed size and unable to dynamically expand if required sometimes leading to wrapped Creator text and overly large Created and Last Updated cols
<img width="737" alt="image" src="https://user-images.githubusercontent.com/19555355/235339978-2b1e69d6-282e-467e-9aaf-1688cf8cc1fc.png">

After: remove fixed col width on Creator col allowing for expansion and distribution of the columns
<img width="889" alt="image" src="https://user-images.githubusercontent.com/19555355/235340025-58231a0d-0075-4525-b4b8-c5152f8b481c.png">

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
