### PR TITLE
export secrets-manager action

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './actions/s3';
 export * from './actions/ecr';
+export * from './actions/secrets-manager';


### PR DESCRIPTION
secrets-manager action was not exported, hence was not usable with the library
