### PR TITLE
ArgoCD: use argocd instance url for dashboard url

### DIFF
--- a/.changeset/stale-eagles-clean.md
+++ b/.changeset/stale-eagles-clean.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+The instance url for the argocd backend plugin will be used if `argocd.baseUrl` is not defined.

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
@@ -146,12 +146,27 @@ const OverviewComponent = ({
     configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length,
   );
 
+  const getBaseUrl = (row: any): string | undefined => {
+    if (supportsMultipleArgoInstances && !baseUrl) {
+      return configApi
+        .getConfigArray('argocd.appLocatorMethods')
+        .find(value => value.getOptionalString('type') === 'config')
+        ?.getOptionalConfigArray('instances')
+        ?.find(
+          value =>
+            value.getOptionalString('name') === row.metadata?.instance?.name,
+        )
+        ?.getOptionalString('url');
+    }
+    return baseUrl;
+  };
+
   const columns: TableColumn[] = [
     {
       title: 'Name',
       highlight: true,
       render: (row: any): React.ReactNode =>
-        detailsDrawerComponent(row, baseUrl),
+        detailsDrawerComponent(row, getBaseUrl(row)),
     },
     {
       title: 'Sync Status',


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

This will use the instance url for the dashboard link if the `argocd.baseUrl` isn't defined.
We need this as we have multiple instances of argocd, all with own dashboards.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
