### PR TITLE
fix: expose instances to fontend

### DIFF
--- a/.changeset/cool-cups-study.md
+++ b/.changeset/cool-cups-study.md
@@ -1,0 +1,7 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-backend': patch
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Expose instances for the frontend to display ArgoCD dashboard links in a multi instance setup.
+Additionally, don't expose secrets.

--- a/plugins/backend/backstage-plugin-argo-cd-backend/config.d.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/config.d.ts
@@ -2,6 +2,14 @@ export interface Config {
   /** Optional configurations for the ArgoCD plugin */
   argocd?: {
     /**
+     * @visibility secret
+     */
+    username?: string;
+    /**
+     * @visibility secret
+     */
+    password?: string;
+    /**
      * The base url of the ArgoCD instance.
      * @visibility frontend
      */
@@ -28,6 +36,18 @@ export interface Config {
          * @visibility frontend
          */
         url: string;
+        /**
+         * @visibility secret
+         */
+        token?: string;
+        /**
+         * @visibility secret
+         */
+        username?: string;
+        /**
+         * @visibility secret
+         */
+        password?: string;
       }>;
     }>;
   };

--- a/plugins/frontend/backstage-plugin-argo-cd/config.d.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/config.d.ts
@@ -19,6 +19,16 @@ export interface Config {
        * @visibility frontend
        */
       type: string;
+      instances: Array<{
+        /**
+         * @visibility frontend
+         */
+        name: string;
+        /**
+         * @visibility frontend
+         */
+        url: string;
+      }>;
     }>;
   };
 }


### PR DESCRIPTION
Sadly I made an error in https://github.com/RoadieHQ/roadie-backstage-plugins/pull/981 and forget to expose the instances to the frontend. This PR will fix this.

FYI @kissmikijr 

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
