### PR TITLE
Update component name in plugin.ts

### DIFF
--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/plugin.ts
@@ -81,7 +81,7 @@ export const HomePageRequestedReviewsCard = githubPullRequestsPlugin.provide(
 export const HomePageYourOpenPullRequestsCard =
   githubPullRequestsPlugin.provide(
     createCardExtension<{ query?: string }>({
-      name: 'HomePageRequestedReviewsCard',
+      name: 'YourOpenPullRequestsCard',
       title: 'Your open pull requests',
       components: () => import('./components/Home/YourOpenPullRequestsCard'),
     }),


### PR DESCRIPTION
Fixed copy paste error. 
Both HomePageRequestedReviewsCard and HomePageYourOpenPullRequestsCard had same name of the component.
The name should be unique, otherwise the components are identified as one on custom homepage...
![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/2512959/33e30d8b-dfe8-4973-91e7-278c98633bb4)
