### PR TITLE
chore: minor refactoring to fix linting...

### DIFF
--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
@@ -516,7 +516,7 @@ describe('ArgoCD service', () => {
       argoToken: 'testToken',
     });
 
-    await expect(resp).rejects.toThrowError(
+    await expect(resp).rejects.toThrow(
       'permission denied: projects, delete, backstagetestmanual, sub: testuser18471, iat: 2022-04-13T12:28:34Z',
     );
   });
@@ -536,7 +536,7 @@ describe('ArgoCD service', () => {
         argoProjectName: 'testApp',
         argoToken: 'testToken',
       }),
-    ).rejects.toThrowError('something unexpected');
+    ).rejects.toThrow('something unexpected');
   });
 
   it('should delete app in argo', async () => {
@@ -580,7 +580,7 @@ describe('ArgoCD service', () => {
       argoToken: 'testToken',
     });
 
-    await expect(resp).rejects.toThrowError(
+    await expect(resp).rejects.toThrow(
       'permission denied: projects, delete, backstagetestmanual, sub: testuser18471, iat: 2022-04-13T12:28:34Z',
     );
   });
@@ -700,7 +700,7 @@ describe('ArgoCD service', () => {
       appSelector: 'testApp',
     });
 
-    await expect(resp).rejects.toThrowError(
+    await expect(resp).rejects.toThrow(
       'Getting unauthorized for Argo CD instance https://argoInstance1.com',
     );
   });

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/router.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/router.test.ts
@@ -105,8 +105,8 @@ describe('router', () => {
       labelValue: 'test-app',
     });
 
-    expect(mockCreateArgoProject).toBeCalledTimes(1);
-    expect(mockCreateArgoApplication).toBeCalledTimes(1);
+    expect(mockCreateArgoProject).toHaveBeenCalledTimes(1);
+    expect(mockCreateArgoApplication).toHaveBeenCalledTimes(1);
     expect(response.body).toMatchObject({
       argoAppName: 'test-app-nonprod',
       argoProjectName: 'test-project',


### PR DESCRIPTION
chore: minor refactoring to fix linting issues

Signed-off-by: Nick Boldt <nboldt@redhat.com>

Fixes these minor lint problems:

```
@roadiehq/backstage-plugin-argo-cd-backend:lint: $ backstage-cli package lint
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      Replace toThrowError() with its canonical name of toThrow()
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      plugins/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts:519:32
@roadiehq/backstage-plugin-argo-cd-backend:lint:      517 |     });
@roadiehq/backstage-plugin-argo-cd-backend:lint:      518 | 
@roadiehq/backstage-plugin-argo-cd-backend:lint:    > 519 |     await expect(resp).rejects.toThrowError(
@roadiehq/backstage-plugin-argo-cd-backend:lint:          |                                ^
@roadiehq/backstage-plugin-argo-cd-backend:lint:      520 |       'permission denied: projects, delete, backstagetestmanual, sub: testuser18471, iat: 2022-04-13T12:28:34Z',
@roadiehq/backstage-plugin-argo-cd-backend:lint:      521 |     );
@roadiehq/backstage-plugin-argo-cd-backend:lint:      522 |   });
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      Replace toThrowError() with its canonical name of toThrow()
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      plugins/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts:539:15
@roadiehq/backstage-plugin-argo-cd-backend:lint:      537 |         argoToken: 'testToken',
@roadiehq/backstage-plugin-argo-cd-backend:lint:      538 |       }),
@roadiehq/backstage-plugin-argo-cd-backend:lint:    > 539 |     ).rejects.toThrowError('something unexpected');
@roadiehq/backstage-plugin-argo-cd-backend:lint:          |               ^
@roadiehq/backstage-plugin-argo-cd-backend:lint:      540 |   });
@roadiehq/backstage-plugin-argo-cd-backend:lint:      541 | 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      542 |   it('should delete app in argo', async () => {
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      Replace toThrowError() with its canonical name of toThrow()
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      plugins/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts:583:32
@roadiehq/backstage-plugin-argo-cd-backend:lint:      581 |     });
@roadiehq/backstage-plugin-argo-cd-backend:lint:      582 | 
@roadiehq/backstage-plugin-argo-cd-backend:lint:    > 583 |     await expect(resp).rejects.toThrowError(
@roadiehq/backstage-plugin-argo-cd-backend:lint:          |                                ^
@roadiehq/backstage-plugin-argo-cd-backend:lint:      584 |       'permission denied: projects, delete, backstagetestmanual, sub: testuser18471, iat: 2022-04-13T12:28:34Z',
@roadiehq/backstage-plugin-argo-cd-backend:lint:      585 |     );
@roadiehq/backstage-plugin-argo-cd-backend:lint:      586 |   });
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      Replace toThrowError() with its canonical name of toThrow()
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      plugins/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts:703:32
@roadiehq/backstage-plugin-argo-cd-backend:lint:      701 |     });
@roadiehq/backstage-plugin-argo-cd-backend:lint:      702 | 
@roadiehq/backstage-plugin-argo-cd-backend:lint:    > 703 |     await expect(resp).rejects.toThrowError(
@roadiehq/backstage-plugin-argo-cd-backend:lint:          |                                ^
@roadiehq/backstage-plugin-argo-cd-backend:lint:      704 |       'Getting unauthorized for Argo CD instance https://argoInstance1.com',
@roadiehq/backstage-plugin-argo-cd-backend:lint:      705 |     );
@roadiehq/backstage-plugin-argo-cd-backend:lint:      706 |   });
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      plugins/backstage-plugin-argo-cd-backend/src/service/router.test.ts:108:35
@roadiehq/backstage-plugin-argo-cd-backend:lint:      106 |     });
@roadiehq/backstage-plugin-argo-cd-backend:lint:      107 | 
@roadiehq/backstage-plugin-argo-cd-backend:lint:    > 108 |     expect(mockCreateArgoProject).toBeCalledTimes(1);
@roadiehq/backstage-plugin-argo-cd-backend:lint:          |                                   ^
@roadiehq/backstage-plugin-argo-cd-backend:lint:      109 |     expect(mockCreateArgoApplication).toBeCalledTimes(1);
@roadiehq/backstage-plugin-argo-cd-backend:lint:      110 |     expect(response.body).toMatchObject({
@roadiehq/backstage-plugin-argo-cd-backend:lint:      111 |       argoAppName: 'test-app-nonprod',
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      plugins/backstage-plugin-argo-cd-backend/src/service/router.test.ts:109:39
@roadiehq/backstage-plugin-argo-cd-backend:lint:      107 | 
@roadiehq/backstage-plugin-argo-cd-backend:lint:      108 |     expect(mockCreateArgoProject).toBeCalledTimes(1);
@roadiehq/backstage-plugin-argo-cd-backend:lint:    > 109 |     expect(mockCreateArgoApplication).toBeCalledTimes(1);
@roadiehq/backstage-plugin-argo-cd-backend:lint:          |                                       ^
@roadiehq/backstage-plugin-argo-cd-backend:lint:      110 |     expect(response.body).toMatchObject({
@roadiehq/backstage-plugin-argo-cd-backend:lint:      111 |       argoAppName: 'test-app-nonprod',
@roadiehq/backstage-plugin-argo-cd-backend:lint:      112 |       argoProjectName: 'test-project',
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: ✘ 6 problems (6 errors, 0 warnings)
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: 
@roadiehq/backstage-plugin-argo-cd-backend:lint: Errors:
@roadiehq/backstage-plugin-argo-cd-backend:lint:   6  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd-backend:lint: error Command failed with exit code 1.
@roadiehq/backstage-plugin-argo-cd-backend:lint: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```