### PR TITLE
Docs | Fixed step output inside utils package

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -343,7 +343,7 @@ spec:
             - item1
         expression: '$ ~> | $ | { "items": [items, "item2"] }|'
   output:
-    result: ${{ steps.serialize.output.result }}
+    result: ${{ steps.jsonata.output.result }}
 ```
 
 Transform a JSON file:
@@ -369,7 +369,7 @@ spec:
         path: input-data.jaon
         expression: '$ ~> | $ | { "items": [items, "item2"] }|'
   output:
-    result: ${{ steps.serialize.output.result }}
+    result: ${{ steps.jsonata.output.result }}
 ```
 
 Transform a YAML file:
@@ -395,7 +395,7 @@ spec:
         path: input-data.yaml
         expression: '$ ~> | $ | { "items": [items, "item2"] }|'
   output:
-    result: ${{ steps.serialize.output.result }}
+    result: ${{ steps.jsonata.output.result }}
 ```
 
 ### Merge JSON


### PR DESCRIPTION
Inside the docs the wrong step was referred to inside the output
Linked to #1014 

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation (if applicable)
