### PR TITLE
fix(argo-frontend-plugin): skip helm revision metadata

### DIFF
--- a/.changeset/cool-coins-protect.md
+++ b/.changeset/cool-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Fix for cases where argo application history source is Helm, which would cause revision metadata api to return 500

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -41,6 +41,9 @@ export const useAppDetails = ({
   ) => {
     const promises: Promise<void>[] | undefined =
       appDetails.status?.history?.map(async (historyRecord: any) => {
+        if (historyRecord.helm !== undefined) {
+          return;
+        }
         const revisionID = historyRecord.revision;
         const revisionDetails = await api.getRevisionDetails({
           url,

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -41,7 +41,7 @@ export const useAppDetails = ({
   ) => {
     const promises: Promise<void>[] | undefined =
       appDetails.status?.history?.map(async (historyRecord: any) => {
-        if (historyRecord.helm !== undefined) {
+        if (historyRecord.source?.chart !== undefined) {
           return;
         }
         const revisionID = historyRecord.revision;

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -41,10 +41,11 @@ export const useAppDetails = ({
   ) => {
     const promises: Promise<void>[] | undefined =
       appDetails.status?.history?.map(async (historyRecord: any) => {
+        const revisionID = historyRecord.revision;
         if (historyRecord.source?.chart !== undefined) {
+          historyRecord.revision = { revisionID: revisionID };
           return;
         }
-        const revisionID = historyRecord.revision;
         const revisionDetails = await api.getRevisionDetails({
           url,
           app,


### PR DESCRIPTION
In cases where argo application history contains revisions that were deployed via helm, the api calls to `/api/v1/applications/{name}/revisions/{revision}/metadata` would return a 500. This is due to the call requiring the revision param to be a git sha, but in the case of helm it will be a version (and there would be no repo to read from.)

ArgoCD source for the above here: https://github.com/argoproj/argo-cd/blob/master/reposerver/repository/repository.go#L2154-L2156

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
