### PR TITLE
null values getting injected for apps with no revision history

### DIFF
--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -161,7 +161,9 @@ export const useAppDetails = ({
               return newItem;
             },
           );
-          return await Promise.all(getRevisionHistroyPromises);
+          return Promise.all(getRevisionHistroyPromises)
+            .then(result => result.filter(n => n))
+          ;
         }
         return result.filter(n => n);
       }

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -144,7 +144,7 @@ export const useAppDetails = ({
           },
         );
         const result = await Promise.all(getRevisionHistroyPromises);
-        return result;
+        return result.filter(n => n);
       }
       if (appSelector || projectName) {
         const result = await api.listApps({ url, appSelector, projectName });
@@ -163,7 +163,7 @@ export const useAppDetails = ({
           );
           return await Promise.all(getRevisionHistroyPromises);
         }
-        return result;
+        return result.filter(n => n);
       }
       return Promise.reject('Neither appName nor appSelector provided');
     } catch (e: any) {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -143,8 +143,8 @@ export const useAppDetails = ({
             return newItem;
           },
         );
-        const result = await Promise.all(getRevisionHistroyPromises);
-        return result.filter(n => n);
+        return Promise.all(getRevisionHistroyPromises)
+          .then(result => result.filter(n => n));
       }
       if (appSelector || projectName) {
         const result = await api.listApps({ url, appSelector, projectName });
@@ -162,8 +162,7 @@ export const useAppDetails = ({
             },
           );
           return Promise.all(getRevisionHistroyPromises)
-            .then(result => result.filter(n => n))
-          ;
+            .then(result => result.filter(n => n));
         }
         return result.filter(n => n);
       }

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -162,7 +162,7 @@ export const useAppDetails = ({
             },
           );
           return Promise.all(getRevisionHistroyPromises)
-            .then(result => result.filter(n => n));
+            .then(output => output.filter(n => n));
         }
         return result.filter(n => n);
       }


### PR DESCRIPTION
when using  "argocd/app-selector" the logic to pull the revision history is injecting null values if there is no history available for the argocd app and getting errors in the UI saying cannot read property of undefined, so fixed the issue by filtering out null values from the array
![Added undefined vaules in the result list](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/19810842/25900881-b1b4-48fb-9527-36900285241c)
![App with no history in items list](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/19810842/48ba8b02-16c8-4d95-b45e-6a862c914508)
![Error from UI](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/19810842/0d7279c4-5030-4ab8-9ea6-0713c583b469)
![UI after the fix](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/19810842/42603b38-fdec-4247-b3f5-5594dae646ff)


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
