### PR TITLE
Display confluence changes in activity stream

### DIFF
--- a/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/JiraCard.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/JiraCard/JiraCard.tsx
@@ -76,10 +76,11 @@ const CardProjectDetails = ({
 
 type JiraCardOptionalProps = {
   hideIssueFilter?: boolean;
+  displayConfluenceChanges?: boolean;
 };
 
 export const JiraCard = (props: EntityProps & JiraCardOptionalProps) => {
-  const { hideIssueFilter } = props;
+  const { hideIssueFilter, displayConfluenceChanges } = props;
   const { entity } = useEntity();
   const classes = useStyles();
   const { projectKey, component, tokenType, label } = useProjectEntity(entity);
@@ -188,7 +189,7 @@ export const JiraCard = (props: EntityProps & JiraCardOptionalProps) => {
             tokenType={tokenType}
             componentName={component}
             label={label}
-            ticketIds={ticketIds}
+            ticketIds={!displayConfluenceChanges ? ticketIds : undefined}
           />
         </div>
       ) : null}


### PR DESCRIPTION
Hello,

I can observe that plugin jira don't allow confluence changes to be displayed with activity stream : 
https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/frontend/backstage-plugin-jira/src/api/index.ts#L333

Display this changes could be interresting for me. That's why I want to provide a patch allowing to configure the jiraCard component to display confluence changes with activity stream.

Regards,
Stéphane MORI