### PR TITLE
Update AWSLambdaOverview.tsx

### DIFF
--- a/plugins/frontend/backstage-plugin-aws-lambda/src/components/AWSLambdaOverview/AWSLambdaOverview.tsx
+++ b/plugins/frontend/backstage-plugin-aws-lambda/src/components/AWSLambdaOverview/AWSLambdaOverview.tsx
@@ -44,6 +44,9 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 type States = 'Pending' | 'Active' | 'Inactive' | 'Failed';
 
 const useStyles = makeStyles(theme => ({
+  card: {
+    marginBottom: '2rem'
+  },
   links: {
     margin: theme.spacing(2, 0),
     display: 'grid',
@@ -135,7 +138,7 @@ const OverviewComponent = ({ lambda }: { lambda: LambdaData }) => {
 
   const classes = useStyles();
   return (
-    <Card>
+    <Card className={classes.card}>
       <CardHeader
         title={<Typography variant="h5">AWS Lambda</Typography>}
         subheader={
@@ -204,22 +207,36 @@ export const isAWSLambdaAvailable = (entity: Entity) =>
 
 const AWSLambdaOverview = ({ entity }: { entity: Entity }) => {
   const { lambdaName, lambdaRegion } = useServiceEntityAnnotations(entity);
-
-  const [lambdaData] = useLambda({
-    lambdaName,
-    region: lambdaRegion,
-  });
-  if (lambdaData.loading) {
+  const lambdaFunctions = lambdaName;
+    
     return (
-      <Card>
-        <CardHeader title={<Typography variant="h5">AWS Lambda</Typography>} />
-        <LinearProgress />
-      </Card>
-    );
-  }
-  return (
-    <>{lambdaData.lambda && <OverviewComponent lambda={lambdaData.lambda} />}</>
-  );
+      <>
+          {
+            lambdaFunctions.map(
+              (functionName, index) => {
+                const [lambdaData] = useLambda({
+                       lambdaName: functionName,
+                       region: lambdaRegion,
+                      });
+
+                if(lambdaData.loading) {
+                        return (
+                          <Card key={index}>
+                            <CardHeader title={<Typography variant="h5">AWS Lambda</Typography>} />
+                            <LinearProgress />
+                          </Card>
+                        );
+                     }
+                return (
+                          <>
+                            {lambdaData.lambda && 
+                              <OverviewComponent lambda={lambdaData.lambda} key={index} />}
+                          </>
+              );
+            })
+          }
+      </>
+  )
 };
 
 export const AWSLambdaOverviewWidget = () => {


### PR DESCRIPTION
Bug fix: Plugin problem identifying more than one lambda function by annotation.

![print2](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/59e8b693-562e-4bbb-b80a-6affa59a6683)

![print1](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/57c8474e-fa20-4e9c-b4c0-9c4030cc0acd)

According to the documentation, to add more than one function, just separate them with a comma, but when doing so, this error appears:

https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-aws-lambda

>1 validation error detected: Value 'teste-lambda-start,teste-lambda-stop' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-.]+)(:($LATEST|[a-zA-Z0-9-]+))?

Taking a look at the core of the plugin, it expects a string in this annotation:

```js
"properties" : {
    "aws.com/lambda-function-name": {"type":"string"}
    }
 ```

After:


![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/ea7c17ec-377c-495f-9042-4e6cfb0ea5ff)
hello, I made some small changes for the plugin to accept more than one function, separated only by a comma.

![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/af28d9c7-9d49-4575-a3d2-f84c6047f53f)


#### :heavy_check_mark: Checklist

- Adicionados testes para novas funcionalidades e testes de regressão para correções de bugs - [ ] Conjunto de alterações adicionado (execute `yarn changeset` na raiz) - [ ] Capturas de tela de antes e depois do anexo (para alterações na interface do usuário) - [ ] Documentação adicionada ou atualizada (se aplicável)
