### PR TITLE
Update useServiceEntityAnnotations.ts

### DIFF
--- a/plugins/frontend/backstage-plugin-aws-lambda/src/hooks/useServiceEntityAnnotations.ts
+++ b/plugins/frontend/backstage-plugin-aws-lambda/src/hooks/useServiceEntityAnnotations.ts
@@ -19,12 +19,14 @@ import { Entity } from '@backstage/catalog-model';
 export const AWS_LAMBDA_ANNOTATION = 'aws.com/lambda-function-name';
 export const AWS_LAMBDA_REGION_ANNOTATION = 'aws.com/lambda-region';
 export const useServiceEntityAnnotations = (entity: Entity) => {
-  const lambdaName =
+  const lambdaNamesString =
     entity?.metadata.annotations?.[AWS_LAMBDA_ANNOTATION] ?? '';
   const lambdaRegion =
     entity?.metadata.annotations?.[AWS_LAMBDA_REGION_ANNOTATION] ?? '';
   const projectName =
     entity?.metadata.annotations?.['github.com/project-slug'] ?? '';
+
+  const lambdaName = lambdaNamesString.includes(',') ? lambdaNamesString.split(',') : [lambdaNamesString];
 
   return {
     projectName,


### PR DESCRIPTION
Bug fix: Plugin problem identifying more than one lambda function by annotation.

![print2](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/59e8b693-562e-4bbb-b80a-6affa59a6683)

![print1](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/57c8474e-fa20-4e9c-b4c0-9c4030cc0acd)

According to the documentation, to add more than one function, just separate them with a comma, but when doing so, this error appears:

https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-aws-lambda

>1 validation error detected: Value 'teste-lambda-start,teste-lambda-stop' at 'functionName' failed to satisfy constraint: Member must satisfy regular expression pattern: (arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-.]+)(:($LATEST|[a-zA-Z0-9-]+))?

Taking a look at the core of the plugin, it expects a string in this annotation:

```js
"properties" : {
    "aws.com/lambda-function-name": {"type":"string"}
    }
 ```

After:


![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/ea7c17ec-377c-495f-9042-4e6cfb0ea5ff)
hello, I made some small changes for the plugin to accept more than one function, separated only by a comma.

![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/84424883/af28d9c7-9d49-4575-a3d2-f84c6047f53f)


#### :heavy_check_mark: Checklist

- Adicionados testes para novas funcionalidades e testes de regressão para correções de bugs - [ ] Conjunto de alterações adicionado (execute `yarn changeset` na raiz) - [ ] Capturas de tela de antes e depois do anexo (para alterações na interface do usuário) - [ ] Documentação adicionada ou atualizada (se aplicável)
