### PR TITLE
Jsonata action sp

### DIFF
--- a/.changeset/chilled-crews-grow.md
+++ b/.changeset/chilled-crews-grow.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+Minor documentation changes to JSONata actions for spelling and consistency wrt capitalization and punctuation

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
@@ -27,7 +27,7 @@ export function createJsonJSONataTransformAction() {
   }>({
     id: 'roadiehq:utils:jsonata:json:transform',
     description:
-      'Allows performing jsonata operations and transformations on a JSON file in the workspace. The result can be read from the `result` step output.',
+      'Allows performing JSONata operations and transformations on a JSON file in the workspace. The result can be read from the `result` step output.',
     supportsDryRun: true,
     schema: {
       input: {
@@ -36,7 +36,7 @@ export function createJsonJSONataTransformAction() {
         properties: {
           path: {
             title: 'Path',
-            description: 'Input path to read json file.',
+            description: 'Input path to read json file',
             type: 'string',
           },
           expression: {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/jsonata.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/jsonata.ts
@@ -23,7 +23,7 @@ export function createJSONataAction() {
   }>({
     id: 'roadiehq:utils:jsonata',
     description:
-      'Allows performing jsonata operations and transformations on input objects and produces the output result as a step output.',
+      'Allows performing JSONata operations and transformations on input objects and produces the output result as a step output.',
     schema: {
       input: {
         type: 'object',
@@ -31,7 +31,7 @@ export function createJSONataAction() {
         properties: {
           data: {
             title: 'Data',
-            description: 'Input data to perform JSONata expression.',
+            description: 'Input data to be transformed',
             type: [
               'object',
               'array',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/jsonata.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/jsonata.ts
@@ -23,7 +23,7 @@ export function createJSONataAction() {
   }>({
     id: 'roadiehq:utils:jsonata',
     description:
-      'Allows performing jsonata opterations and transformations on input objects and produces the output result as a step output.',
+      'Allows performing jsonata operations and transformations on input objects and produces the output result as a step output.',
     schema: {
       input: {
         type: 'object',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -28,7 +28,7 @@ export function createYamlJSONataTransformAction() {
   }>({
     id: 'roadiehq:utils:jsonata:yaml:transform',
     description:
-      'Allows performing jsonata operations and transformations on a YAML file in the workspace. The result can be read from the `result` step output.',
+      'Allows performing JSONata operations and transformations on a YAML file in the workspace. The result can be read from the `result` step output.',
     supportsDryRun: true,
     schema: {
       input: {
@@ -37,7 +37,7 @@ export function createYamlJSONataTransformAction() {
         properties: {
           path: {
             title: 'Path',
-            description: 'Input path to read yaml file.',
+            description: 'Input path to read yaml file',
             type: 'string',
           },
           expression: {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -28,7 +28,7 @@ export function createYamlJSONataTransformAction() {
   }>({
     id: 'roadiehq:utils:jsonata:yaml:transform',
     description:
-      'Allows performing jsonata opterations and transformations on a YAML file in the workspace. The result can be read from the `result` step output.',
+      'Allows performing jsonata operations and transformations on a YAML file in the workspace. The result can be read from the `result` step output.',
     supportsDryRun: true,
     schema: {
       input: {


### PR DESCRIPTION
Correctness and consistency among jsonata-related scaffolder actions. I could not see that a `changeset` script was in fact enabled in the project (nor can I find it in core Backstage anymore when I know I have created these in the past :/ ).

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
