### PR TITLE
Allow for backstage default mkdocs.yaml

### DIFF
--- a/.changeset/sharp-crabs-fail.md
+++ b/.changeset/sharp-crabs-fail.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': patch
+---
+
+Allow for backstage default mkdocs.yaml

--- a/utils/roadie-backstage-entity-validator/src/relativeSpaceValidation.js
+++ b/utils/roadie-backstage-entity-validator/src/relativeSpaceValidation.js
@@ -21,7 +21,10 @@ const validateTechDocs = async (data, filePath) => {
   }
   const techDocsAnnotation =
     data.metadata.annotations['backstage.io/techdocs-ref'];
-  if (!techDocsAnnotation.includes('dir') || techDocsAnnotation.match(/^dir:.$/gm)) {
+  if (
+    !techDocsAnnotation.includes('dir') ||
+    techDocsAnnotation.match(/^dir:.$/gm)
+  ) {
     return;
   }
 

--- a/utils/roadie-backstage-entity-validator/src/relativeSpaceValidation.js
+++ b/utils/roadie-backstage-entity-validator/src/relativeSpaceValidation.js
@@ -21,7 +21,7 @@ const validateTechDocs = async (data, filePath) => {
   }
   const techDocsAnnotation =
     data.metadata.annotations['backstage.io/techdocs-ref'];
-  if (!techDocsAnnotation.includes('dir')) {
+  if (!techDocsAnnotation.includes('dir') || techDocsAnnotation.match(/^dir:.$/gm)) {
     return;
   }
 

--- a/utils/roadie-backstage-entity-validator/src/validator.test.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.test.js
@@ -278,6 +278,32 @@ spec:
       validator.validateFromFile('invalid-resource-entity.yml'),
     ).rejects.toThrow();
   });
+  describe('validateDefaultTechDocs', () => {
+    const defaultVol = {
+      './test-entity.yaml': `
+      apiVersion: backstage.io/v1alpha1
+      kind: Component
+      metadata:
+        name: test-entity
+        description: |
+          Foo bar description
+        annotations:
+          backstage.io/techdocs-ref: dir:.
+      spec:
+        type: service
+        owner: user:dtuite
+        lifecycle: experimental
+      `,
+    };
+    describe('default techdocs annotations is set', () => {
+      it('should use the default mkdocs.yaml', async () => {
+        vol.fromJSON(defaultVol);
+        await expect(
+          validator.validateFromFile('./test-entity.yaml'),
+        ).resolves.toBeUndefined();
+      });
+    });
+  });
   describe('validateTechDocs', () => {
     const defaultVol = {
       './test-entity.yaml': `


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
Allows for backstage default mkocs.yaml that was introduced in v1.11.0

closes https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1050
#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
