### PR TITLE
Object results

### DIFF
--- a/.changeset/soft-forks-pull.md
+++ b/.changeset/soft-forks-pull.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+support object result in jsonata actions

--- a/.changeset/yellow-elephants-shop.md
+++ b/.changeset/yellow-elephants-shop.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+correct jsonata action tests' descriptions

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.test.ts
@@ -35,7 +35,7 @@ describe('roadiehq:utils:jsonata:json:transform', () => {
   };
   const action = createJsonJSONataTransformAction();
 
-  it('should output result of having applied the given transformation', async () => {
+  it('should output default string result of having applied the given transformation', async () => {
     mock({
       'fake-tmp-dir': {
         'fake-file.json': '{ "hello": ["world"] }',
@@ -54,5 +54,48 @@ describe('roadiehq:utils:jsonata:json:transform', () => {
       'result',
       JSON.stringify({ hello: ['world', 'item2'] }),
     );
+  });
+
+  it('should output string result of having applied the given transformation', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.json': '{ "hello": ["world"] }',
+      },
+    });
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.json',
+        expression: '$ ~> | $ | { "hello": [hello, "item2"] }|',
+        as: 'string',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'result',
+      JSON.stringify({ hello: ['world', 'item2'] }),
+    );
+  });
+
+  it('should output object result of having applied the given transformation', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.json': '{ "hello": ["world"] }',
+      },
+    });
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.json',
+        expression: '$ ~> | $ | { "hello": [hello, "item2"] }|',
+        as: 'object',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith('result', {
+      hello: ['world', 'item2'],
+    });
   });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Larder Software Limited
+ * Copyright 2023 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { getVoidLogger } from '@backstage/backend-common';
 import { createJsonJSONataTransformAction } from './json';
 import { PassThrough } from 'stream';
@@ -34,7 +35,7 @@ describe('roadiehq:utils:jsonata:json:transform', () => {
   };
   const action = createJsonJSONataTransformAction();
 
-  it('should write file to the workspacePath with the given transformation', async () => {
+  it('should output result of having applied the given transformation', async () => {
     mock({
       'fake-tmp-dir': {
         'fake-file.json': '{ "hello": ["world"] }',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
@@ -50,6 +50,7 @@ export function createJsonJSONataTransformAction() {
             description:
               'Permitted values are: "string" (default) and "object"',
             type: 'string',
+            enum: ['string', 'object'],
           },
           replacer: {
             title: 'Replacer',
@@ -77,12 +78,13 @@ export function createJsonJSONataTransformAction() {
       },
     },
     async handler(ctx) {
-      let post: (rz: any) => any;
+      let resultHandler: (rz: any) => any;
 
       if (ctx.input.as === 'object') {
-        post = rz => rz;
+        resultHandler = rz => rz;
       } else {
-        post = rz => JSON.stringify(rz, ctx.input.replacer, ctx.input.space);
+        resultHandler = rz =>
+          JSON.stringify(rz, ctx.input.replacer, ctx.input.space);
       }
       const sourceFilepath = resolveSafeChildPath(
         ctx.workspacePath,
@@ -93,7 +95,7 @@ export function createJsonJSONataTransformAction() {
       const expression = jsonata(ctx.input.expression);
       const result = expression.evaluate(data);
 
-      ctx.output('result', post(result));
+      ctx.output('result', resultHandler(result));
     },
   });
 }

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/json.ts
@@ -24,6 +24,7 @@ export function createJsonJSONataTransformAction() {
     expression: string;
     replacer?: string[];
     space?: string;
+    as?: 'string' | 'object';
   }>({
     id: 'roadiehq:utils:jsonata:json:transform',
     description:
@@ -42,6 +43,12 @@ export function createJsonJSONataTransformAction() {
           expression: {
             title: 'Expression',
             description: 'JSONata expression to perform on the input',
+            type: 'string',
+          },
+          as: {
+            title: 'Desired Result Type',
+            description:
+              'Permitted values are: "string" (default) and "object"',
             type: 'string',
           },
           replacer: {
@@ -64,12 +71,19 @@ export function createJsonJSONataTransformAction() {
         properties: {
           result: {
             title: 'Output result from JSONata',
-            type: 'object',
+            type: 'object | string',
           },
         },
       },
     },
     async handler(ctx) {
+      let post: (rz: any) => any;
+
+      if (ctx.input.as === 'object') {
+        post = rz => rz;
+      } else {
+        post = rz => JSON.stringify(rz, ctx.input.replacer, ctx.input.space);
+      }
       const sourceFilepath = resolveSafeChildPath(
         ctx.workspacePath,
         ctx.input.path,
@@ -77,13 +91,9 @@ export function createJsonJSONataTransformAction() {
 
       const data = JSON.parse(fs.readFileSync(sourceFilepath).toString());
       const expression = jsonata(ctx.input.expression);
-      const result = JSON.stringify(
-        expression.evaluate(data),
-        ctx.input.replacer,
-        ctx.input.space,
-      );
+      const result = expression.evaluate(data);
 
-      ctx.output('result', result);
+      ctx.output('result', post(result));
     },
   });
 }

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
@@ -36,7 +36,7 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
   };
   const action = createYamlJSONataTransformAction();
 
-  it('should output result of having applied the given transformation', async () => {
+  it('should output default string result of having applied the given transformation', async () => {
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': 'hello: [world]',
@@ -48,6 +48,28 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
       input: {
         path: 'fake-file.yaml',
         expression: '$ ~> | $ | { "hello": [hello, "item2"] }|',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'result',
+      yaml.dump({ hello: ['world', 'item2'] }),
+    );
+  });
+
+  it('should output string result of having applied the given transformation', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': 'hello: [world]',
+      },
+    });
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        expression: '$ ~> | $ | { "hello": [hello, "item2"] }|',
+        as: 'string',
       },
     });
 
@@ -91,5 +113,26 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
     });
 
     expect(mockDump).toHaveBeenCalledWith({ hello: 'beautiful world' }, opts);
+  });
+
+  it('should output object result of having applied the given transformation', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': 'hello: [world]',
+      },
+    });
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        expression: '$ ~> | $ | { "hello": [hello, "item2"] }|',
+        as: 'object',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith('result', {
+      hello: ['world', 'item2'],
+    });
   });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Larder Software Limited
+ * Copyright 2023 Larder Software Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { getVoidLogger } from '@backstage/backend-common';
 import { createYamlJSONataTransformAction } from './yaml';
 import { PassThrough } from 'stream';
@@ -35,7 +36,7 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
   };
   const action = createYamlJSONataTransformAction();
 
-  it('should write file to the workspacePath with the given transformation', async () => {
+  it('should output result of having applied the given transformation', async () => {
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': 'hello: [world]',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -51,6 +51,7 @@ export function createYamlJSONataTransformAction() {
             description:
               'Permitted values are: "string" (default) and "object"',
             type: 'string',
+            enum: ['string', 'object'],
           },
           options: yamlOptionsSchema,
         },
@@ -66,12 +67,12 @@ export function createYamlJSONataTransformAction() {
       },
     },
     async handler(ctx) {
-      let post: (rz: any) => any;
+      let resultHandler: (rz: any) => any;
 
       if (ctx.input.as === 'object') {
-        post = rz => rz;
+        resultHandler = rz => rz;
       } else {
-        post = rz => yaml.dump(rz, ctx.input.options);
+        resultHandler = rz => yaml.dump(rz, ctx.input.options);
       }
       const sourceFilepath = resolveSafeChildPath(
         ctx.workspacePath,
@@ -82,7 +83,7 @@ export function createYamlJSONataTransformAction() {
       const expression = jsonata(ctx.input.expression);
       const result = expression.evaluate(data);
 
-      ctx.output('result', post(result));
+      ctx.output('result', resultHandler(result));
     },
   });
 }

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.ts
@@ -25,6 +25,7 @@ export function createYamlJSONataTransformAction() {
     path: string;
     expression: string;
     options?: supportedDumpOptions;
+    as?: 'string' | 'object';
   }>({
     id: 'roadiehq:utils:jsonata:yaml:transform',
     description:
@@ -45,6 +46,12 @@ export function createYamlJSONataTransformAction() {
             description: 'JSONata expression to perform on the input',
             type: 'string',
           },
+          as: {
+            title: 'Desired Result Type',
+            description:
+              'Permitted values are: "string" (default) and "object"',
+            type: 'string',
+          },
           options: yamlOptionsSchema,
         },
       },
@@ -53,12 +60,19 @@ export function createYamlJSONataTransformAction() {
         properties: {
           result: {
             title: 'Output result from JSONata',
-            type: 'object',
+            type: 'object | string',
           },
         },
       },
     },
     async handler(ctx) {
+      let post: (rz: any) => any;
+
+      if (ctx.input.as === 'object') {
+        post = rz => rz;
+      } else {
+        post = rz => yaml.dump(rz, ctx.input.options);
+      }
       const sourceFilepath = resolveSafeChildPath(
         ctx.workspacePath,
         ctx.input.path,
@@ -66,9 +80,9 @@ export function createYamlJSONataTransformAction() {
 
       const data = yaml.load(fs.readFileSync(sourceFilepath).toString());
       const expression = jsonata(ctx.input.expression);
-      const result = yaml.dump(expression.evaluate(data), ctx.input.options);
+      const result = expression.evaluate(data);
 
-      ctx.output('result', result);
+      ctx.output('result', post(result));
     },
   });
 }


### PR DESCRIPTION
This PR builds on https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1053 which I hope will be accepted. I noticed that the result of the jsonata actions was documented as being of `object` type even though the Typescript seemed pretty adamant that the type was `string`. This PR adds an additional `as` input parameter which, when supplied the value `object` will set the action's result as the actual object returned from executing the JSONata `expression` against the specified `data` parameter, rather than encoding it back to the original format. Omitting `as` or specifying  `string` will trigger the original functionality.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
