### PR TITLE
chore: lint: Replace toThrowError() with its canonical name of toThrow()

### DIFF
--- a/.changeset/old-turtles-do.md
+++ b/.changeset/old-turtles-do.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+lint: Replace toThrowError() with its canonical name of toThrow()

--- a/.changeset/old-turtles-do.md
+++ b/.changeset/old-turtles-do.md
@@ -1,5 +1,0 @@
----
-'@roadiehq/backstage-plugin-argo-cd': patch
----
-
-lint: Replace toThrowError() with its canonical name of toThrow()

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.test.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.test.ts
@@ -67,6 +67,6 @@ describe('API calls', () => {
 
     const error = new Error('Need to provide appName or appSelector');
 
-    await expect(client.serviceLocatorUrl({})).rejects.toThrowError(error);
+    await expect(client.serviceLocatorUrl({})).rejects.toThrow(error);
   });
 });


### PR DESCRIPTION
Replace toThrowError() with its canonical name of toThrow()

https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-alias-methods.md

<!-- Please describe what these changes achieve -->

fixes linter issue

```
@roadiehq/backstage-plugin-argo-cd:lint:   ✘  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd:lint: 
@roadiehq/backstage-plugin-argo-cd:lint:      Replace toThrowError() with its canonical name of toThrow()
@roadiehq/backstage-plugin-argo-cd:lint: 
@roadiehq/backstage-plugin-argo-cd:lint: 
@roadiehq/backstage-plugin-argo-cd:lint:      plugins/backstage-plugin-argo-cd/src/api/index.test.ts:70:56
@roadiehq/backstage-plugin-argo-cd:lint:      68 |     const error = new Error('Need to provide appName or appSelector');
@roadiehq/backstage-plugin-argo-cd:lint:      69 | 
@roadiehq/backstage-plugin-argo-cd:lint:    > 70 |     await expect(client.serviceLocatorUrl({})).rejects.toThrowError(error);
@roadiehq/backstage-plugin-argo-cd:lint:         |                                                        ^
@roadiehq/backstage-plugin-argo-cd:lint:      71 |   });
@roadiehq/backstage-plugin-argo-cd:lint:      72 | });
@roadiehq/backstage-plugin-argo-cd:lint:      73 | 
@roadiehq/backstage-plugin-argo-cd:lint: 
@roadiehq/backstage-plugin-argo-cd:lint: ✘ 1 problem (1 error, 0 warnings)
@roadiehq/backstage-plugin-argo-cd:lint: 
@roadiehq/backstage-plugin-argo-cd:lint: 
@roadiehq/backstage-plugin-argo-cd:lint: Errors:
@roadiehq/backstage-plugin-argo-cd:lint:   1  https://google.com/#q=jest%2Fno-alias-methods
@roadiehq/backstage-plugin-argo-cd:lint: error Command failed with exit code 1.
@roadiehq/backstage-plugin-argo-cd:lint: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
