### PR TITLE
fix: return item when no history

### DIFF
--- a/.changeset/late-countries-judge.md
+++ b/.changeset/late-countries-judge.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-argocd': patch
+---
+
+fix: return item when no history on argo app

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -132,15 +132,14 @@ export const useAppDetails = ({
         };
         const getRevisionHistroyPromises = items.items.map(
           async (item: any) => {
-            let newItem;
             if (item?.status.history && item?.status.history.length > 0) {
-              newItem = getRevisionHistroyDetails(
+              return getRevisionHistroyDetails(
                 item,
                 item.metadata.name,
                 item.metadata.instance.name,
               );
             }
-            return newItem;
+            return item;
           },
         );
         return Promise.all(getRevisionHistroyPromises).then(result =>
@@ -155,11 +154,10 @@ export const useAppDetails = ({
           };
           const getRevisionHistroyPromises = apps.items.map(
             async (item: any) => {
-              let newItem;
               if (item?.status.history && item?.status.history.length > 0) {
-                newItem = getRevisionHistroyDetails(item, item.metadata.name);
+                return getRevisionHistroyDetails(item, item.metadata.name);
               }
-              return newItem;
+              return item;
             },
           );
           return Promise.all(getRevisionHistroyPromises).then(output =>

--- a/plugins/frontend/backstage-plugin-argo-cd/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/mocks/mocks.ts
@@ -364,11 +364,18 @@ export const getResponseStubAppListForInstanceTwo = () => {
 
 export const multipleApps = () => {
   const item = JSON.parse(JSON.stringify(getResponseStubScanning));
+
   const item1 = JSON.parse(JSON.stringify(item));
   item1.metadata.name = 'guestbook-prod';
+
   const item2 = JSON.parse(JSON.stringify(item));
   item2.metadata.name = 'guestbook-staging';
-  return [item1, item2];
+
+  const item3 = JSON.parse(JSON.stringify(item));
+  item3.metadata.name = 'guestbook-nohistory';
+  item3.status.history = [];
+
+  return [item1, item2, item3];
 };
 
 export const getResponseStubAppListWithMultipleApps = {
@@ -406,6 +413,23 @@ export class ArgoCDApiMock implements ArgoCDApi {
         {
           metadata: {
             name: 'guestbook-staging',
+          },
+          status: {
+            sync: {
+              status: 'OutOfSync',
+            },
+            health: {
+              status: 'Healthy',
+            },
+            operationState: {
+              startedAt: '2020-11-18T16:47:03Z',
+              finishedAt: '2020-11-18T16:47:04Z',
+            },
+          },
+        },
+        {
+          metadata: {
+            name: 'guestbook-nohistory',
           },
           status: {
             sync: {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/plugin.test.tsx
@@ -879,6 +879,19 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/name/guestbook-nohistory/revisions/6bed858de32a0e876ec49dad1a2e3c5840d3fb07/metadata',
+          (_, res, ctx) =>
+            res(
+              ctx.json({
+                author: 'testuser <testuser@test.com>',
+                date: '2023-03-20T18:44:10Z',
+                message: 'Update README.md',
+              }),
+            ),
+        ),
+      );
+      worker.use(
+        rest.get(
           'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name%3dguestbook',
           (_, res, ctx) =>
             res(ctx.json(getResponseStubAppListForInstanceTwo())),
@@ -908,9 +921,12 @@ describe('argo-cd', () => {
       expect(
         await rendered.findByText('guestbook-staging'),
       ).toBeInTheDocument();
+      expect(
+        await rendered.findByText('guestbook-nohistory'),
+      ).toBeInTheDocument();
 
       const apps = await rendered.findAllByText('argoInstance1');
-      expect(apps).toHaveLength(2);
+      expect(apps).toHaveLength(3);
       expect(await rendered.findByText('argoInstance2')).toBeInTheDocument();
     });
     it('should display fetched data from an instance when scanning multiple instances', async () => {
@@ -967,6 +983,19 @@ describe('argo-cd', () => {
       );
       worker.use(
         rest.get(
+          'https://testbackend.com/api/argocd/argoInstance/argoInstance1/applications/name/guestbook-nohistory/revisions/6bed858de32a0e876ec49dad1a2e3c5840d3fb07/metadata',
+          (_, res, ctx) =>
+            res(
+              ctx.json({
+                author: 'testuser <testuser@test.com>',
+                date: '2023-03-20T18:44:10Z',
+                message: 'Update README.md',
+              }),
+            ),
+        ),
+      );
+      worker.use(
+        rest.get(
           'https://testbackend.com/api/argocd/argoInstance/argoInstance2/applications/selector/name%3dguestbook',
           (_, res, ctx) => res(ctx.json(getEmptyResponseStub)),
         ),
@@ -982,9 +1011,12 @@ describe('argo-cd', () => {
       expect(
         await rendered.findByText('guestbook-staging'),
       ).toBeInTheDocument();
+      expect(
+        await rendered.findByText('guestbook-nohistory'),
+      ).toBeInTheDocument();
 
       const apps = await rendered.findAllByText('argoInstance1');
-      expect(apps).toHaveLength(2);
+      expect(apps).toHaveLength(3);
       expect(rendered.queryByText('argoInstance2')).toBeNull();
     });
     it('should display an empty table when receiving no data from multiple instances', async () => {


### PR DESCRIPTION
On the argocd plugin, when trying to display applications using app-selector, if the application status.history field is undefined, then the output was empty.

Following your logical in the case: `if (argoSearchMethod && appName)` (line 87 of the file useAppDetails.ts):
```
if (argoSearchMethod && appName) {
        const kubeInfo = await api.serviceLocatorUrl({
          appName: appName as string,
        });
        if (kubeInfo instanceof Error) return kubeInfo;
        const promises = kubeInfo.map(async (instance: any) => {
          const apiOut = await api.getAppDetails({
            url,
            appName,
            instance: instance.name,
          });
          if (!apiOut.metadata) {
            return {
              status: {
                history: [],
                sync: { status: 'Missing' },
                health: { status: 'Missing' },
                operationState: {},
              },
              metadata: { name: appName, instance: instance.name },
            };
          }
          apiOut.metadata.instance = instance;
          if (
            apiOut &&
            apiOut?.status &&
            apiOut?.status?.history &&
            apiOut?.status?.history.length > 0
          ) {
            return getRevisionHistroyDetails(apiOut, appName, instance.name);
          }
          return apiOut;
        });
```

I applied the same behavior for the following case: `if (appSelector || projectName)` line 159.


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
