### PR TITLE
Allow for multiple dashboard urls to be provided and rendered for a c…

### DIFF
--- a/.changeset/silly-pillows-yell.md
+++ b/.changeset/silly-pillows-yell.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-datadog': patch
+---
+
+Modify DatadogDashboardPage to allow for multiple comma-separated urls to be provided and rendered for a given component.

--- a/plugins/frontend/backstage-plugin-datadog/README.md
+++ b/plugins/frontend/backstage-plugin-datadog/README.md
@@ -103,7 +103,11 @@ metadata:
 
 ![dashboard share](./docs/dd-dashboard-share.png?raw=true)
 
-### Adding the annotations and the values from Datadog to your component's metadata file.
+- **Note**: You can also add multiple dashboards by creating a list of URLs in the annotation file (Each URL must be separated by a comma - `,` )
+
+### Adding the annotations and the values from Datadog to your component's metadata file
+
+#### Embedding a single dashboard
 
 ```yaml
 apiVersion: backstage.io/v1alpha1
@@ -114,6 +118,19 @@ metadata:
     A sample service
   annotations:
     datadoghq.com/dashboard-url: datadoghq.com
+```
+
+#### Embedding multiple dashboards
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sample-service
+  description: |
+    A sample service
+  annotations:
+    datadoghq.com/dashboard-url: datadoghq.com,datadoghq.com/dashboard2
 ```
 
 ## Embed a datadog graph in Backstage

--- a/plugins/frontend/backstage-plugin-datadog/src/components/DatadogDashboardPage.tsx
+++ b/plugins/frontend/backstage-plugin-datadog/src/components/DatadogDashboardPage.tsx
@@ -17,33 +17,41 @@
 import React from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { InfoCard } from '@backstage/core-components';
+import { Grid } from '@material-ui/core';
 import { useDatadogAppData } from './useDatadogAppData';
 import { Resizable } from 're-resizable';
 import ZoomOutMapIcon from '@material-ui/icons/ZoomOutMap';
 
 export const DatadogDashboardPage = ({ entity }: { entity: Entity }) => {
   const { dashboardUrl } = useDatadogAppData({ entity });
+  const allDashboardUrls: string[] = dashboardUrl.split(',');
   return (
-    <InfoCard title="Datadog dashboard">
-      <Resizable
-        defaultSize={{
-          width: '100%',
-          height: 500,
-        }}
-        handleComponent={{ bottomRight: <ZoomOutMapIcon /> }}
-      >
-        <iframe
-          title="dashboard"
-          src={`${dashboardUrl}`}
-          style={{
-            border: 'none',
-            height: '100%',
-            width: '100%',
-            resize: 'both',
-            overflow: 'auto',
-          }}
-        />
-      </Resizable>
-    </InfoCard>
+    <Grid container spacing={3}>
+      {allDashboardUrls.map((value, index) => (
+        <Grid item md={12}>
+          <InfoCard title={`Datadog dashboard ${index}`} variant="gridItem">
+            <Resizable
+              defaultSize={{
+                width: 100,
+                height: 500,
+              }}
+              handleComponent={{ bottomRight: <ZoomOutMapIcon /> }}
+            >
+              <iframe
+                title="dashboard"
+                src={`${value}`}
+                style={{
+                  border: 'none',
+                  height: '100%',
+                  width: '100%',
+                  resize: 'both',
+                  overflow: 'auto',
+                }}
+              />
+            </Resizable>
+          </InfoCard>
+        </Grid>
+      ))}
+    </Grid>
   );
 };


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
The current Datadog plugin only allows for a single dashboard to be rendered through the `datadoghq.com/dashboard-url:` annotation.  There are going to be use-cases where a certain component will have multiple dashboards that need to be displayed through the plugin. This change allows for a comma-separated list of dashboard URLs to be passed through this annotation and rendered on the component page.
#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
