### PR TITLE
Account for multiline comments in markdown content

### DIFF
--- a/.changeset/witty-garlics-tap.md
+++ b/.changeset/witty-garlics-tap.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-github-insights': patch
+---
+
+The `MarkdownContent` component currently removes only single line comments if `preserveHtmlComments` is not set.
+This change accounts for single line and multiline HTML comments

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/MarkdownContent/MarkdownContent.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/MarkdownContent/MarkdownContent.tsx
@@ -86,7 +86,7 @@ const GithubFileContent = (props: MarkdownContentProps) => {
 
   let content = value.content;
   if (!preserveHtmlComments) {
-    content = content.replace(/<!--.*?-->/g, '');
+    content = content.replace(/<!--(.|\n)*?-->/g, '');
   }
 
   return (


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

The `MarkdownContent` component currently removes only single line comments if `preserveHtmlComments` is not set.
This change accounts for single line and multiline HTML comments

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
