### PR TITLE
fix: return item when no history

### DIFF
--- a/.changeset/clean-cobras-shop.md
+++ b/.changeset/clean-cobras-shop.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+fix: return item when no history


### PR DESCRIPTION
In the pr https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1105 I made a mistake in the package selection with changeset.


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
