### PR TITLE
Explicitly define protocol in links

### DIFF
--- a/.changeset/nervous-papayas-heal.md
+++ b/.changeset/nervous-papayas-heal.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-insights': patch
+---
+
+Explicitly define protocol for component links instead of protocol-less

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
@@ -68,11 +68,13 @@ const ContributorsCard = () => {
     <InfoCard
       title="Contributors"
       deepLink={{
-        link: `//${hostname}/${owner}/${repo}/graphs/contributors`,
+        link: `https://${hostname}/${owner}/${repo}/graphs/contributors`,
         title: 'People',
         onClick: e => {
           e.preventDefault();
-          window.open(`//${hostname}/${owner}/${repo}/graphs/contributors`);
+          window.open(
+            `https://${hostname}/${owner}/${repo}/graphs/contributors`,
+          );
         },
       }}
       className={classes.infoCard}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/components/ContributorTooltipContent/ContributorTooltipContent.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/components/ContributorTooltipContent/ContributorTooltipContent.tsx
@@ -65,7 +65,7 @@ const ContributorTooltipContent = ({ contributorLogin }: Props) => {
         <Grid item xs={12}>
           <Typography variant="h6">
             <Link
-              href={`//${hostname}/${contributor.login}`}
+              href={`https://${hostname}/${contributor.login}`}
               color="inherit"
               target="_blank"
               rel="noopener noreferrer"

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/EnvironmentsCard/EnvironmentsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/EnvironmentsCard/EnvironmentsCard.tsx
@@ -67,11 +67,11 @@ const EnvironmentsCard = () => {
     <InfoCard
       title="Environments"
       deepLink={{
-        link: `//${hostname}/${owner}/${repo}/deployments`,
+        link: `https://${hostname}/${owner}/${repo}/deployments`,
         title: 'Environments',
         onClick: e => {
           e.preventDefault();
-          window.open(`//${hostname}/${owner}/${repo}/deployments`);
+          window.open(`https://${hostname}/${owner}/${repo}/deployments`);
         },
       }}
       className={classes.infoCard}

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReadMeCard/ReadMeCard.tsx
@@ -70,11 +70,13 @@ const ReadMeCard = (props: ReadMeCardProps) => {
       title={props.title || 'Readme'}
       className={classes.infoCard}
       deepLink={{
-        link: `//${hostname}/${owner}/${repo}/blob/HEAD/${linkPath}`,
+        link: `https://${hostname}/${owner}/${repo}/blob/HEAD/${linkPath}`,
         title: 'Readme',
         onClick: e => {
           e.preventDefault();
-          window.open(`//${hostname}/${owner}/${repo}/blob/HEAD/${linkPath}`);
+          window.open(
+            `https://${hostname}/${owner}/${repo}/blob/HEAD/${linkPath}`,
+          );
         },
       }}
     >

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ReleasesCard/ReleasesCard.tsx
@@ -70,11 +70,11 @@ const ReleasesCard = () => {
     <InfoCard
       title="Releases"
       deepLink={{
-        link: `//${hostname}/${owner}/${repo}/releases`,
+        link: `https://${hostname}/${owner}/${repo}/releases`,
         title: 'Releases',
         onClick: e => {
           e.preventDefault();
-          window.open(`//${hostname}/${owner}/${repo}/releases`);
+          window.open(`https://${hostname}/${owner}/${repo}/releases`);
         },
       }}
       className={classes.infoCard}


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

This updates the `github-insights` plugin to explicitly define the protocol on external links instead of being protocol-less.
When implementing the plugin the underlying `InfoCard` was removing the first slash which made this a relative link (ex. `/github.com/...` instead of `//github.com/...`.
This caused it to try to open in the Backstage app instead of GitHub.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
