### PR TITLE
add templating to select field from api

### DIFF
--- a/.changeset/light-dragons-check.md
+++ b/.changeset/light-dragons-check.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/plugin-scaffolder-frontend-module-http-request-field': minor
+---
+
+Allow parameters to be used for the select field options.

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/package.json
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/package.json
@@ -40,6 +40,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.45",
     "@rjsf/core": "^3.0.1",
+    "nunjucks": "^3.2.3",
     "zod": "^3.19.1",
     "lodash": "^4.17.21",
     "react-use": "^17.2.4"
@@ -57,6 +58,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/jest": "*",
     "@types/node": "*",
+    "@types/nunjucks": "^3.2.3",
     "msw": "^1.0.1",
     "cross-fetch": "^3.1.5"
   },

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.test.tsx
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.test.tsx
@@ -52,7 +52,10 @@ describe('SelectFieldFromApi', () => {
       json: jest.fn().mockResolvedValue(['result1', 'result2']),
     });
     const uiSchema = { 'ui:options': { path: '/test-endpoint' } };
-    const props = { uiSchema } as unknown as FieldProps<string>;
+    const props = {
+      uiSchema,
+      formContext: { formData: {} },
+    } as unknown as FieldProps<string>;
     const { getByTestId, getByText } = await renderWithEffects(
       wrapInTestApp(
         <TestApiProvider apis={apis}>
@@ -75,7 +78,10 @@ describe('SelectFieldFromApi', () => {
     const uiSchema = {
       'ui:options': { path: '/test-endpoint', arraySelector: 'myarray' },
     };
-    const props = { uiSchema } as unknown as FieldProps<string>;
+    const props = {
+      uiSchema,
+      formContext: { formData: {} },
+    } as unknown as FieldProps<string>;
     const { getByTestId, getByText } = await renderWithEffects(
       wrapInTestApp(
         <TestApiProvider apis={apis}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11373,7 +11373,7 @@
 
 "@types/nunjucks@^3.2.3":
   version "3.2.3"
-  resolved "https://roadiehq.jfrog.io/artifactory/api/npm/roadiehq/@types/nunjucks/-/nunjucks-3.2.3.tgz#994e68cb575c3ac1be27e6f99543183b3c3605aa"
+  resolved "https://registry.yarnpkg.com/@types/nunjucks/-/nunjucks-3.2.3.tgz#994e68cb575c3ac1be27e6f99543183b3c3605aa"
   integrity sha512-+lFIql0nbWSftazQ27cOYvSLC92SsfjxrU0I/Iys7hoxrBkN8OF+wmxxzx3bLFyFrLgDZ9lUckGcwldE4SfDQA==
 
 "@types/oauth@*":

--- a/yarn.lock
+++ b/yarn.lock
@@ -11371,6 +11371,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/nunjucks@^3.2.3":
+  version "3.2.3"
+  resolved "https://roadiehq.jfrog.io/artifactory/api/npm/roadiehq/@types/nunjucks/-/nunjucks-3.2.3.tgz#994e68cb575c3ac1be27e6f99543183b3c3605aa"
+  integrity sha512-+lFIql0nbWSftazQ27cOYvSLC92SsfjxrU0I/Iys7hoxrBkN8OF+wmxxzx3bLFyFrLgDZ9lUckGcwldE4SfDQA==
+
 "@types/oauth@*":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@types/oauth/-/oauth-0.9.1.tgz#e17221e7f7936b0459ae7d006255dff61adca305"


### PR DESCRIPTION
add templating to select field from api

- the select field from api, must be on the page after the field/s that it depends on.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
