### PR TITLE
Adds support for Applications in any namespace

### DIFF
--- a/.changeset/ninety-starfishes-compare.md
+++ b/.changeset/ninety-starfishes-compare.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Adds support for Applications in any namespace (as per https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/)

--- a/.changeset/ninety-starfishes-compare.md
+++ b/.changeset/ninety-starfishes-compare.md
@@ -1,5 +1,5 @@
 ---
-'@roadiehq/backstage-plugin-argo-cd': patch
+'@roadiehq/backstage-plugin-argo-cd': minor
 ---
 
 Adds support for Applications in any namespace (as per https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/)

--- a/plugins/frontend/backstage-plugin-argo-cd/README.md
+++ b/plugins/frontend/backstage-plugin-argo-cd/README.md
@@ -145,6 +145,26 @@ The Argo plugin will fetch the Argo CD instances an app is deployed to and use t
 
 Please visit the [Argo CD Backend Plugin](https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd-backend) for more information
 
+## Support for apps in any namespace beta feature
+
+If you want to use the "Applications in any namespace" beta [feature](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/), you have to explicitly enable it in the configuration.
+
+In the configuration file, you need to toggle the feature:
+
+```yaml
+argocd:
+  ...
+  namespacedApps: true
+```
+
+After enabling the feature, you can use the newly available `argocd/app-namespace` annotation on entities:
+
+```yaml
+metadata:
+  annotations:
+    argocd/app-namespace: my-test-ns
+```
+
 ## Develop plugin locally
 
 You can run the application by running `yarn dev` at the root of this monorepo.

--- a/plugins/frontend/backstage-plugin-argo-cd/config.d.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/config.d.ts
@@ -7,6 +7,11 @@ export interface Config {
      */
     baseUrl?: string;
     /**
+     * Support for the ArgoCD beta feature "Applications in any namespace"
+     * @visibility frontend
+     */
+    namespacedApps?: boolean;
+    /**
      * The base url of the ArgoCD instance.
      * @visibility frontend
      */

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.test.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.test.ts
@@ -27,13 +27,17 @@ describe('API calls', () => {
       backendBaseUrl: '',
       searchInstances: true,
       identityApi: getIdentityApiStub,
+      useNamespacedApps: false,
     });
 
-    const response = await client.serviceLocatorUrl({ appName: 'test' });
+    const response = await client.serviceLocatorUrl({
+      appName: 'test',
+      appNamespace: 'my-test-ns',
+    });
 
     // Let's verify the fetch was called with the requested URL and Authorization header
     expect(global.fetch).toHaveBeenCalledWith(
-      expect.anything(),
+      expect.not.stringMatching('appNamespace'),
       expect.objectContaining({
         headers: {
           'Content-Type': 'application/json',
@@ -51,6 +55,7 @@ describe('API calls', () => {
       backendBaseUrl: '',
       searchInstances: true,
       identityApi: getIdentityApiStub,
+      useNamespacedApps: false,
     });
 
     const response = await client.serviceLocatorUrl({ appName: 'test' });
@@ -63,10 +68,39 @@ describe('API calls', () => {
       backendBaseUrl: '',
       searchInstances: true,
       identityApi: getIdentityApiStub,
+      useNamespacedApps: false,
     });
 
     const error = new Error('Need to provide appName or appSelector');
 
     await expect(client.serviceLocatorUrl({})).rejects.toThrow(error);
+  });
+
+  it('serviceLocatorUrl: fetches namespaced applications', async () => {
+    const client = new ArgoCDApiClient({
+      discoveryApi: getDiscoveryApiStub,
+      backendBaseUrl: '',
+      searchInstances: true,
+      identityApi: getIdentityApiStub,
+      useNamespacedApps: true,
+    });
+
+    const response = await client.serviceLocatorUrl({
+      appName: 'test',
+      appNamespace: 'my-test-ns',
+    });
+
+    // Let's verify the fetch was called with the requested URL and Authorization header
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringMatching('appNamespace=my-test-ns'),
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer fake-id-token`,
+        },
+      }),
+    );
+
+    expect(response).toEqual(getServiceListStub);
   });
 });

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -202,7 +202,7 @@ export class ArgoCDApiClient implements ArgoCDApi {
           options.instance
         }/applications/name/${encodeURIComponent(
           options.appName as string,
-        )}?${query}`,
+        )}${query}`,
         argoCDAppDetails,
       );
     }

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
@@ -230,13 +230,15 @@ const ArgoCDDetails = ({
   entity: Entity;
   extraColumns: TableColumn[];
 }) => {
-  const { url, appName, appSelector, projectName } = useArgoCDAppData({
-    entity,
-  });
+  const { url, appName, appSelector, appNamespace, projectName } =
+    useArgoCDAppData({
+      entity,
+    });
   const { loading, value, error, retry } = useAppDetails({
     url,
     appName,
     appSelector,
+    appNamespace,
     projectName,
   });
   if (loading) {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
@@ -45,6 +45,8 @@ const HistoryTable = ({
 }) => {
   const configApi = useApi(configApiRef);
   const baseUrl = configApi.getOptionalString('argocd.baseUrl');
+  const namespaced =
+    configApi.getOptionalBoolean('argocd.namespacedApps') ?? false;
   const supportsMultipleArgoInstances: boolean = Boolean(
     configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length,
   );
@@ -57,6 +59,7 @@ const HistoryTable = ({
             return app.status.history.map(entry => {
               return {
                 app: app.metadata.name,
+                appNamespace: app.metadata.namespace,
                 instance: app.metadata?.instance?.name,
                 ...entry,
               };
@@ -74,7 +77,9 @@ const HistoryTable = ({
       render: (row: any): React.ReactNode =>
         baseUrl ? (
           <Link
-            href={`${baseUrl}/applications/${row.app}`}
+            href={`${baseUrl}/applications/${
+              namespaced ? `${row.appNamespace}/${row.app}` : row.app
+            }`}
             target="_blank"
             rel="noopener"
           >
@@ -168,13 +173,15 @@ const HistoryTable = ({
 };
 
 const ArgoCDHistory = ({ entity }: { entity: Entity }) => {
-  const { url, appName, appSelector, projectName } = useArgoCDAppData({
-    entity,
-  });
+  const { url, appName, appSelector, appNamespace, projectName } =
+    useArgoCDAppData({
+      entity,
+    });
   const { loading, value, error, retry } = useAppDetails({
     url,
     appName,
     appSelector,
+    appNamespace,
     projectName,
   });
   if (loading) {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
@@ -11,6 +11,7 @@ import { StructuredMetadataTable } from '@backstage/core-components';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import CloseIcon from '@material-ui/icons/Close';
 import MaterialButton from '@material-ui/core/Button';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 interface TableContent {
   [key: string]: any;
@@ -43,6 +44,10 @@ export const DetailsDrawerComponent = (
 ) => {
   const classes = useStyles();
   const [state, setState] = React.useState(false);
+  const configApi = useApi(configApiRef);
+  const namespaced =
+    configApi.getOptionalBoolean('argocd.namespacedApps') ?? false;
+
   const toggleDrawer =
     (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
       if (
@@ -72,7 +77,11 @@ export const DetailsDrawerComponent = (
           title="Open Argo CD Dashboard"
           endIcon={<OpenInNewIcon />}
           target="_blank"
-          href={`${baseUrl}/applications/${rowData.metadata.name}`}
+          href={`${baseUrl}/applications/${
+            namespaced
+              ? `${rowData.metadata.namespace}/${rowData.metadata.name}`
+              : rowData.metadata.name
+          }`}
         >
           Open Argo CD Dashboard
         </MaterialButton>

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useArgoCDAppData.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useArgoCDAppData.ts
@@ -18,6 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 
 export const ARGOCD_ANNOTATION_APP_NAME = 'argocd/app-name';
 export const ARGOCD_ANNOTATION_APP_SELECTOR = 'argocd/app-selector';
+export const ARGOCD_ANNOTATION_APP_NAMESPACE = 'argocd/app-namespace';
 export const ARGOCD_ANNOTATION_PROJECT_NAME = 'argocd/project-name';
 export const ARGOCD_ANNOTATION_PROXY_URL = 'argocd/proxy-url';
 
@@ -26,6 +27,8 @@ export const useArgoCDAppData = ({ entity }: { entity: Entity }) => {
     entity?.metadata.annotations?.[ARGOCD_ANNOTATION_APP_NAME] ?? '';
   const appSelector =
     entity?.metadata.annotations?.[ARGOCD_ANNOTATION_APP_SELECTOR] ?? '';
+  const appNamespace =
+    entity?.metadata.annotations?.[ARGOCD_ANNOTATION_APP_NAMESPACE];
   const projectName =
     entity?.metadata.annotations?.[ARGOCD_ANNOTATION_PROJECT_NAME];
   const url =
@@ -38,5 +41,5 @@ export const useArgoCDAppData = ({ entity }: { entity: Entity }) => {
       "Cannot provide both 'argocd/app-name' and 'argocd-app' annotations",
     );
   }
-  return { url, appName, appSelector, projectName };
+  return { url, appName, appSelector, appNamespace, projectName };
 };

--- a/plugins/frontend/backstage-plugin-argo-cd/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/mocks/mocks.ts
@@ -26,6 +26,31 @@ export const getEntityStub = {
   },
 };
 
+export const getEntityStubWithAppNamespace = {
+  metadata: {
+    namespace: 'default',
+    annotations: {
+      'backstage.io/managed-by-location':
+        'url:https://github.com/mcalus3/sample-service/blob/master/backstage.yaml',
+      'argocd/app-name': 'namespaced-guestbook',
+      'argocd/app-namespace': 'my-test-ns',
+    },
+    name: 'sample-service',
+    description:
+      'A service for testing Backstage functionality. For example, we can trigger errors\non the sample-service, these are sent to Sentry, then we can view them in the \nBackstage plugin for Sentry.\n',
+    uid: 'e8a73cc9-21d4-449e-b97a-5d3ce0b21323',
+    etag: 'ZmJkOGVkYjktMDM1ZS00YWIzLTkxMWQtMjI5MDk3N2I5M2Rm',
+    generation: 1,
+  },
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  spec: {
+    type: 'service',
+    owner: 'david@roadie.io',
+    lifecycle: 'experimental',
+  },
+};
+
 export const getEntityStubWithAppSelector = {
   metadata: {
     namespace: 'default',
@@ -66,6 +91,143 @@ export const getResponseStub = {
   metadata: {
     name: 'guestbook',
     namespace: 'argocd',
+    selfLink:
+      '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
+    uid: 'f959d66b-9ef2-4819-a1f2-f35874b61303',
+    resourceVersion: '7277391',
+    generation: 23872,
+    creationTimestamp: '2020-11-18T16:45:56Z',
+    managedFields: [
+      {
+        manager: 'argocd-server',
+        operation: 'Update',
+        apiVersion: 'argoproj.io/v1alpha1',
+        time: '2020-11-20T19:28:06Z',
+      },
+      {
+        manager: 'argocd-application-controller',
+        operation: 'Update',
+        apiVersion: 'argoproj.io/v1alpha1',
+        time: '2021-01-07T08:38:15Z',
+      },
+    ],
+  },
+  spec: {
+    source: {
+      repoURL: 'https://github.com/argoproj/argocd-example-apps',
+      path: 'guestbook',
+      targetRevision: 'HEAD',
+    },
+    destination: {
+      server: 'https://kubernetes.default.svc',
+      namespace: 'default',
+    },
+    project: 'default',
+  },
+  status: {
+    resources: [
+      {
+        version: 'v1',
+        kind: 'Service',
+        namespace: 'default',
+        name: 'guestbook-ui',
+        status: 'Synced',
+        health: { status: 'Healthy' },
+      },
+      {
+        group: 'apps',
+        version: 'v1',
+        kind: 'Deployment',
+        namespace: 'default',
+        name: 'guestbook-ui',
+        status: 'Synced',
+        health: { status: 'Healthy' },
+      },
+    ],
+    sync: {
+      status: 'Synced',
+      comparedTo: {
+        source: {
+          repoURL: 'https://github.com/argoproj/argocd-example-apps',
+          path: 'guestbook',
+          targetRevision: 'HEAD',
+        },
+        destination: {
+          server: 'https://kubernetes.default.svc',
+          namespace: 'default',
+        },
+      },
+      revision: '6bed858de32a0e876ec49dad1a2e3c5840d3fb07',
+    },
+    health: { status: 'Healthy' },
+    history: [
+      {
+        revision: '6bed858de32a0e876ec49dad1a2e3c5840d3fb07',
+        deployStartedAt: '2020-11-18T16:47:02Z',
+        deployedAt: '2020-11-18T16:47:04Z',
+        id: 0,
+        source: {
+          repoURL: 'https://github.com/argoproj/argocd-example-apps',
+          path: 'guestbook',
+          targetRevision: 'HEAD',
+        },
+      },
+    ],
+    reconciledAt: '2021-01-07T08:38:15Z',
+    operationState: {
+      operation: {
+        sync: {
+          revision: '6bed858de32a0e876ec49dad1a2e3c5840d3fb07',
+          syncStrategy: {},
+        },
+      },
+      phase: 'Succeeded',
+      message: 'successfully synced (all tasks run)',
+      syncResult: {
+        resources: [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Service',
+            namespace: 'default',
+            name: 'guestbook-ui',
+            status: 'Synced',
+            message: 'service/guestbook-ui created',
+            hookPhase: 'Running',
+            syncPhase: 'Sync',
+          },
+          {
+            group: 'apps',
+            version: 'v1',
+            kind: 'Deployment',
+            namespace: 'default',
+            name: 'guestbook-ui',
+            status: 'Synced',
+            message: 'deployment.apps/guestbook-ui created',
+            hookPhase: 'Running',
+            syncPhase: 'Sync',
+          },
+        ],
+        revision: '6bed858de32a0e876ec49dad1a2e3c5840d3fb07',
+        source: {
+          repoURL: 'https://github.com/argoproj/argocd-example-apps',
+          path: 'guestbook',
+          targetRevision: 'HEAD',
+        },
+      },
+      startedAt: '2020-11-18T16:47:03Z',
+      finishedAt: '2020-11-18T16:47:04Z',
+    },
+    observedAt: '2021-01-07T08:38:15Z',
+    sourceType: 'Directory',
+    summary: { images: ['gcr.io/heptio-images/ks-guestbook-demo:0.2'] },
+  },
+};
+
+export const getResponseStubNamespaced = {
+  metadata: {
+    name: 'namespaced-guestbook',
+    namespace: 'my-test-ns',
     selfLink:
       '/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/guestbook',
     uid: 'f959d66b-9ef2-4819-a1f2-f35874b61303',

--- a/plugins/frontend/backstage-plugin-argo-cd/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/plugin.ts
@@ -29,6 +29,9 @@ export const argocdPlugin = createPlugin({
           discoveryApi,
           identityApi,
           backendBaseUrl: configApi.getString('backend.baseUrl'),
+          useNamespacedApps: Boolean(
+            configApi.getOptionalBoolean('argocd.namespacedApps'),
+          ),
           searchInstances: Boolean(
             configApi.getOptionalConfigArray('argocd.appLocatorMethods')
               ?.length,

--- a/plugins/frontend/backstage-plugin-argo-cd/src/types.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/types.ts
@@ -8,6 +8,7 @@ export const argoCDAppDeployRevisionDetails = t.type({
 export const argoCDAppDetails = t.type({
   metadata: t.type({
     name: t.string,
+    namespace: t.string,
     instance: t.union([
       t.type({
         name: t.union([t.string, t.undefined]),


### PR DESCRIPTION
I've added support for namespaced applications in Argo CD (issue #1068 and #1038). I've added it all under a feature flag argocd.namespacedApps.

I do think it needs documentation for the functionality. At least the part enabling the functionality:
```yaml
[app-config.yaml]
argocd:
  namespacedApps: true
```

And how to use new annotation:
```yaml
[entity.yaml]
...
metadata:
  annotations:
    argocd/app-namespace: my-test-ns
```

should be available somwhere, but I'm not sure if you want it in the readme file or perhaps somewhere else to keep things clean.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
