### PR TITLE
fix: forward aws-ecr errors

### DIFF
--- a/.changeset/funny-shirts-accept.md
+++ b/.changeset/funny-shirts-accept.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-aws': patch
+---
+
+Return AWS ECR errors

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/ecr/create.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/src/actions/ecr/create.ts
@@ -96,6 +96,7 @@ export function createEcrAction(options?: {
       } catch (e) {
         assertError(e);
         ctx.logger.warn(`Unable to create ECR repository: ${e}`);
+        throw e;
       }
     },
   });


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
Return errors from AWS ECR create action to prevent scaffolding broken projects.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
