### PR TITLE
Updated to use @backstage/plugin-home-react

### DIFF
--- a/.changeset/big-readers-ring.md
+++ b/.changeset/big-readers-ring.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Updated to use `@backstage/plugin-home-react` instead of `@backstage/plugin-home`

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -39,7 +39,7 @@
     "@backstage/core-components": "^0.13.5",
     "@backstage/core-plugin-api": "^1.6.0",
     "@backstage/plugin-catalog-react": "^1.8.4",
-    "@backstage/plugin-home": "^0.5.8",
+    "@backstage/plugin-home-react": "^0.1.3",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/plugin.ts
@@ -21,7 +21,7 @@ import {
   createRoutableExtension,
   createComponentExtension,
 } from '@backstage/core-plugin-api';
-import { createCardExtension } from '@backstage/plugin-home';
+import { createCardExtension } from '@backstage/plugin-home-react';
 
 import { githubPullRequestsApiRef, GithubPullRequestsClient } from './api';
 


### PR DESCRIPTION
Updated @roadiehq/backstage-plugin-github-pull-requests to use @backstage/plugin-home-react instead of @backstage/plugin-home

Closes https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1114 and https://github.com/backstage/backstage/issues/20196

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
