### PR TITLE
Update PullRequestsListView to fit full height

### DIFF
--- a/.changeset/dull-cars-clap.md
+++ b/.changeset/dull-cars-clap.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Updated `PullRequestsListView` to fit the full height of the content it is in

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsListView/PullRequestsListView.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsListView/PullRequestsListView.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
     border: '1px solid grey',
     borderRadius: '6px',
     overflowY: 'auto',
-    maxHeight: '18rem',
+    maxHeight: '100%',
   },
   pullRequestRow: {
     paddingTop: '0.5rem',


### PR DESCRIPTION
Updated `PullRequestsListView` to fit the full height of the content it is in, for example:

| Before  | After  |  
|---|---|
| <img width="617" alt="Screenshot 2023-10-05 at 9 31 27 PM" src="https://github.com/RoadieHQ/roadie-backstage-plugins/assets/67169551/907d0f6f-7829-4d04-9986-557a8d7d74e4"> | <img width="610" alt="Screenshot 2023-10-05 at 9 31 47 PM" src="https://github.com/RoadieHQ/roadie-backstage-plugins/assets/67169551/bdfb3487-7779-42bb-a8b3-3ae7d1f3ca29">  |  

Showing the skeletons in the screenshots as it's the easiest way to obfuscate sensitive PR content

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
