### PR TITLE
feat: add `uiUrl` as config to enable links to Prometheus

### DIFF
--- a/.changeset/smart-crews-trade.md
+++ b/.changeset/smart-crews-trade.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-prometheus': minor
+---
+
+Add `uiUrl` as config to enable links to Prometheus.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -199,6 +199,7 @@ argocd:
 
 prometheus:
   proxyPath: /prometheus/api
+  uiUrl: http://localhost:9090
 
 bugsnag:
   resultsPerPage: 50

--- a/packages/entities/test-entity.yaml
+++ b/packages/entities/test-entity.yaml
@@ -14,6 +14,8 @@ metadata:
     datadoghq.com/graph-token: qwertytoken1234
     argocd/app-name: test-app
     bugsnag.com/project-key: RoadieHQTest/Test bugsnag application
+    prometheus.io/rule: prometheus_http_requests_total,sum by (handler) (prometheus_http_requests_total),prometheus_http_requests_total|component
+    prometheus.io/alert: all
 spec:
   type: service
   owner: roadie

--- a/plugins/frontend/backstage-plugin-prometheus/README.md
+++ b/plugins/frontend/backstage-plugin-prometheus/README.md
@@ -39,6 +39,7 @@ proxy:
 # Defaults to /prometheus/api and can be omitted if proxy is configured for that url
 prometheus:
   proxyPath: /prometheus/api
+  uiUrl: http://localhost:9090
 ```
 
 ## Content page setup
@@ -181,9 +182,11 @@ proxy:
 
 prometheus:
   proxyPath: /prometheus/api
+  uiUrl: http://localhost:9090
   instances:
     - name: prometheusTeamB
       proxyPath: /prometheusTeamB/api
+      uiUrl: http://localhost:9999
 ```
 
 ## Advanced Dynamic Prometheus Proxying

--- a/plugins/frontend/backstage-plugin-prometheus/config.d.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/config.d.ts
@@ -28,6 +28,12 @@ export interface Config {
     proxyPath?: string;
 
     /**
+     * The URL for the Prometheus UI.
+     * @visibility frontend
+     */
+    uiUrl?: string;
+
+    /**
      * The proxy service instances for Prometheus.
      * Should be used if you have multiple Prometheus instances you like to proxy to.
      * @visibility frontend
@@ -46,6 +52,11 @@ export interface Config {
          * @visibility frontend
          */
         proxyPath: string;
+        /**
+         * The URL for the Prometheus UI.
+         * @visibility frontend
+         */
+        uiUrl?: string;
       },
     ];
   };

--- a/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
@@ -47,6 +47,23 @@ export class PrometheusApi {
     return `${proxyUrl}${this.getProxyPath({ serviceName })}`;
   }
 
+  public getUiUrl({ serviceName }: { serviceName?: string }) {
+    if (Boolean(serviceName)) {
+      const instances = this.configApi.getOptionalConfigArray(
+        'prometheus.instances',
+      );
+      if (instances && instances?.length > 0) {
+        const instance = instances.find(
+          value => value.getString('name') === serviceName,
+        );
+        if (Boolean(instance)) {
+          return instance?.getOptionalString('uiUrl');
+        }
+      }
+    }
+    return this.configApi.getOptionalString('prometheus.uiUrl');
+  }
+
   private getProxyPath({ serviceName }: { serviceName?: string }) {
     if (Boolean(serviceName)) {
       const instances = this.configApi.getOptionalConfigArray(

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.test.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.test.tsx
@@ -57,6 +57,7 @@ const config = {
 
 const mockPrometheusApi = {
   getAlerts: () => require('../../mocks/mockAlertResponse.json'),
+  getUiUrl: () => undefined,
 };
 
 const apis: [AnyApiRef, Partial<unknown>][] = [

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 
 import {
   InfoCard,
+  Link,
   Progress,
   StatusAborted,
   StatusError,
@@ -25,7 +26,7 @@ import {
   Table,
   TableColumn,
 } from '@backstage/core-components';
-import { Chip, Tooltip, makeStyles } from '@material-ui/core';
+import { Chip, Tooltip, makeStyles, Grid, Typography } from '@material-ui/core';
 // eslint-disable-next-line
 import Alert from '@material-ui/lab/Alert';
 import { DateTime } from 'luxon';
@@ -137,15 +138,29 @@ export const PrometheusAlertStatus = ({
   alerts: string[] | 'all';
   onRowClick?: OnRowClick;
 }) => {
-  const { error, loading, displayableAlerts } = useAlerts(alerts);
+  const { error, loading, displayableAlerts, uiUrl } = useAlerts(alerts);
   if (loading) {
     return <Progress />;
   } else if (error) {
     return <Alert severity="error">{error?.message}</Alert>;
   }
+
+  const title = (
+    <Grid container justifyContent="space-between" alignItems="center">
+      <Grid item>Prometheus Alerts</Grid>
+      {uiUrl && (
+        <Grid item>
+          <Typography variant="subtitle1">
+            <Link to={`${uiUrl}/alerts`}>Go to Prometheus</Link>
+          </Typography>
+        </Grid>
+      )}
+    </Grid>
+  );
+
   return (
     <div>
-      <InfoCard title="Prometheus Alerts" noPadding>
+      <InfoCard title={title} noPadding>
         <Table
           options={{
             search: false,

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusGraph/PrometheusGraph.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusGraph/PrometheusGraph.tsx
@@ -16,7 +16,7 @@
 
 import React, { useEffect } from 'react';
 import { DateTime } from 'luxon';
-import { Box, useTheme } from '@material-ui/core';
+import { Box, Grid, Typography, useTheme } from '@material-ui/core';
 import {
   Area,
   AreaChart,
@@ -32,7 +32,7 @@ import {
 
 // @ts-ignore no types
 import useDimensions from 'react-use-dimensions';
-import { InfoCard, Progress } from '@backstage/core-components';
+import { InfoCard, Link, Progress } from '@backstage/core-components';
 import Alert from '@material-ui/lab/Alert';
 import { BackstagePalette } from '@backstage/theme';
 import { CustomTooltip, tooltipCollector } from '../CustomTooltip';
@@ -250,13 +250,31 @@ export const PrometheusGraph = ({
   } else if (error) {
     return <Alert severity="error">{error.message}</Alert>;
   }
+
+  const title = (
+    <Grid container justifyContent="space-between" alignItems="center">
+      <Grid item>{query}</Grid>
+      {value?.uiUrl && (
+        <Grid item>
+          <Typography variant="subtitle1">
+            <Link
+              to={`${value.uiUrl}/graph?g0.expr=${encodeURI(query)}&g0.tab=0`}
+            >
+              Go to Prometheus
+            </Link>
+          </Typography>
+        </Grid>
+      )}
+    </Grid>
+  );
+
   const { data, keys, metrics } = value ?? { data: [], keys: [], metrics: {} };
   return graphType === 'line' ? (
-    <InfoCard title={query}>
+    <InfoCard title={title}>
       <LineGraph data={data} keys={keys} metrics={metrics} />
     </InfoCard>
   ) : (
-    <InfoCard title={query}>
+    <InfoCard title={title}>
       {' '}
       <AreaGraph data={data} keys={keys} metrics={metrics} />
     </InfoCard>

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusGraph/PrometheusGraphEntityWrapper.test.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusGraph/PrometheusGraphEntityWrapper.test.tsx
@@ -59,6 +59,7 @@ const config = {
 
 const mockPrometheusApi = {
   query: () => require('../../mocks/mockQueryResponse.json'),
+  getUiUrl: () => undefined,
 };
 
 const apis: [AnyApiRef, Partial<unknown>][] = [

--- a/plugins/frontend/backstage-plugin-prometheus/src/hooks/usePrometheus.test.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/hooks/usePrometheus.test.ts
@@ -30,6 +30,7 @@ describe('usePrometheus', () => {
     getApiUrl: () => 'dontcare',
     query: () => ['this', 'is', 'mocked', 'via', 'other', 'hook'],
     getAlerts: () => ['alert'],
+    getUiUrl: () => undefined,
   });
 
   (useEntity as any).mockReturnValue({


### PR DESCRIPTION
Adding links to Prometheus for the Prometheus plugin, as it is useful to deep dive into the system.

![CleanShot 2023-10-08 at 17 34 43@2x](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/1021324/f68eb265-3128-4ec1-a3be-757305e12d79)


#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [X] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
