### PR TITLE
Return entities after validating

### DIFF
--- a/.changeset/silent-lions-doubt.md
+++ b/.changeset/silent-lions-doubt.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': minor
+---
+
+the validation functions return the validated entities

--- a/utils/roadie-backstage-entity-validator/src/validator.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.js
@@ -139,7 +139,7 @@ export const validate = async (
       responses.forEach(it => console.log(yaml.dump(it)));
     }
 
-    return responses.filter((e) => e !== undefined);
+    return responses.filter(e => e !== undefined);
   } catch (e) {
     throw new Error(e);
   }
@@ -155,7 +155,11 @@ export const validateFromFile = async (
     console.log(`Validating Entity Schema policies for file ${filepath}`);
   }
 
-  const entities = await validate(fileContents, verbose, customAnnotationSchemaLocation);
+  const entities = await validate(
+    fileContents,
+    verbose,
+    customAnnotationSchemaLocation,
+  );
   await relativeSpaceValidation(fileContents, filepath, verbose);
 
   return entities;

--- a/utils/roadie-backstage-entity-validator/src/validator.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.js
@@ -138,6 +138,8 @@ export const validate = async (
       console.log('Entity Schema policies validated\n');
       responses.forEach(it => console.log(yaml.dump(it)));
     }
+
+    return responses.filter((e) => e !== undefined);
   } catch (e) {
     throw new Error(e);
   }
@@ -153,6 +155,8 @@ export const validateFromFile = async (
     console.log(`Validating Entity Schema policies for file ${filepath}`);
   }
 
-  await validate(fileContents, verbose, customAnnotationSchemaLocation);
+  const entities = await validate(fileContents, verbose, customAnnotationSchemaLocation);
   await relativeSpaceValidation(fileContents, filepath, verbose);
+
+  return entities;
 };

--- a/utils/roadie-backstage-entity-validator/src/validator.test.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.test.js
@@ -230,7 +230,7 @@ spec:
   it('Should successfully validate simple catalog info', async () => {
     await expect(
       validator.validateFromFile('catalog-info.yml'),
-    ).resolves.toBeUndefined();
+    ).resolves.toHaveLength(2);
   });
 
   it('Should fail to validate with incorrect catalog-info', async () => {
@@ -242,13 +242,13 @@ spec:
   it('Should successfully validate catalog info with replacements', async () => {
     await expect(
       validator.validateFromFile('catalog-info-with-replacement.yml'),
-    ).resolves.toBeUndefined();
+    ).resolves.toHaveLength(1);
     await expect(
       validator.validateFromFile('catalog-info-with-openapi-placeholder.yml'),
-    ).resolves.toBeUndefined();
+    ).resolves.toHaveLength(1);
     await expect(
       validator.validateFromFile('catalog-info-with-asyncapi-placeholder.yml'),
-    ).resolves.toBeUndefined();
+    ).resolves.toHaveLength(1);
   });
 
   it('Should fail to validate with incorrect catalog-info that has an empty label', async () => {
@@ -300,7 +300,7 @@ spec:
         vol.fromJSON(defaultVol);
         await expect(
           validator.validateFromFile('./test-entity.yaml'),
-        ).resolves.toBeUndefined();
+        ).resolves.toHaveLength(1);
       });
     });
   });
@@ -333,13 +333,13 @@ spec:
         vol.fromJSON({ ...defaultVol, 'test-dir/mkdocs.yaml': 'bar' });
         await expect(
           validator.validateFromFile('./test-entity.yaml'),
-        ).resolves.toBeUndefined();
+        ).resolves.toHaveLength(1);
       });
       it('should resolve when mkdocs.yml found', async () => {
         vol.fromJSON({ ...defaultVol, 'test-dir/mkdocs.yml': 'bar' });
         await expect(
           validator.validateFromFile('./test-entity.yaml'),
-        ).resolves.toBeUndefined();
+        ).resolves.toHaveLength(1);
       });
     });
   });
@@ -347,13 +347,13 @@ spec:
     it('Should successfully validate v2 template', async () => {
       await expect(
         validator.validateFromFile('template-v2-entity.yml'),
-      ).resolves.toBeUndefined();
+      ).resolves.toHaveLength(1);
     });
 
     it('Should successfully validate v3 template', async () => {
       await expect(
         validator.validateFromFile('template-v3-entity.yml'),
-      ).resolves.toBeUndefined();
+      ).resolves.toHaveLength(1);
     });
   });
 
@@ -365,7 +365,7 @@ spec:
           false,
           'custom-validation-schema.json',
         ),
-      ).resolves.toBeUndefined();
+      ).resolves.toHaveLength(1);
     });
 
     it('should throw validate error when validating against custom annotation schema', async () => {

--- a/utils/roadie-backstage-entity-validator/src/validator.test.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.test.js
@@ -230,7 +230,74 @@ spec:
   it('Should successfully validate simple catalog info', async () => {
     await expect(
       validator.validateFromFile('catalog-info.yml'),
-    ).resolves.toHaveLength(2);
+    ).resolves.toEqual([
+      {
+        metadata: {
+          namespace: 'default',
+          name: 'sample-service-5',
+          description:
+            'A service for testing Backstage functionality. Configured for GitHub Actions, Sentry, AWS Lambda, Datadog and mis-configured techdocs.\n',
+          annotations: {
+            'github.com/project-slug': 'roadiehq/sample-service',
+            'sentry.io/project-slug': 'sample-service',
+            'aws.com/lambda-function-name': 'HelloWorld',
+            'aws.com/lambda-region': 'eu-west-1',
+            'backstage.io/techdocs-ref':
+              'url:https://github.com/RoadieHQ/sample-service/tree/main',
+            'jira/project-key': 'TEST',
+            'jira/component': 'COMP',
+            'snyk.io/org-name': 'roadie',
+            'backstage.io/view-url':
+              'https://github.com/RoadieHQ/sample-service/tree/main',
+            'backstage.io/source-location':
+              'url:https://github.com/RoadieHQ/sample-service/tree/main/',
+            testextraannotation: 'adfstea',
+            'backstage.io/ldap-uuid': 'c57e8ba2-6cc4-1039-9ebc-d5f241a7ca21',
+          },
+        },
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        spec: {
+          type: 'service',
+          owner: 'user:dtuite',
+          lifecycle: 'experimental',
+          providesApis: ['sample-service'],
+        },
+      },
+      {
+        metadata: {
+          namespace: 'default',
+          name: 'sample-service-5',
+          description:
+            'A service for testing Backstage functionality. Configured for GitHub Actions, Sentry, AWS Lambda, Datadog and mis-configured techdocs.\n',
+          annotations: {
+            'github.com/project-slug': 'roadiehq/sample-service',
+            'sentry.io/project-slug': 'sample-service',
+            'aws.com/lambda-function-name': 'HelloWorld',
+            'aws.com/lambda-region': 'eu-west-1',
+            'backstage.io/techdocs-ref':
+              'url:https://github.com/RoadieHQ/sample-service/tree/main',
+            'jira/project-key': 'TEST',
+            'jira/component': 'COMP',
+            'snyk.io/org-name': 'roadie',
+            'backstage.io/view-url':
+              'https://github.com/RoadieHQ/sample-service/tree/main',
+            'backstage.io/source-location':
+              'url:https://github.com/RoadieHQ/sample-service/tree/main/',
+            testextraannotation: 'adfstea',
+            'backstage.io/ldap-uuid': 'c57e8ba2-6cc4-1039-9ebc-d5f241a7ca21',
+          },
+        },
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        spec: {
+          type: 'service',
+          owner: 'user:dtuite',
+          lifecycle: 'experimental',
+          providesApis: ['sample-service'],
+        },
+      },
+    ]);
   });
 
   it('Should fail to validate with incorrect catalog-info', async () => {
@@ -242,13 +309,61 @@ spec:
   it('Should successfully validate catalog info with replacements', async () => {
     await expect(
       validator.validateFromFile('catalog-info-with-replacement.yml'),
-    ).resolves.toHaveLength(1);
+    ).resolves.toEqual([
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'API',
+        metadata: {
+          namespace: 'default',
+          name: 'test-service-api',
+          description: 'API for test-service',
+        },
+        spec: {
+          type: 'openapi',
+          lifecycle: 'production',
+          owner: 'group:team-atools',
+          definition: 'DUMMY TEXT',
+        },
+      },
+    ]);
     await expect(
       validator.validateFromFile('catalog-info-with-openapi-placeholder.yml'),
-    ).resolves.toHaveLength(1);
+    ).resolves.toEqual([
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'API',
+        metadata: {
+          namespace: 'default',
+          name: 'test-service-api',
+          description: 'API for test-service',
+        },
+        spec: {
+          type: 'openapi',
+          lifecycle: 'production',
+          owner: 'group:team-atools',
+          definition: 'DUMMY TEXT',
+        },
+      },
+    ]);
     await expect(
       validator.validateFromFile('catalog-info-with-asyncapi-placeholder.yml'),
-    ).resolves.toHaveLength(1);
+    ).resolves.toEqual([
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'API',
+        metadata: {
+          namespace: 'default',
+          name: 'test-service-api',
+          description: 'API for test-service',
+        },
+        spec: {
+          type: 'openapi',
+          lifecycle: 'production',
+          owner: 'group:team-atools',
+          definition: 'DUMMY TEXT',
+        },
+      },
+    ]);
   });
 
   it('Should fail to validate with incorrect catalog-info that has an empty label', async () => {
@@ -300,7 +415,25 @@ spec:
         vol.fromJSON(defaultVol);
         await expect(
           validator.validateFromFile('./test-entity.yaml'),
-        ).resolves.toHaveLength(1);
+        ).resolves.toEqual([
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              namespace: 'default',
+              name: 'test-entity',
+              description: 'Foo bar description\n',
+              annotations: {
+                'backstage.io/techdocs-ref': 'dir:.',
+              },
+            },
+            spec: {
+              type: 'service',
+              lifecycle: 'experimental',
+              owner: 'user:dtuite',
+            },
+          },
+        ]);
       });
     });
   });
@@ -333,13 +466,49 @@ spec:
         vol.fromJSON({ ...defaultVol, 'test-dir/mkdocs.yaml': 'bar' });
         await expect(
           validator.validateFromFile('./test-entity.yaml'),
-        ).resolves.toHaveLength(1);
+        ).resolves.toEqual([
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              namespace: 'default',
+              name: 'test-entity',
+              description: 'Foo bar description\n',
+              annotations: {
+                'backstage.io/techdocs-ref': 'dir:test-dir',
+              },
+            },
+            spec: {
+              type: 'service',
+              lifecycle: 'experimental',
+              owner: 'user:dtuite',
+            },
+          },
+        ]);
       });
       it('should resolve when mkdocs.yml found', async () => {
         vol.fromJSON({ ...defaultVol, 'test-dir/mkdocs.yml': 'bar' });
         await expect(
           validator.validateFromFile('./test-entity.yaml'),
-        ).resolves.toHaveLength(1);
+        ).resolves.toEqual([
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              namespace: 'default',
+              name: 'test-entity',
+              description: 'Foo bar description\n',
+              annotations: {
+                'backstage.io/techdocs-ref': 'dir:test-dir',
+              },
+            },
+            spec: {
+              type: 'service',
+              lifecycle: 'experimental',
+              owner: 'user:dtuite',
+            },
+          },
+        ]);
       });
     });
   });
@@ -347,13 +516,59 @@ spec:
     it('Should successfully validate v2 template', async () => {
       await expect(
         validator.validateFromFile('template-v2-entity.yml'),
-      ).resolves.toHaveLength(1);
+      ).resolves.toEqual([
+        {
+          apiVersion: 'backstage.io/v1beta2',
+          kind: 'Template',
+          metadata: {
+            namespace: 'default',
+            name: 'sample-template-v2',
+          },
+          spec: {
+            type: 'foo',
+            steps: [
+              {
+                action: 'roadiehq:utils:zip',
+                id: 'zip',
+                input: {
+                  outputPath: 'foo.zip',
+                  path: 'foo.txt',
+                },
+                name: 'Zip',
+              },
+            ],
+          },
+        },
+      ]);
     });
 
     it('Should successfully validate v3 template', async () => {
       await expect(
         validator.validateFromFile('template-v3-entity.yml'),
-      ).resolves.toHaveLength(1);
+      ).resolves.toEqual([
+        {
+          apiVersion: 'scaffolder.backstage.io/v1beta3',
+          kind: 'Template',
+          metadata: {
+            namespace: 'default',
+            name: 'sample-template-v3',
+          },
+          spec: {
+            type: 'foo',
+            steps: [
+              {
+                action: 'roadiehq:utils:zip',
+                id: 'zip',
+                input: {
+                  outputPath: 'foo.zip',
+                  path: 'foo.txt',
+                },
+                name: 'Zip',
+              },
+            ],
+          },
+        },
+      ]);
     });
   });
 
@@ -365,7 +580,31 @@ spec:
           false,
           'custom-validation-schema.json',
         ),
-      ).resolves.toHaveLength(1);
+      ).resolves.toEqual([
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: {
+            namespace: 'default',
+            name: 'sample-service-5',
+            description:
+              'A service for testing Backstage functionality. Configured for GitHub Actions, Sentry, AWS Lambda, Datadog and mis-configured techdocs.\n',
+            annotations: {
+              'backstage.io/source-location':
+                'url:https://github.com/RoadieHQ/sample-service/tree/main/',
+              'backstage.io/view-url':
+                'https://github.com/RoadieHQ/sample-service/tree/main',
+              'custom/source-location': 'custom-field-value:12342',
+              'github.com/project-slug': 'roadiehq/sample-service',
+            },
+          },
+          spec: {
+            type: 'service',
+            lifecycle: 'experimental',
+            owner: 'user:dtuite',
+          },
+        },
+      ]);
     });
 
     it('should throw validate error when validating against custom annotation schema', async () => {

--- a/utils/roadie-backstage-entity-validator/types.d.ts
+++ b/utils/roadie-backstage-entity-validator/types.d.ts
@@ -1,8 +1,12 @@
+import {
+  Entity,
+} from "@backstage/catalog-model";
+
 export const validateFromFile: (
   filepath: string,
   verbose: boolean,
-) => Promise<void>;
+) => Promise<Entity[]>;
 export const validate: (
   fileContents: string,
   verbose: boolean,
-) => Promise<void>;
+) => Promise<Entity[]>;

--- a/utils/roadie-backstage-entity-validator/types.d.ts
+++ b/utils/roadie-backstage-entity-validator/types.d.ts
@@ -1,6 +1,4 @@
-import {
-  Entity,
-} from "@backstage/catalog-model";
+import { Entity } from '@backstage/catalog-model';
 
 export const validateFromFile: (
   filepath: string,


### PR DESCRIPTION
I have a use case where I'd like to use your validator but I'd also like to do additional checks based on the parsed entities. I could copy paste a large part of your util to parse them once again but simply returning the objects also works for me.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
