### PR TITLE
Update default size of resizable in DatadogDashboardPage.tsx

### DIFF
--- a/plugins/frontend/backstage-plugin-datadog/src/components/DatadogDashboardPage.tsx
+++ b/plugins/frontend/backstage-plugin-datadog/src/components/DatadogDashboardPage.tsx
@@ -32,7 +32,7 @@ export const DatadogDashboardPage = ({ entity }: { entity: Entity }) => {
           <InfoCard title={`Datadog dashboard ${index}`} variant="gridItem">
             <Resizable
               defaultSize={{
-                width: 100,
+                width: '100%',
                 height: 500,
               }}
               handleComponent={{ bottomRight: <ZoomOutMapIcon /> }}


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
In the Datadog Plugin, the DatadogDashboardPage.tsx has a Resizable element which has default width as 100 which is rendered as 100px by the browser. This makes the Dashboard's width appear very small and user has to re-adjust the width each time this page is visited.
(Before Image)
<img width="1792" alt="Screenshot 2023-10-24 at 2 25 10 PM" src="https://github.com/RoadieHQ/roadie-backstage-plugins/assets/30374310/bb347cf7-9daa-481e-83c5-d69c90124e31">

By making a minor change to the default width and making it '100%', it now expands to take the full width of the parent card. This enhances visibility of the Dashboard and UI is also improved.
(After Image)
<img width="1792" alt="Screenshot 2023-10-24 at 2 26 27 PM" src="https://github.com/RoadieHQ/roadie-backstage-plugins/assets/30374310/82343e38-95f0-45f1-a6a7-ec7955bb5b9c">

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ :heavy_check_mark ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
