### PR TITLE
Prometheus: Added condition to control the Prometheus cards display

### DIFF
--- a/.changeset/tidy-olives-clean.md
+++ b/.changeset/tidy-olives-clean.md
@@ -1,5 +1,5 @@
 ---
-'@roadiehq/backstage-plugin-prometheus': minior
+'@roadiehq/backstage-plugin-prometheus': minor
 ---
 
 Add condition to control the Prometheus cards display in the entity overview page

--- a/.changeset/tidy-olives-clean.md
+++ b/.changeset/tidy-olives-clean.md
@@ -1,5 +1,5 @@
 ---
-'@roadiehq/backstage-plugin-prometheus': major
+'@roadiehq/backstage-plugin-prometheus': minior
 ---
 
 Add condition to control the Prometheus cards display in the entity overview page

--- a/.changeset/tidy-olives-clean.md
+++ b/.changeset/tidy-olives-clean.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-prometheus': major
+---
+
+Add condition to control the Prometheus cards display in the entity overview page

--- a/plugins/frontend/backstage-plugin-prometheus/README.md
+++ b/plugins/frontend/backstage-plugin-prometheus/README.md
@@ -72,6 +72,7 @@ const serviceEntityPage = (
 import {
   EntityPrometheusAlertCard,
   EntityPrometheusGraphCard,
+  isPrometheusAvailable
 } from '@roadiehq/backstage-plugin-prometheus';
 
 ...
@@ -79,12 +80,16 @@ import {
 const overviewContent = (
   <Grid container spacing={3}>
     ...
-    <Grid item md={8}>
-      <EntityPrometheusAlertCard />
-    </Grid>
-    <Grid item md={6}>
-      <EntityPrometheusGraphCard />
-    </Grid>
+    <EntitySwitch>
+      <EntitySwitch.Case if={isPrometheusAvailable}>
+        <Grid item md={8}>
+          <EntityPrometheusAlertCard />
+        </Grid>
+        <Grid item md={6}>
+          <EntityPrometheusGraphCard />
+        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>
     ...
   </Grid>
 );

--- a/plugins/frontend/backstage-plugin-prometheus/src/conditions.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/conditions.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import {
+  PROMETHEUS_RULE_ANNOTATION,
+  PROMETHEUS_ALERT_ANNOTATION,
+  PROMETHEUS_SERVICE_NAME_ANNOTATION,
+  PROMETHEUS_ALERT_LABEL_ANNOTATION,
+} from './components/util';
+
+export const isPrometheusAvailable = (entity: Entity) =>
+  Boolean(entity?.metadata.annotations?.[PROMETHEUS_RULE_ANNOTATION]) ||
+  Boolean(entity?.metadata.annotations?.[PROMETHEUS_ALERT_ANNOTATION]) ||
+  Boolean(entity?.metadata.annotations?.[PROMETHEUS_SERVICE_NAME_ANNOTATION]) ||
+  Boolean(entity?.metadata.annotations?.[PROMETHEUS_ALERT_LABEL_ANNOTATION]);

--- a/plugins/frontend/backstage-plugin-prometheus/src/index.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/index.ts
@@ -22,3 +22,4 @@ export {
 
 export { PrometheusGraph } from './components/PrometheusGraph';
 export { PrometheusAlertStatus } from './components/PrometheusAlertStatus';
+export { isPrometheusAvailable } from './conditions';


### PR DESCRIPTION
Added condition to mask the Prometheus card in the overview page if the entity is not annotated.

Example

```diff
import {
  EntityPrometheusContent,
  EntityPrometheusAlertCard,  
  EntityPrometheusGraphCard,
+  isPrometheusAvailable
} from '@alithya/backstage-plugin-prometheus'; 

const overviewContent = (
  <Grid container spacing={3} alignItems="stretch">
    {entityWarningContent}

+    <EntitySwitch>
+      <EntitySwitch.Case if={isPrometheusAvailable}>
        <Grid item md={6}>
          <EntityPrometheusAlertCard />
        </Grid>
        <Grid item md={6}>
          <EntityPrometheusGraphCard />
        </Grid>
+      </EntitySwitch.Case>
+    </EntitySwitch>



```

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
