### PR TITLE
Return error responses as well as successful responses in templates

### DIFF
--- a/.changeset/nasty-walls-retire.md
+++ b/.changeset/nasty-walls-retire.md
@@ -1,5 +1,5 @@
 ---
-'@roadiehq/scaffolder-backend-module-http-request': patch
+'@roadiehq/scaffolder-backend-module-http-request': minor
 ---
 
-Return error responses as well as successful responses in templates
+Add flag that allows return of error responses as well as successful responses in templates so that the next step can run.

--- a/.changeset/nasty-walls-retire.md
+++ b/.changeset/nasty-walls-retire.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Return error responses as well as successful responses in templates

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -67,6 +67,7 @@ describe('http:backstage:request', () => {
             headers: {},
           },
           logger,
+          false,
         );
       });
     });
@@ -101,6 +102,7 @@ describe('http:backstage:request', () => {
             body: '{"name":"test"}',
           },
           logger,
+          false,
         );
       });
     });
@@ -135,6 +137,7 @@ describe('http:backstage:request', () => {
             body: '{"name":"test"}',
           },
           logger,
+          false,
         );
       });
     });
@@ -162,6 +165,7 @@ describe('http:backstage:request', () => {
             body: 'test',
           },
           logger,
+          false,
         );
       });
     });
@@ -189,6 +193,7 @@ describe('http:backstage:request', () => {
             body: '<?xml version="1.0" encoding="UTF-8"><node>asdf</node>',
           },
           logger,
+          false,
         );
       });
     });
@@ -223,6 +228,7 @@ describe('http:backstage:request', () => {
             body: 'test',
           },
           logger,
+          false,
         );
       });
 
@@ -257,6 +263,7 @@ describe('http:backstage:request', () => {
             body: 'test',
           },
           logger,
+          false,
         );
       });
     });
@@ -288,6 +295,7 @@ describe('http:backstage:request', () => {
             body: undefined,
           },
           logger,
+          false,
         );
       });
     });
@@ -316,6 +324,7 @@ describe('http:backstage:request', () => {
             },
           },
           logger,
+          false,
         );
       });
     });
@@ -345,6 +354,7 @@ describe('http:backstage:request', () => {
             headers: {},
           },
           logger,
+          false,
         );
       });
     });
@@ -375,6 +385,7 @@ describe('http:backstage:request', () => {
             headers: {},
           },
           logger,
+          false,
         );
       });
     });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -34,6 +34,7 @@ export function createHttpBackstageAction(options: {
     params?: Params;
     body?: any;
     logRequestPath?: boolean;
+    continueOnBadResponse?: boolean;
   }>({
     id: 'http:backstage:request',
     description:
@@ -85,6 +86,13 @@ export function createHttpBackstageAction(options: {
               'Option to turn request path logging off. On by default',
             type: 'boolean',
           },
+          continueOnBadResponse: {
+            title: 'Continue on error',
+            description:
+              'Return response code and body and continue to next scaffolder step if the response status is not a 2xx. False by default.',
+            type: 'boolean',
+            default: 'false',
+          },
         },
       },
       output: {
@@ -111,6 +119,7 @@ export function createHttpBackstageAction(options: {
       const token = ctx.secrets?.backstageToken;
       const { method, params } = input;
       const logRequestPath = input.logRequestPath ?? true;
+      const continueOnBadResponse = input.continueOnBadResponse || false;
       const url = await generateBackstageUrl(discovery, input.path);
 
       if (logRequestPath) {
@@ -158,7 +167,11 @@ export function createHttpBackstageAction(options: {
         httpOptions.headers.authorization = `Bearer ${token}`;
       }
 
-      const { code, headers, body } = await http(httpOptions, ctx.logger);
+      const { code, headers, body } = await http(
+        httpOptions,
+        ctx.logger,
+        continueOnBadResponse,
+      );
 
       ctx.output('code', code);
       ctx.output('headers', headers);

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -89,7 +89,7 @@ export function createHttpBackstageAction(options: {
           continueOnBadResponse: {
             title: 'Continue on error',
             description:
-              'Return response code and body and continue to next scaffolder step if the response status is not a 2xx. False by default.',
+              'Return response code and body and continue to next scaffolder step if the response status is 4xx or 5xx. False by default.',
             type: 'boolean',
             default: 'false',
           },

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -89,7 +89,7 @@ export function createHttpBackstageAction(options: {
           continueOnBadResponse: {
             title: 'Continue on error',
             description:
-              'Return response code and body and continue to next scaffolder step if the response status is 4xx or 5xx. False by default.',
+              'Return response code and body and continue to next scaffolder step if the response status is 4xx or 5xx. By default the step will fail if any status code is returned 400 and above.',
             type: 'boolean',
             default: 'false',
           },

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
@@ -157,7 +157,7 @@ describe('http', () => {
       });
 
       describe("when there's a status code >= 400", () => {
-        it('fails with an error', async () => {
+        it('fails with an error by default', async () => {
           const mockedResponse: Response = {
             ...mockResponse,
             ok: false,
@@ -173,6 +173,30 @@ describe('http', () => {
           await expect(
             async () => await http(options, logger),
           ).rejects.toThrowError('Unable to complete request');
+
+          const logEvents = logOutput.trim().split('\n');
+          expect(logEvents).toEqual(
+            expect.arrayContaining([
+              expect.stringContaining(`"error":"bad request"`),
+            ]),
+          );
+        });
+        it('returns response without headers if continueOnBadResponse', async () => {
+          const mockedResponse: Response = {
+            ...mockResponse,
+            ok: false,
+            status: 401,
+            json: async () => ({
+              error: 'bad request',
+            }),
+          };
+
+          (fetch as unknown as jest.Mock).mockResolvedValue(
+            Promise.resolve(mockedResponse),
+          );
+          const response = await http(options, logger, true);
+          expect(response.code).toEqual(401);
+          expect(await response.body).toEqual({ error: 'bad request' });
 
           const logEvents = logOutput.trim().split('\n');
           expect(logEvents).toEqual(
@@ -230,7 +254,7 @@ describe('http', () => {
           await expect(
             async () => await http(options, logger),
           ).rejects.toThrowError(
-            'Could not get response: Error: Unable to get JSON',
+            'Could not parse response body: Error: Unable to get JSON',
           );
         });
       });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
@@ -197,6 +197,7 @@ describe('http', () => {
           const response = await http(options, logger, true);
           expect(response.code).toEqual(401);
           expect(await response.body).toEqual({ error: 'bad request' });
+          expect(await response.headers).toMatchObject({});
 
           const logEvents = logOutput.trim().split('\n');
           expect(logEvents).toEqual(

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
@@ -34,6 +34,7 @@ export const generateBackstageUrl = async (
 export const http = async (
   options: HttpOptions,
   logger: Logger,
+  continueOnBadResponse: boolean = false,
 ): Promise<any> => {
   let res: any;
   const controller = new AbortController();
@@ -69,7 +70,7 @@ export const http = async (
   try {
     body = isJSON() ? await res.json() : { message: await res.text() };
   } catch (e) {
-    throw new HttpError(`Could not get response: ${e}`);
+    throw new HttpError(`Could not parse response body: ${e}`);
   }
 
   if (res.status >= 400) {
@@ -78,7 +79,10 @@ export const http = async (
         res.status
       } Response body: ${JSON.stringify(body)}`,
     );
-    return { code: res.status, headers: {}, body };
+    if (continueOnBadResponse) {
+      return { code: res.status, headers: {}, body };
+    }
+    throw new HttpError('Unable to complete request');
   }
   return { code: res.status, headers, body };
 };

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
@@ -78,7 +78,7 @@ export const http = async (
         res.status
       } Response body: ${JSON.stringify(body)}`,
     );
-    throw new HttpError('Unable to complete request');
+    return { code: res.status, headers: {}, body };
   }
   return { code: res.status, headers, body };
 };


### PR DESCRIPTION
https://app.shortcut.com/larder/story/17453/einride-fetch-entities-from-scaffolder-template

This will allow logic that can expect 404s from an endpoint and continue the scaffolder job rather than erroring out.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
