### PR TITLE
Bugfix/history inefficient

### DIFF
--- a/.changeset/smooth-cameras-own.md
+++ b/.changeset/smooth-cameras-own.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': minor
+---
+
+Lazy load revisions and allow admins to limit the numbers of revisions to load in the configuration

--- a/plugins/frontend/backstage-plugin-argo-cd/README.md
+++ b/plugins/frontend/backstage-plugin-argo-cd/README.md
@@ -26,7 +26,8 @@ If you have your own backstage application without this plugin, here it's how to
 yarn add @roadiehq/backstage-plugin-argo-cd
 ```
 
-2. In the `app-config.yaml` file in the root directory, add argo-cd to the proxy object and optionally add the base url for your argoCD web UI:
+2. In the `app-config.yaml` file in the root directory, add argo-cd to the proxy object and optionally add the base url
+   for your argoCD web UI:
 
 ```yml
 proxy:
@@ -60,30 +61,38 @@ export { argocdPlugin } from '@roadiehq/backstage-plugin-argo-cd';
 ```ts
 // packages/app/src/components/catalog/EntityPage.tsx
 import {
-  EntityArgoCDHistoryCard,
-  isArgocdAvailable,
+    EntityArgoCDHistoryCard,
+    isArgocdAvailable,
 } from '@roadiehq/backstage-plugin-argo-cd';
 
 const overviewContent = (
-  <Grid container spacing={3} alignItems="stretch">
-    ...
-    <EntitySwitch>
-      <EntitySwitch.Case if={e => Boolean(isArgocdAvailable(e))}>
-        <Grid item sm={6}>
-          <EntityArgoCDHistoryCard />
-        </Grid>
-      </EntitySwitch.Case>
-    </EntitySwitch>
-    ...
-  </Grid>
-);
+    <Grid container
+spacing = {3}
+alignItems = "stretch" >
+...
+<EntitySwitch>
+    <EntitySwitch.Case
+if= {e =>
+Boolean(isArgocdAvailable(e))
+}>
+<Grid item
+sm = {6} >
+    <EntityArgoCDHistoryCard / >
+    </Grid>
+    < /EntitySwitch.Case>
+    < /EntitySwitch>
+...
+</Grid>
+)
+;
 ```
 
 ## How to use Argo-cd plugin in Backstage
 
 The Argo CD plugin is a part of the Backstage sample app. To start using it for your component, you have to:
 
-1. Add an annotation to the YAML config file of a component. If there is only a single Argo CD application for the component, you can use
+1. Add an annotation to the YAML config file of a component. If there is only a single Argo CD application for the
+   component, you can use
 
    ```yml
    argocd/app-name: <app-name>
@@ -97,14 +106,16 @@ The Argo CD plugin is a part of the Backstage sample app. To start using it for 
 
    **Note:** You can only use one of the options per component.
 
-2. Add your auth key to the environmental variables for your backstage backend server (you can acquire it by sending a GET HTTP request to Argo CD's `/session` endpoint with username and password):
+2. Add your auth key to the environmental variables for your backstage backend server (you can acquire it by sending a
+   GET HTTP request to Argo CD's `/session` endpoint with username and password):
    ```
    ARGOCD_AUTH_TOKEN="argocd.token=<auth-token>"
    ```
 
 ## Support for multiple ArgoCD instances - Option 1
 
-If you want to create multiple components that fetch data from different argoCD instances, you have to add a proxy config for each instance:
+If you want to create multiple components that fetch data from different argoCD instances, you have to add a proxy
+config for each instance:
 
 ```yml
 proxy:
@@ -139,15 +150,20 @@ argocd/proxy-url: '/argocd/api2'
 
 ## Support for multiple Argo CD instances - Option 2 - Argo CD backend plugin
 
-If you want to create multiple components that fetch data from different Argo CD instances, you can dynamically set the Argo CD instance url by adding the following to your app-config.yaml files.
+If you want to create multiple components that fetch data from different Argo CD instances, you can dynamically set the
+Argo CD instance url by adding the following to your app-config.yaml files.
 
-The Argo plugin will fetch the Argo CD instances an app is deployed to and use the backstage-plugin-argo-cd-backend plugin to reach out to each Argo instance based on the mapping mentioned below.
+The Argo plugin will fetch the Argo CD instances an app is deployed to and use the backstage-plugin-argo-cd-backend
+plugin to reach out to each Argo instance based on the mapping mentioned below.
 
-Please visit the [Argo CD Backend Plugin](https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd-backend) for more information
+Please visit the [Argo CD Backend Plugin](https://www.npmjs.com/package/@roadiehq/backstage-plugin-argo-cd-backend) for
+more information
 
 ## Support for apps in any namespace beta feature
 
-If you want to use the "Applications in any namespace" beta [feature](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/), you have to explicitly enable it in the configuration.
+If you want to use the "Applications in any namespace"
+beta [feature](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/), you have to explicitly
+enable it in the configuration.
 
 In the configuration file, you need to toggle the feature:
 
@@ -163,6 +179,17 @@ After enabling the feature, you can use the newly available `argocd/app-namespac
 metadata:
   annotations:
     argocd/app-namespace: my-test-ns
+```
+
+## Limit the number of revisions to load
+
+The `ArgoCDHistoryCard` loads all app revisions by default. If your app has many revisions, this can lead to a lot of
+requests and long loading times. Therefore, you can limit the number of revisions to load in your configuration file:
+
+```yaml
+argocd:
+  ...
+  revisionsToLoad: 3
 ```
 
 ## Develop plugin locally

--- a/plugins/frontend/backstage-plugin-argo-cd/config.d.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/config.d.ts
@@ -7,10 +7,15 @@ export interface Config {
      */
     baseUrl?: string;
     /**
-     * Support for the ArgoCD beta feature "Applications in any namespace"
+     * Support for the ArgoCD beta feature "Applications in any namespace".
      * @visibility frontend
      */
     namespacedApps?: boolean;
+    /**
+     * The number of revisions to load per application in the history table.
+     * @visibility frontend
+     */
+    revisionsToLoad?: number;
     /**
      * The base url of the ArgoCD instance.
      * @visibility frontend

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
@@ -16,16 +16,14 @@
 
 import { Entity } from '@backstage/catalog-model';
 import {
-  InfoCard,
   ErrorBoundary,
+  InfoCard,
   MissingAnnotationEmptyState,
-  Table,
-  TableColumn,
 } from '@backstage/core-components';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { LinearProgress, Link, List, ListItem } from '@material-ui/core';
-import React from 'react';
+import { LinearProgress } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
 import { isArgocdAvailable } from '../conditions';
 import { ArgoCDAppDetails, ArgoCDAppList } from '../types';
 import { useAppDetails } from './useAppDetails';
@@ -33,151 +31,49 @@ import {
   ARGOCD_ANNOTATION_APP_NAME,
   useArgoCDAppData,
 } from './useArgoCDAppData';
-import SyncIcon from '@material-ui/icons/Sync';
-import moment from 'moment';
+import { ArgoCDApi, argoCDApiRef } from '../api';
+import {
+  ArgoCDHistoryTable,
+  ArgoCDHistoryTableRow,
+} from './ArgoCDHistoryTable';
 
-const HistoryTable = ({
-  data,
-  retry,
-}: {
-  data: ArgoCDAppList;
-  retry: () => void;
-}) => {
-  const configApi = useApi(configApiRef);
-  const baseUrl = configApi.getOptionalString('argocd.baseUrl');
-  const namespaced =
-    configApi.getOptionalBoolean('argocd.namespacedApps') ?? false;
-  const supportsMultipleArgoInstances: boolean = Boolean(
-    configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length,
-  );
+const isHelmChart = (row: any): boolean => {
+  return row.source?.chart !== undefined;
+};
 
-  const history = data.items
-    ? data.items
-        .filter(Boolean)
-        .map(app => {
-          if (app?.status?.history) {
-            return app.status.history.map(entry => {
-              return {
-                app: app.metadata.name,
-                appNamespace: app.metadata.namespace,
-                instance: app.metadata?.instance?.name,
-                ...entry,
-              };
-            });
-          }
-          return {};
-        })
-        .filter(value => Object.keys(value).length !== 0)
-        .flat()
-    : [];
-  const columns: TableColumn[] = [
-    {
-      title: 'Name',
-      field: 'name',
-      render: (row: any): React.ReactNode =>
-        baseUrl ? (
-          <Link
-            href={`${baseUrl}/applications/${
-              namespaced ? `${row.appNamespace}/${row.app}` : row.app
-            }`}
-            target="_blank"
-            rel="noopener"
-          >
-            {row.app}
-          </Link>
-        ) : (
-          row.app
-        ),
-    },
-    {
-      title: 'Deploy Details',
-      defaultSort: 'desc',
-      field: 'deployedAt',
-      render: (row: any): React.ReactNode => (
-        <List dense style={{ padding: '0px' }}>
-          <ListItem style={{ paddingLeft: '0px' }}>
-            {row.deployedAt
-              ? `Deployed at ${moment(row.deployedAt)
-                  .local()
-                  .format('DD MMM YYYY, H:mm:ss')}`
-              : null}
-          </ListItem>
-          <ListItem style={{ paddingLeft: '0px' }}>
-            {row.deployedAt
-              ? `Run ${moment(row.deployStartedAt).local().fromNow()}`
-              : null}
-          </ListItem>
-          <ListItem style={{ paddingLeft: '0px' }}>
-            {row.deployedAt && row.deployStartedAt
-              ? `Took
-            ${moment
-              .duration(
-                moment(row.deployStartedAt).diff(moment(row.deployedAt)),
-              )
-              .humanize()}`
-              : null}
-          </ListItem>
-        </List>
-      ),
-    },
-    {
-      title: 'Author',
-      field: 'revision.author',
-      render: (row: any): React.ReactNode => <div>{row.revision?.author}</div>,
-    },
-    {
-      title: 'Message',
-      field: 'revision.message',
-      render: (row: any): React.ReactNode => <div>{row.revision?.message}</div>,
-    },
-    {
-      title: 'Revision',
-      field: 'revision.revisionID',
-      render: (row: any): React.ReactNode => (
-        <div>{row.revision?.revisionID}</div>
-      ),
-    },
-  ];
+const getRevisionId = (row: any): string => {
+  if (row.revision.hasOwnProperty('revisionID')) {
+    return row.revision.revisionID;
+  }
+  return row.revision;
+};
 
-  if (supportsMultipleArgoInstances) {
-    columns.splice(1, 0, {
-      title: 'Instance',
-      field: 'instance',
-      render: (row: any): React.ReactNode =>
-        row.metadata?.instance?.name
-          ? row.metadata?.instance?.name
-          : row.instance,
-    });
+const withRevisionDetails = async (
+  api: ArgoCDApi,
+  url: string,
+  row: any,
+): Promise<ArgoCDHistoryTableRow> => {
+  if (isHelmChart(row)) {
+    row.revisionDetails = { author: 'n/a', message: 'n/a', date: 'n/a' };
+    return row;
   }
 
-  return (
-    <Table
-      title="ArgoCD history"
-      options={{
-        paging: true,
-        search: false,
-        draggable: false,
-        padding: 'dense',
-      }}
-      data={history}
-      columns={columns}
-      actions={[
-        {
-          icon: () => <SyncIcon />,
-          tooltip: 'Refresh',
-          isFreeAction: true,
-          onClick: () => retry(),
-        },
-      ]}
-    />
-  );
+  row.revisionDetails = await api.getRevisionDetails({
+    url: url,
+    app: row.app,
+    appNamespace: row.appNamespace,
+    revisionID: getRevisionId(row),
+    instanceName: row.instance,
+  });
+  return row;
 };
 
 const ArgoCDHistory = ({ entity }: { entity: Entity }) => {
+  const [tableRows, setTableRows] = useState<ArgoCDHistoryTableRow[]>([]);
+
+  const argoCDApi = useApi(argoCDApiRef);
   const { url, appName, appSelector, appNamespace, projectName } =
-    useArgoCDAppData({
-      entity,
-    });
+    useArgoCDAppData({ entity });
   const { loading, value, error, retry } = useAppDetails({
     url,
     appName,
@@ -185,6 +81,41 @@ const ArgoCDHistory = ({ entity }: { entity: Entity }) => {
     appNamespace,
     projectName,
   });
+
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+    let apps: ArgoCDAppDetails[];
+    if ((value as ArgoCDAppList).items !== undefined) {
+      apps = (value as ArgoCDAppList).items ?? [];
+    } else if (Array.isArray(value)) {
+      apps = value as Array<ArgoCDAppDetails>;
+    } else {
+      apps = [value as ArgoCDAppDetails];
+    }
+    const rows: ArgoCDHistoryTableRow[] = apps
+      .filter(app => app?.status?.history)
+      .flatMap(app =>
+        // @ts-ignore TS2532: The filter statement above prevents this from being undefined
+        app.status.history.map(entry => ({
+          key: `${app.metadata.name}-${entry.revision}`,
+          app: app.metadata.name,
+          appNamespace: app.metadata.namespace,
+          instance: app.metadata?.instance?.name,
+          ...entry,
+        })),
+      );
+    setTableRows(rows);
+
+    // Update all items at once because otherwise it could lead to the too many re-renders error
+    Promise.all(
+      rows.map(async row => await withRevisionDetails(argoCDApi, url, row)),
+    ).then(rowsWithRevisions => {
+      setTableRows(rowsWithRevisions);
+    });
+  }, [value, argoCDApi, url]);
+
   if (loading) {
     return (
       <InfoCard title="ArgoCD history">
@@ -200,25 +131,12 @@ const ArgoCDHistory = ({ entity }: { entity: Entity }) => {
     );
   }
 
-  if (value) {
-    if ((value as ArgoCDAppList).items !== undefined) {
-      return <HistoryTable data={value as ArgoCDAppList} retry={retry} />;
-    }
-    if (Array.isArray(value)) {
-      const wrapped: ArgoCDAppList = {
-        items: value as Array<ArgoCDAppDetails>,
-      };
-      return <HistoryTable data={wrapped} retry={retry} />;
-    }
-    const wrapped: ArgoCDAppList = {
-      items: [value as ArgoCDAppDetails],
-    };
-    return <HistoryTable data={wrapped} retry={retry} />;
+  if (tableRows.length) {
+    return <ArgoCDHistoryTable data={tableRows} retry={retry} />;
   }
 
   return null;
 };
-
 export const ArgoCDHistoryCard = () => {
   const { entity } = useEntity();
   return !isArgocdAvailable(entity) ? (

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryTable.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryTable.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Table, TableColumn } from '@backstage/core-components';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { Link, List, ListItem } from '@material-ui/core';
+import React from 'react';
+import SyncIcon from '@material-ui/icons/Sync';
+import moment from 'moment';
+import {
+  ArgoCDAppDeployRevisionDetails,
+  ArgoCDAppHistoryDetails,
+} from '../types';
+
+export type ArgoCDHistoryTableRow = ArgoCDAppHistoryDetails & {
+  app: string;
+  appNamespace: string;
+  instance?: string;
+  revisionDetails?: ArgoCDAppDeployRevisionDetails;
+};
+
+export const ArgoCDHistoryTable = ({
+  data,
+  retry,
+}: {
+  data: ArgoCDHistoryTableRow[];
+  retry: () => void;
+}) => {
+  const configApi = useApi(configApiRef);
+  const baseUrl = configApi.getOptionalString('argocd.baseUrl');
+  const namespaced =
+    configApi.getOptionalBoolean('argocd.namespacedApps') ?? false;
+  const supportsMultipleArgoInstances: boolean = Boolean(
+    configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length,
+  );
+
+  const columns: TableColumn[] = [
+    {
+      title: 'Name',
+      field: 'name',
+      render: (row: any): React.ReactNode =>
+        baseUrl ? (
+          <Link
+            href={`${baseUrl}/applications/${
+              namespaced ? `${row.appNamespace}/${row.app}` : row.app
+            }`}
+            target="_blank"
+            rel="noopener"
+          >
+            {row.app}
+          </Link>
+        ) : (
+          row.app
+        ),
+    },
+    {
+      title: 'Deploy Details',
+      defaultSort: 'desc',
+      field: 'deployedAt',
+      render: (row: any): React.ReactNode => (
+        <List dense style={{ padding: '0px' }}>
+          <ListItem style={{ paddingLeft: '0px' }}>
+            {row.deployedAt
+              ? `Deployed at ${moment(row.deployedAt)
+                  .local()
+                  .format('DD MMM YYYY, H:mm:ss')}`
+              : null}
+          </ListItem>
+          <ListItem style={{ paddingLeft: '0px' }}>
+            {row.deployedAt
+              ? `Run ${moment(row.deployStartedAt).local().fromNow()}`
+              : null}
+          </ListItem>
+          <ListItem style={{ paddingLeft: '0px' }}>
+            {row.deployedAt && row.deployStartedAt
+              ? `Took
+            ${moment
+              .duration(
+                moment(row.deployStartedAt).diff(moment(row.deployedAt)),
+              )
+              .humanize()}`
+              : null}
+          </ListItem>
+        </List>
+      ),
+    },
+    {
+      title: 'Author',
+      field: 'revisionDetails.author',
+      render: (row: any): React.ReactNode => (
+        <div>{row.revisionDetails?.author || 'Loading...'}</div>
+      ),
+    },
+    {
+      title: 'Message',
+      field: 'revisionDetails.message',
+      render: (row: any): React.ReactNode => (
+        <div>{row.revisionDetails?.message || 'Loading...'}</div>
+      ),
+    },
+    {
+      title: 'Revision',
+      field: 'revision',
+      render: (row: any): React.ReactNode => <div>{row.revision}</div>,
+    },
+  ];
+
+  if (supportsMultipleArgoInstances) {
+    columns.splice(1, 0, {
+      title: 'Instance',
+      field: 'instance',
+      render: (row: any): React.ReactNode =>
+        row.metadata?.instance?.name
+          ? row.metadata?.instance?.name
+          : row.instance,
+    });
+  }
+
+  return (
+    <Table
+      title="ArgoCD history"
+      options={{
+        paging: true,
+        search: false,
+        draggable: false,
+        padding: 'dense',
+      }}
+      data={data}
+      columns={columns}
+      actions={[
+        {
+          icon: () => <SyncIcon />,
+          tooltip: 'Refresh',
+          isFreeAction: true,
+          onClick: () => retry(),
+        },
+      ]}
+    />
+  );
+};

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/useAppDetails.ts
@@ -17,7 +17,6 @@
 import { configApiRef, errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { useAsyncRetry } from 'react-use';
 import { argoCDApiRef } from '../api';
-import { ArgoCDAppDetails } from '../types';
 
 export const useAppDetails = ({
   appName,
@@ -36,57 +35,13 @@ export const useAppDetails = ({
   const errorApi = useApi(errorApiRef);
   const configApi = useApi(configApiRef);
 
-  const getRevisionHistoryDetails = async (
-    appDetails: ArgoCDAppDetails,
-    app: string,
-    instanceName?: string | undefined,
-  ) => {
-    const promises: Promise<void>[] | undefined =
-      appDetails.status?.history?.map(async (historyRecord: any) => {
-        let revisionID = '';
-        if (historyRecord.revision.hasOwnProperty('revisionID')) {
-          revisionID = historyRecord.revision.revisionID;
-        } else {
-          revisionID = historyRecord.revision;
-        }
-        if (historyRecord.source?.chart !== undefined) {
-          historyRecord.revision = { revisionID: revisionID };
-          return;
-        }
-        const revisionDetails = await api.getRevisionDetails({
-          url,
-          app,
-          appNamespace: appDetails.metadata.namespace,
-          revisionID,
-          instanceName,
-        });
-        historyRecord.revision = { revisionID: revisionID, ...revisionDetails };
-      });
-    await Promise.all(promises as readonly unknown[] | []);
-    return appDetails;
-  };
-
   const { loading, value, error, retry } = useAsyncRetry(async () => {
     const argoSearchMethod: boolean = Boolean(
       configApi.getOptionalConfigArray('argocd.appLocatorMethods')?.length,
     );
     try {
       if (!argoSearchMethod && appName) {
-        const appDetails = await api.getAppDetails({
-          url,
-          appName,
-          appNamespace,
-        });
-        if (
-          appDetails &&
-          appDetails?.status &&
-          appDetails?.status?.history &&
-          appDetails?.status?.history.length > 0
-        ) {
-          return getRevisionHistoryDetails(appDetails, appName);
-        }
-
-        return appDetails;
+        return await api.getAppDetails({ url, appName, appNamespace });
       }
       if (argoSearchMethod && appName) {
         const kubeInfo = await api.serviceLocatorUrl({
@@ -113,14 +68,6 @@ export const useAppDetails = ({
             };
           }
           apiOut.metadata.instance = instance;
-          if (
-            apiOut &&
-            apiOut?.status &&
-            apiOut?.status?.history &&
-            apiOut?.status?.history.length > 0
-          ) {
-            return getRevisionHistoryDetails(apiOut, appName, instance.name);
-          }
           return apiOut;
         });
         return await Promise.all(promises);
@@ -132,60 +79,27 @@ export const useAppDetails = ({
         });
         if (kubeInfo instanceof Error) return kubeInfo;
         const promises = kubeInfo.map(async (instance: any) => {
-          const apiOut = await api.getAppListDetails({
+          return await api.getAppListDetails({
             url,
             appSelector,
             appNamespace,
             instance: instance.name,
           });
-          return apiOut;
         });
         const output = await Promise.all(promises);
-        const items = {
+        return {
           items: output
             .flatMap(argoCdAppList => argoCdAppList.items)
             .filter(item => item !== null),
         };
-        const getRevisionHistroyPromises = items.items.map(
-          async (item: any) => {
-            if (item?.status.history && item?.status.history.length > 0) {
-              return getRevisionHistoryDetails(
-                item,
-                item.metadata.name,
-                item.metadata.instance.name,
-              );
-            }
-            return item;
-          },
-        );
-        return Promise.all(getRevisionHistroyPromises).then(result =>
-          result.filter(n => n),
-        );
       }
       if (appSelector || projectName) {
-        const result = await api.listApps({
+        return await api.listApps({
           url,
           appSelector,
           appNamespace,
           projectName,
         });
-        if (result.items && result.items.length > 0) {
-          const apps = {
-            items: result.items.filter(item => item !== null),
-          };
-          const getRevisionHistroyPromises = apps.items.map(
-            async (item: any) => {
-              if (item?.status.history && item?.status.history.length > 0) {
-                return getRevisionHistoryDetails(item, item.metadata.name);
-              }
-              return item;
-            },
-          );
-          return Promise.all(getRevisionHistroyPromises).then(output =>
-            output.filter(n => n),
-          );
-        }
-        return result;
       }
       return Promise.reject('Neither appName nor appSelector provided');
     } catch (e: any) {

--- a/plugins/frontend/backstage-plugin-argo-cd/src/types.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/types.ts
@@ -5,6 +5,23 @@ export const argoCDAppDeployRevisionDetails = t.type({
   date: t.union([t.string, t.undefined]),
   message: t.union([t.string, t.undefined]),
 });
+
+export const argoCDAppHistory = t.type({
+  id: t.union([t.number, t.undefined]),
+  revision: t.union([
+    t.type({
+      revisionID: t.union([t.number, t.undefined]),
+      author: t.union([t.number, t.undefined]),
+      date: t.union([t.string, t.undefined]),
+      message: t.union([t.string, t.undefined]),
+    }),
+    t.undefined,
+    t.string,
+  ]),
+  deployStartedAt: t.union([t.string, t.undefined]),
+  deployedAt: t.union([t.string, t.undefined]),
+});
+
 export const argoCDAppDetails = t.type({
   metadata: t.type({
     name: t.string,
@@ -31,30 +48,12 @@ export const argoCDAppDetails = t.type({
       }),
       t.undefined,
     ]),
-    history: t.union([
-      t.array(
-        t.type({
-          id: t.union([t.number, t.undefined]),
-          revision: t.union([
-            t.type({
-              revisionID: t.union([t.number, t.undefined]),
-              author: t.union([t.number, t.undefined]),
-              date: t.union([t.string, t.undefined]),
-              message: t.union([t.string, t.undefined]),
-            }),
-            t.undefined,
-            t.string,
-          ]),
-          deployStartedAt: t.union([t.string, t.undefined]),
-          deployedAt: t.union([t.string, t.undefined]),
-        }),
-      ),
-      t.undefined,
-    ]),
+    history: t.union([t.array(argoCDAppHistory), t.undefined]),
   }),
 });
 
 export type ArgoCDAppDetails = t.TypeOf<typeof argoCDAppDetails>;
+export type ArgoCDAppHistoryDetails = t.TypeOf<typeof argoCDAppHistory>;
 export type ArgoCDAppDeployRevisionDetails = t.TypeOf<
   typeof argoCDAppDeployRevisionDetails
 >;


### PR DESCRIPTION
This solves parts of issue #1121 because the `ArgoCDHistoryCard` took very long to load (and sometimes didn't load at all) if an app had many revisions. Therefore I implemented the following:

- Load the app details first and then lazy load all revisions
- Make the number of revisions to load configurable in the app configuration

I tested this with some internal apps that nearly never loaded before and with this change it worked much better.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)

> Note: I didn't add any screenshots because the UI still looks the same.

> Note2: I'm not a frontend dev but I did my best :D 
