### PR TITLE
Use the CORE_SCHEMA when parsing entity YAML

### DIFF
--- a/.changeset/nine-olives-deny.md
+++ b/.changeset/nine-olives-deny.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': patch
+---
+
+use CORE_SCHEMA when processing entity YAML to more closely reflect how Backstage core parses YAML

--- a/utils/roadie-backstage-entity-validator/src/validator.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.js
@@ -99,7 +99,7 @@ export const validate = async (
   };
 
   try {
-    const data = yaml.loadAll(fileContents);
+    const data = yaml.loadAll(fileContents, { schema: yaml.CORE_SCHEMA });
     data.forEach(it => {
       modifyPlaceholders(it);
     });

--- a/utils/roadie-backstage-entity-validator/src/validator.test.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.test.js
@@ -129,6 +129,20 @@ spec:
   providesApis:
     - sample-service
 `,
+      'catalog-info-with-date-annotation.yml': `
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sample-service-6
+  annotations:
+    annotation-with-date-like-value: 1955-11-05
+spec:
+  type: service
+  owner: group:team-atools
+  lifecycle: experimental
+`,
       'catalog-info-with-custom-fields.yml': `
     apiVersion: backstage.io/v1alpha1
     kind: Component
@@ -361,6 +375,29 @@ spec:
           lifecycle: 'production',
           owner: 'group:team-atools',
           definition: 'DUMMY TEXT',
+        },
+      },
+    ]);
+  });
+
+  it('Should successfully validate catalog info with an annotation that look like a date', async () => {
+    await expect(
+      validator.validateFromFile('catalog-info-with-date-annotation.yml'),
+    ).resolves.toEqual([
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'sample-service-6',
+          namespace: 'default',
+          annotations: {
+            'annotation-with-date-like-value': '1955-11-05',
+          },
+        },
+        spec: {
+          type: 'service',
+          lifecycle: 'experimental',
+          owner: 'group:team-atools',
         },
       },
     ]);


### PR DESCRIPTION
By default (an despite the [recommendations in the YAML spec](https://yaml.org/spec/1.2-old/spec.html#id2804923)), `js-yaml` [uses](https://www.npmjs.com/package/js-yaml#load-string---options-) a `DEFAULT_SCHEMA` which supports additional "special" types in the YAML document. This behavior differs from the `yaml` package (used by the core Backstage catalog processor/parser) which [defaults](https://eemeli.org/yaml/#schema-options) to the `CORE_SCHEMA` instead.

This change adjusts the usage of `js-yaml` to more closely reflect the actual YAML processor used by Backstage so that (for instance) if an annotation has a value that looks like a date, the value is parsed as a string (like `yaml` does) instead of a `Date` object (which is the default behavior under the `DEFAULT_SCHEMA` when parsing with `js-yaml`).

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
