### PR TITLE
Allow for the JSON file output after a 'merge` to match input file indentation.

### DIFF
--- a/.changeset/large-roses-dance.md
+++ b/.changeset/large-roses-dance.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': minor
+---
+
+Allow option for JSON output files after merging to match the input file indentation

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -409,6 +409,11 @@ spec:
 - path: The file path for the JSON you want to edit.
 - content: The JSON you want to merge in, as a string or a YAML object.
 
+**Optional params:**
+
+- mergeArrays: If `true` then where a value is an array the merge function will concatenate the provided array value with the target array.
+- matchFileIndent: If `true` then it will try and identify the indentation in the file specified by `path` and apply the same indentation to the output file. If not set (or `false`) it will use the default indentation of `2` spaces in the output file.
+
 #### Example Merge JSON template using an object input
 
 ```yaml

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
@@ -38,6 +38,7 @@
     "@backstage/plugin-scaffolder-node": "^0.2.8",
     "adm-zip": "^0.5.9",
     "cross-fetch": "^3.1.4",
+    "detect-indent": "^7.0.1",
     "fs-extra": "^10.0.0",
     "js-yaml": "^4.0.0",
     "jsonata": "^1.8.6",

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -192,6 +192,46 @@ describe('roadiehq:utils:json:merge', () => {
     });
   });
 
+  it('output file indentation should match default file indentation of 2 spaces', async () => {
+    const jsonData = {
+      scripts: {
+        lsltr: 'ls -ltr',
+      },
+      array: ['first item'],
+    };
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.json': JSON.stringify(jsonData, null, 4),
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.json',
+        mergeArrays: true,
+        content: {
+          scripts: {
+            lsltrh: 'ls -ltrh',
+          },
+          array: ['second item'],
+        },
+      },
+    });
+
+    expect(fs.existsSync('fake-tmp-dir/fake-file.json')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.json', 'utf-8');
+    expect(JSON.parse(file)).toEqual({
+      scripts: {
+        lsltr: 'ls -ltr',
+        lsltrh: 'ls -ltrh',
+      },
+      array: ['first item', 'second item'],
+    });
+    expect(detectIndent(file).amount).toBe(2);
+  });
+
   it('output file indentation should match input file indentation', async () => {
     const jsonData = {
       scripts: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16115,6 +16115,11 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
+detect-indent@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.1.tgz#cbb060a12842b9c4d333f1cac4aa4da1bb66bc25"
+  integrity sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==
+
 detect-libc@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"


### PR DESCRIPTION
This supports a new optional parameter with the `roadiehq:utils:json:merge` action:
* `matchFileIndent` 

This will check the source file and identify the indentation used - and then if set to true will write the output file with the same indentation. 
Useful where modifying existing JSON files with an indentation other than '2'

The default and fallback value it still '2'

This is a PR related to this issue: #1209 

I have added a simple additional test where it has a source file with 4 space indent, and checks the output file is also 4.
It checks that when the parameter is not set the output file indentation remains at '2'.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
