### PR TITLE
fix: ensure query params are preserved when not using namespaced apps

### DIFF
--- a/.changeset/tall-years-compete.md
+++ b/.changeset/tall-years-compete.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Fix issue where query params were stripped when not using namespaced apps

--- a/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/api/index.ts
@@ -19,7 +19,6 @@ import {
   isDecodeError as tsIsDecodeError,
 } from 'io-ts-promise';
 import reporter from 'io-ts-reporters';
-import { ARGOCD_ANNOTATION_APP_NAMESPACE } from '../components/useArgoCDAppData';
 
 export interface ArgoCDApi {
   listApps(options: {
@@ -67,6 +66,8 @@ export type Options = {
   useNamespacedApps: boolean;
 };
 
+const APP_NAMESPACE_QUERY_PARAM = 'appNamespace';
+
 export class ArgoCDApiClient implements ArgoCDApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly backendBaseUrl: string;
@@ -93,8 +94,7 @@ export class ArgoCDApiClient implements ArgoCDApi {
     const result = Object.keys(params)
       .filter(key => params[key] !== undefined)
       .filter(
-        key =>
-          this.useNamespacedApps || key === ARGOCD_ANNOTATION_APP_NAMESPACE,
+        key => key !== APP_NAMESPACE_QUERY_PARAM || this.useNamespacedApps,
       )
       .map(
         k =>


### PR DESCRIPTION
Resolves https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1181

I'm not 100% sure what the intent of with the param filtering is, but based on context provided from https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1126, I _believe_ that the intent is to remove the `appNamespace` query param if the Backstage instance is not opted into namespaced app support via `app-config.yaml`.


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes) **N/A**
- [x] Added or updated documentation (if applicable) **N/A**
