### PR TITLE
Start support for multi-doc transform

### DIFF
--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 export { createJSONataAction } from './jsonata';
-export { createYamlJSONataTransformAction } from './yaml';
+export { createYamlJSONataTransformAction, createYamlJSONataTransformAllAction } from './yaml';
 export { createJsonJSONataTransformAction } from './json';


### PR DESCRIPTION
Support for the LoadAll() function when converting YAML to JSON to be transformed by jsonata.  

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
