### PR TITLE
Error when importing detect-indent with scaffolder-backend-module-utils

### DIFF
--- a/.changeset/strange-rice-fry.md
+++ b/.changeset/strange-rice-fry.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+Resolve CommonJS vs ESM Module import use dynamic import)

--- a/.changeset/strange-rice-fry.md
+++ b/.changeset/strange-rice-fry.md
@@ -2,4 +2,4 @@
 '@roadiehq/scaffolder-backend-module-utils': patch
 ---
 
-Resolve CommonJS vs ESM Module import use dynamic import)
+Fix version of detect-indent to 6.1.0 to avoid ESM/CommonJS issues.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
@@ -38,7 +38,7 @@
     "@backstage/plugin-scaffolder-node": "^0.2.8",
     "adm-zip": "^0.5.9",
     "cross-fetch": "^3.1.4",
-    "detect-indent": "^7.0.1",
+    "detect-indent": "^6.1.0",
     "fs-extra": "^10.0.0",
     "js-yaml": "^4.0.0",
     "jsonata": "^1.8.6",

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -21,6 +21,7 @@ import { extname } from 'path';
 import { isArray, isNull, mergeWith } from 'lodash';
 import yaml from 'js-yaml';
 import { supportedDumpOptions, yamlOptionsSchema } from '../../types';
+import detectIndent from 'detect-indent';
 
 function mergeArrayCustomiser(objValue: string | any[], srcValue: any) {
   if (isArray(objValue) && !isNull(objValue)) {
@@ -106,7 +107,6 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
 
       let fileIndent = 2;
       if (ctx.input.matchFileIndent) {
-        const detectIndent = (await import('detect-indent')).default;
         fileIndent = detectIndent(
           fs.readFileSync(sourceFilepath, 'utf8'),
         ).amount;

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -21,7 +21,6 @@ import { extname } from 'path';
 import { isArray, isNull, mergeWith } from 'lodash';
 import yaml from 'js-yaml';
 import { supportedDumpOptions, yamlOptionsSchema } from '../../types';
-import detectIndent from 'detect-indent';
 
 function mergeArrayCustomiser(objValue: string | any[], srcValue: any) {
   if (isArray(objValue) && !isNull(objValue)) {
@@ -107,6 +106,7 @@ export function createMergeJSONAction({ actionId }: { actionId?: string }) {
 
       let fileIndent = 2;
       if (ctx.input.matchFileIndent) {
+        const detectIndent = (await import('detect-indent')).default;
         fileIndent = detectIndent(
           fs.readFileSync(sourceFilepath, 'utf8'),
         ).amount;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16110,15 +16110,10 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-detect-indent@^6.0.0:
+detect-indent@^6.0.0, detect-indent@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
-
-detect-indent@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.1.tgz#cbb060a12842b9c4d333f1cac4aa4da1bb66bc25"
-  integrity sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==
 
 detect-libc@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This is a patch change to my previous PR - which got missed in our testing.
When running locally all works fine - but when running in a container I see the following error:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/detect-indent/index.js from /app/node_modules/@roadiehq/scaffolder-backend-module-utils/dist/index.cjs.js not supported.
ovo-backstage-backstage-dev-1  | Instead change the require of index.js in /app/node_modules/@roadiehq/scaffolder-backend-module-utils/dist/index.cjs.js to a dynamic import() which is available in all CommonJS modules.
ovo-backstage-backstage-dev-1  |     at Object.<anonymous> (/app/node_modules/@roadiehq/scaffolder-backend-module-utils/dist/index.cjs.js:14:20)
ovo-backstage-backstage-dev-1  |     at Object.<anonymous> (/app/packages/backend/dist/index.cjs.js:42:36) {
ovo-backstage-backstage-dev-1  |   code: 'ERR_REQUIRE_ESM'
```

This PR changes from `require` to a dynamic import as suggested.  

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [X] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
