### PR TITLE
Use the CORE_SCHEMA when parsing entity YAML

### DIFF
--- a/.changeset/thin-singers-brake.md
+++ b/.changeset/thin-singers-brake.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': patch
+---
+
+use CORE_SCHEMA when parsing catalog YAML files for validation

--- a/utils/roadie-backstage-entity-validator/src/relativeSpaceValidation.js
+++ b/utils/roadie-backstage-entity-validator/src/relativeSpaceValidation.js
@@ -53,7 +53,7 @@ export const relativeSpaceValidation = async (
   verbose,
 ) => {
   try {
-    const data = yaml.loadAll(fileContents);
+    const data = yaml.loadAll(fileContents, { schema: yaml.CORE_SCHEMA });
     if (verbose) {
       console.log('Validating locally dependant catalog contents');
     }


### PR DESCRIPTION
This is a follow-up to #1198 and applies the same fix to keep YAML parsing inline with how Backstage core parses the catalog YAML files.

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
