### PR TITLE
Align cross-fetch dependency for scaffolder action

### DIFF
--- a/.changeset/light-guests-begin.md
+++ b/.changeset/light-guests-begin.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Bump `cross-fetch` to version "^4.0.0"

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/package.json
@@ -35,7 +35,7 @@
     "@backstage/core-app-api": "^1.11.1",
     "@backstage/core-plugin-api": "^1.8.0",
     "@backstage/plugin-scaffolder-backend": "^1.19.1",
-    "cross-fetch": "^3.1.4",
+    "cross-fetch": "^4.0.0",
     "winston": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR is bumping the version of `cross-fetch` to the latest major. This version has been in use for a couple versions of backstage now: https://github.com/backstage/backstage/pull/21229

For some reason, it was still working back then, but since we released the version 1.22 or Backstage, the scaffolder templates using this action would start to fail with a proper reason. Basically, after some investigation, the `fetch` inside the `http` helper method would just get stuck and the `Abort` signal would be triggered after 1 minute.

We were thinking that a routing issue was happening to us, but the same requests with curl and similar tools worked fine. So we tried to use a local version of this plugin but bumping the `cross-fetch` version to align to the other backstage dependencies. Suddenly this got fixed. So I would expect that this could be a potential issue for other people as well. I think it might also make sense to bump all the other dependencies as well, just to make sure this is not happening in other places.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
