### PR TITLE
fix: add proper content type header to argo DELETE request on app and project

### DIFF
--- a/.changeset/violet-ducks-check.md
+++ b/.changeset/violet-ducks-check.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-backend': patch
+---
+
+add proper content type header to argo DELETE request on app and project

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -619,6 +619,7 @@ export class ArgoService implements ArgoServiceApi {
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${argoToken}`,
+        'Content-Type': 'application/json',
       },
     };
 
@@ -650,6 +651,7 @@ export class ArgoService implements ArgoServiceApi {
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${argoToken}`,
+        'Content-Type': 'application/json',
       },
     };
 

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
@@ -475,6 +475,24 @@ describe('ArgoCD service', () => {
     expect(resp).toStrictEqual(true);
   });
 
+  it('should delete project with json content type header', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}));
+    await argoService.deleteProject({
+      baseUrl: 'https://argoInstance1.com',
+      argoProjectName: 'testApp',
+      argoToken: 'testToken',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+  });
+
   it('should fail to delete project in argo when bad status', async () => {
     fetchMock.mockResponseOnce(JSON.stringify({}), { status: 500 });
 
@@ -537,6 +555,24 @@ describe('ArgoCD service', () => {
     });
 
     expect(resp).toStrictEqual(true);
+  });
+
+  it('should delete app with json content type header', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({}));
+    await argoService.deleteApp({
+      baseUrl: 'https://argoInstance1.com',
+      argoApplicationName: 'testApp',
+      argoToken: 'testToken',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
   });
 
   it('should fail to delete app in argo when bad status', async () => {


### PR DESCRIPTION
- Add `Content-Type` header to `DELETE` request for Argo App and Project

Local Deletion Without Header:
![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/67761435/5082fdc8-1d4e-4726-afe8-91d884296e4b)

With Header:
![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/67761435/f875f8a8-41b5-4451-be2d-4e5e9a5bf707)


<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
