### PR TITLE
Allow unsetting SelectFieldFromApi

### DIFF
--- a/.changeset/smooth-tables-know.md
+++ b/.changeset/smooth-tables-know.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/plugin-scaffolder-frontend-module-http-request-field': patch
+---
+
+Allow unsetting the selected value

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/components/SelectFieldFromApi/SelectFieldFromApi.tsx
@@ -169,7 +169,15 @@ const SelectFieldFromApiComponent = (
         items={dropDownData}
         placeholder={placeholder}
         label={title}
-        onChange={selected => props.onChange(selected as string)}
+        onChange={selected => {
+          // The Select component adds the placeholder to the items list and gives it a value of []. This is incompatible
+          // with a field of type string so we need to unset the value in this case.
+          props.onChange(
+            Array.isArray(selected) && !selected.length
+              ? undefined
+              : selected.toString(),
+          );
+        }}
       />
       <FormHelperText>{description}</FormHelperText>
     </FormControl>


### PR DESCRIPTION
Allow users to unset the select field by clicking the placeholder value. Previously this set the value to an empty array but since we're not supporting multiselect this value is invalid. 


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
