### PR TITLE
fix(rag-ai-backend-retrieval-augmenter): 401 unauthorized in searchClient

### DIFF
--- a/.changeset/cuddly-lies-jam.md
+++ b/.changeset/cuddly-lies-jam.md
@@ -1,7 +1,6 @@
 ---
 '@roadiehq/rag-ai-backend-retrieval-augmenter': minor
 '@roadiehq/rag-ai-backend': minor
-'backend': minor
 ---
 
 Fix the 401 unauthorized error in searchClient for rag-ai-backend-retrieval-augmenter when using authMiddleware in backstage backend

--- a/.changeset/cuddly-lies-jam.md
+++ b/.changeset/cuddly-lies-jam.md
@@ -1,0 +1,7 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': minor
+'@roadiehq/rag-ai-backend': minor
+'backend': minor
+---
+
+Fix the 401 unauthorized error in searchClient for rag-ai-backend-retrieval-augmenter when using authMiddleware in backstage backend

--- a/packages/backend/src/plugins/ai.ts
+++ b/packages/backend/src/plugins/ai.ts
@@ -70,6 +70,7 @@ export default async function createPlugin({
       discovery,
       logger,
       vectorStore: augmentationIndexer.vectorStore,
+      tokenManager,
     }),
     model,
     config,

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/README.md
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/README.md
@@ -19,6 +19,7 @@ const retrievalPipeline = createDefaultRetrievalPipeline({
   discovery,
   logger,
   vectorStore: augmentationIndexer.vectorStore,
+  tokenManager,
 });
 ```
 

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/defaultInitializer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/defaultInitializer.ts
@@ -22,25 +22,34 @@ import {
 } from './retrieval';
 import { RoadieVectorStore } from '@roadiehq/rag-ai-node';
 import { Logger } from 'winston';
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import {
+  PluginEndpointDiscovery,
+  TokenManager,
+} from '@backstage/backend-common';
 
 export type DefaultRetrievalPipelineOptions = {
   vectorStore: RoadieVectorStore;
   logger: Logger;
   discovery: PluginEndpointDiscovery;
+  tokenManager: TokenManager;
 };
 
 export const createDefaultRetrievalPipeline = ({
   vectorStore,
   discovery,
   logger,
+  tokenManager,
 }: DefaultRetrievalPipelineOptions) => {
   const vectorEmbeddingsRetriever = new VectorEmbeddingsRetriever({
     vectorStore: vectorStore,
     logger,
   });
 
-  const searchRetriever = new SearchRetriever({ discovery, logger });
+  const searchRetriever = new SearchRetriever({
+    discovery,
+    logger,
+    tokenManager,
+  });
 
   const sourceBasedRetrieverConfig = new Map();
   sourceBasedRetrieverConfig.set('catalog', [

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/retrieval/retrievers/SearchClient.test.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/retrieval/retrievers/SearchClient.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SearchClient, SearchClientQuery } from './SearchClient';
+import {
+  PluginEndpointDiscovery,
+  TokenManager,
+} from '@backstage/backend-common';
+import { EmbeddingsSource } from '@roadiehq/rag-ai-node';
+
+describe('SearchClient', () => {
+  let mockDiscoveryApi: PluginEndpointDiscovery;
+  let mockTokenManager: TokenManager;
+  let mockLogger: any;
+  let searchClient: SearchClient;
+
+  beforeEach(() => {
+    mockDiscoveryApi = {
+      getBaseUrl: jest.fn().mockResolvedValue('http://mock-search-url'),
+      getExternalBaseUrl: jest.fn(),
+    };
+    mockTokenManager = {
+      getToken: jest.fn().mockResolvedValue({ token: 'mock-token' }),
+      authenticate: jest.fn(),
+    };
+    mockLogger = {
+      warn: jest.fn(),
+    };
+
+    searchClient = new SearchClient({
+      discoveryApi: mockDiscoveryApi,
+      tokenManager: mockTokenManager,
+      logger: mockLogger,
+    });
+  });
+
+  it('should create a SearchClient with the correct constructor parameters', () => {
+    expect(searchClient).toBeDefined();
+    expect(searchClient).toBeInstanceOf(SearchClient);
+  });
+
+  it('should set correct authorization header in query search method', async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({ results: [] }),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+    global.fetch = mockFetch;
+    const query: SearchClientQuery = {
+      term: 'catalog',
+      source: 'catalog' as EmbeddingsSource,
+    };
+
+    await searchClient.query(query);
+
+    expect(mockDiscoveryApi.getBaseUrl).toHaveBeenCalled();
+    expect(mockTokenManager.getToken).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://mock-search-url/query?term=catalog&types[0]=software-catalog',
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer mock-token',
+        },
+      },
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/retrieval/retrievers/SearchRetriever.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/retrieval/retrievers/SearchRetriever.ts
@@ -21,7 +21,10 @@ import {
 } from '@roadiehq/rag-ai-node';
 import { Logger } from 'winston';
 import { SearchClient } from './SearchClient';
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
+import {
+  PluginEndpointDiscovery,
+  TokenManager,
+} from '@backstage/backend-common';
 
 export class SearchRetriever implements AugmentationRetriever {
   private readonly searchClient: SearchClient;
@@ -31,16 +34,19 @@ export class SearchRetriever implements AugmentationRetriever {
     discovery,
     logger,
     searchClient,
+    tokenManager,
   }: {
     discovery: PluginEndpointDiscovery;
     logger: Logger;
     searchClient?: SearchClient;
+    tokenManager: TokenManager;
   }) {
     this.searchClient =
       searchClient ??
       new SearchClient({
         discoveryApi: discovery,
         logger: logger.child({ label: 'rag-ai-searchclient' }),
+        tokenManager,
       });
     this.logger = logger;
   }

--- a/plugins/backend/rag-ai-backend/README.md
+++ b/plugins/backend/rag-ai-backend/README.md
@@ -143,6 +143,7 @@ const retrievalPipeline = createDefaultRetrievalPipeline({
   discovery,
   logger,
   vectorStore: augmentationIndexer.vectorStore,
+  tokenManager,
 });
 ```
 
@@ -230,6 +231,7 @@ export default async function createPlugin({
       discovery,
       logger,
       vectorStore: augmentationIndexer.vectorStore,
+      tokenManager,
     }),
     model,
     config,
@@ -294,6 +296,7 @@ export default async function createPlugin({
       discovery,
       logger,
       vectorStore: augmentationIndexer.vectorStore,
+      tokenManager,
     }),
     model,
     config,


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

Fix: #1328 

Purpose of this PR is to add token while querying backstage search api in the `searchClient.ts` of this lib `rag-ai-backend-retrieval-augmenter` to avoid http 401 error when using authMiddleware in backstage backend

LMK if that's ok (not sure about the changeset?), or if it need improvement (I'm quite a newbie here 😄)

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
