### PR TITLE
Okta Backend Plugin should mask tokens #1277

### DIFF
--- a/.changeset/lazy-papayas-decide.md
+++ b/.changeset/lazy-papayas-decide.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Do not expose Okta secrets in frontend.

--- a/plugins/backend/catalog-backend-module-okta/src/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/types.ts
@@ -15,13 +15,41 @@
  */
 
 export type AccountConfig = {
+  /*
+   * The URL of the Okta organization.
+   * @visibility frontend
+   */
   orgUrl: string;
+  /*
+   * The API token to use for authentication.
+   * @visibility secret
+   */
   token?: string;
   oauth?: {
+    /*
+     * The client ID.
+     * @visibility secret
+     */
     clientId: string;
+    /*
+     * The client key.
+     * @visibility secret
+     */
     keyId?: string;
+    /*
+     * The private key.
+     * @visibility secret
+     */
     privateKey: string;
   };
+  /*
+   * The user filter to apply when fetching users.
+   * @visibility frontend
+   */
   userFilter?: string;
+  /*
+   * The group filter to apply when fetching groups.
+   * @visibility frontend
+   */
   groupFilter?: string;
 };


### PR DESCRIPTION
From a security perspective, sensitive values should be masked when presented in the UI.  This is outlined here:  https://backstage.io/docs/conf/defining/  

I may be being overly sensitive with the oauth bits, but better to be safe than sorry.  

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
