### PR TITLE
Add array as possible body input type to http:backstage:request action

### DIFF
--- a/.changeset/two-socks-obey.md
+++ b/.changeset/two-socks-obey.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': minor
+---
+
+Added array as possible body input type to http:backstage:request action

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -199,6 +199,43 @@ describe('http:backstage:request', () => {
       });
     });
 
+    describe('with body defined as application/json and passing an array', () => {
+      it('should create a request and pass body parameter', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify([
+              {
+                name: 'test',
+              },
+            ]),
+          },
+        });
+        expect(http).toHaveBeenCalledWith(
+          {
+            url: 'http://backstage.tests/api/proxy/foo',
+            method: 'POST',
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: '[{"name":"test"}]',
+          },
+          logger,
+          false,
+        );
+      });
+    });
+
     describe('with authorization header', () => {
       const BACKSTAGE_TOKEN = 'BACKSTAGE_TOKEN';
       it('should create a request and pass backstage token as authorization header', async () => {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -79,7 +79,7 @@ export function createHttpBackstageAction(options: {
           body: {
             title: 'Request body',
             description: 'The body you would like to pass to your request',
-            type: ['object', 'string'],
+            type: ['object', 'string', 'array'],
           },
           logRequestPath: {
             title: 'Request path logging',


### PR DESCRIPTION
Http request accept array in their body, so should _http:backstage:request_ action. This PR adds that.


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
