### PR TITLE
fix(plugins/backend/backstage-plugin-argo-cd-backend): argo response error unsupported media type

### DIFF
--- a/.changeset/silent-tables-invent.md
+++ b/.changeset/silent-tables-invent.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-backend': patch
+---
+
+fix: invalid media type error for argo instances that expect content type headerto be provided, we added content type for each argo call

--- a/.changeset/silent-tables-invent.md
+++ b/.changeset/silent-tables-invent.md
@@ -2,4 +2,4 @@
 '@roadiehq/backstage-plugin-argo-cd-backend': patch
 ---
 
-fix: invalid media type error for argo instances that expect content type headerto be provided, we added content type for each argo call
+fix: invalid media type error for argo instances that expect content type header to be provided, we added content type for each argo call.

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -595,6 +595,7 @@ export class ArgoService implements ArgoServiceApi {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${argoToken}`,
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
     };

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -1021,6 +1021,7 @@ export class ArgoService implements ArgoServiceApi {
     const options = {
       headers: {
         Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
       },
       method: 'GET',
     };
@@ -1078,6 +1079,7 @@ export class ArgoService implements ArgoServiceApi {
     const options = {
       headers: {
         Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
       },
       method: 'DELETE',
     };

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
@@ -1588,7 +1588,12 @@ describe('ArgoCD service', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(
         'https://argoInstance1.com/api/v1/applications/application',
-        expect.objectContaining({ headers: { Authorization: 'Bearer token' } }),
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/json',
+          },
+        }),
       );
     });
 
@@ -1851,7 +1856,10 @@ describe('ArgoCD service', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         'https://argoInstance1.com/api/v1/applications/application/operation',
         expect.objectContaining({
-          headers: { Authorization: 'Bearer token' },
+          headers: {
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/json',
+          },
           method: 'DELETE',
         }),
       );
@@ -1870,7 +1878,10 @@ describe('ArgoCD service', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         'https://passedArgoInstance1.com/api/v1/applications/application/operation',
         expect.objectContaining({
-          headers: { Authorization: 'Bearer passedToken' },
+          headers: {
+            Authorization: 'Bearer passedToken',
+            'Content-Type': 'application/json',
+          },
           method: 'DELETE',
         }),
       );


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

We received an "415 Unsupported Media Type" error when testing the latest implementation of argo cd backend plugin ([v3](https://github.com/RoadieHQ/roadie-backstage-plugins/releases/tag/release-2024-04-23)) that was released on 4/23/2024. Specifically when deleting argo applications with the terminate operation flag. The terminate call was failing with 415 Unsupported Media Type. 

To fix this, we need to add the content type to the header. 

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
