### PR TITLE
AWS Providers - Make owner tag mapping case insensitive

### DIFF
--- a/.changeset/lemon-kings-yell.md
+++ b/.changeset/lemon-kings-yell.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-aws': minor
+---
+
+Changes owner tag mapping to be case insensitive

--- a/plugins/backend/catalog-backend-module-aws/src/utils/tags.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/utils/tags.test.ts
@@ -72,6 +72,15 @@ describe('labelsFromTags and ownerFromTags', () => {
       expect(result).toBe('owner1');
     });
 
+    it('should return owner from array of tags with capitalisation', () => {
+      const tags = [
+        { Key: 'Owner', Value: 'owner1' },
+        { Key: 'Another', Value: 'value2' },
+      ];
+      const result = ownerFromTags(tags);
+      expect(result).toBe('owner1');
+    });
+
     it('should return "unknown" when no owner tag in array', () => {
       const tags = [
         { Key: 'tag:one', Value: 'value1' },

--- a/plugins/backend/catalog-backend-module-aws/src/utils/tags.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/utils/tags.ts
@@ -53,7 +53,9 @@ export const ownerFromTags = (
     return UNKNOWN_OWNER;
   }
   if (Array.isArray(tags)) {
-    const ownerTag = tags?.find(tag => tag.Key === ownerTagKey);
+    const ownerTag = tags?.find(
+      tag => tag.Key?.toLowerCase() === ownerTagKey.toLowerCase(),
+    );
     if (ownerTag) {
       return ownerTag.Value ? ownerTag.Value : UNKNOWN_OWNER;
     }


### PR DESCRIPTION
Make owner tag mapping case insensitive - currently the owner tag expected is a lowercase string but organisations often use AWS tagging conventions and may want to use an uppercase string for consistency. 

Having both breaks a validation rule at stitching time in the catalog backend.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
