### PR TITLE
make markdown card alerts less noisy

### DIFF
--- a/.changeset/angry-stingrays-beam.md
+++ b/.changeset/angry-stingrays-beam.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': patch
+---
+
+Make the static resource loading errors less noisy.

--- a/plugins/home/backstage-plugin-home-markdown/src/apis/GithubClient.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/apis/GithubClient.ts
@@ -41,11 +41,9 @@ const baseUrl = 'https://api.github.com';
 
 export class GithubClient implements GithubApi {
   private githubAuthApi: OAuthApi;
-  private errorApi: ErrorApi;
 
   constructor(deps: { githubAuthApi: OAuthApi; errorApi: ErrorApi }) {
     this.githubAuthApi = deps.githubAuthApi;
-    this.errorApi = deps.errorApi;
   }
 
   async getContent(props: {
@@ -99,7 +97,10 @@ export class GithubClient implements GithubApi {
             '',
           )}`;
         } catch (e: any) {
-          this.errorApi.post(e);
+          /* eslint no-console: ["error", { allow: ["warn"] }] */
+          console.warn(
+            `There was a problem loading the static resource ${href}: ${e.message}`,
+          );
         }
       }
     }


### PR DESCRIPTION
make markdown card alerts less noisy

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
