### PR TITLE
Add matchRegex to `roadiehq:utils:fs:replace` to allow for more complex replacements

### DIFF
--- a/.changeset/unlucky-scissors-decide.md
+++ b/.changeset/unlucky-scissors-decide.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': minor
+---
+
+Support regular expression substitution with roadiehq:utils:fs:replace

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -751,6 +751,10 @@ This action replaces found string in files with content defined in input.
 - files[].find: A text to be replaced
 - files[].replaceWith: A text to be used to replace above
 
+**Optional params:**
+
+- files[].matchRegex: If `true` then treats the `find` parameter as a regular expression.
+
 ```yaml
 ---
 parameters:

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/replaceInFile.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/replaceInFile.test.ts
@@ -103,4 +103,32 @@ describe('roadiehq:utils:fs:replace', () => {
     const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
     expect(file).toEqual('foo: baz');
   });
+  it('should replace regular expressions and write file to the workspacePath with the given content', async () => {
+    await fileCreationAction.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        content: 'foo: bar',
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        files: [
+          {
+            file: 'fake-file.yaml',
+            find: '(.*): (.*)',
+            matchRegex: true,
+            replaceWith: '$1: baz',
+          },
+        ],
+      } as any,
+    });
+    expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
+    expect(file).toEqual('foo: baz');
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/replaceInFile.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/fs/replaceInFile.ts
@@ -24,6 +24,7 @@ export function createReplaceInFileAction() {
     files: Array<{
       file: string;
       find: string;
+      matchRegex: boolean;
       replaceWith: string;
     }>;
   }>({
@@ -51,6 +52,10 @@ export function createReplaceInFileAction() {
                 find: {
                   type: 'string',
                   title: 'A string to be replaced',
+                },
+                matchRegex: {
+                  type: 'bool',
+                  title: 'Use regex to match the find string',
                 },
                 replaceWith: {
                   type: 'string',
@@ -83,8 +88,12 @@ export function createReplaceInFileAction() {
         );
         const content: string = fs.readFileSync(sourceFilepath).toString();
 
-        // Not regex
-        const replacedContent = content.replaceAll(file.find, file.replaceWith);
+        let find: string | RegExp = file.find;
+        if (file.matchRegex) {
+          find = new RegExp(file.find, 'g');
+        }
+
+        const replacedContent = content.replaceAll(find, file.replaceWith);
 
         fs.writeFileSync(sourceFilepath, replacedContent);
       }


### PR DESCRIPTION
When using  `roadiehq:utils:fs:replace` then you may wish to replace based on a regular expression.

For example we want to create a template that updates the `go.mod` to the latest go version. As we don't know which version the source is using then without a regular expression match we would have to search for every different option.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
