### PR TITLE
Show open issues by default in Security Insights & Dependabot

### DIFF
--- a/.changeset/smart-carrots-repair.md
+++ b/.changeset/smart-carrots-repair.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': patch
+---
+
+Dependabot and Security Insights tabs now show open issues by default instead of all issues.

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/DependabotAlertsTable/DependabotAlertsTable.tsx
@@ -105,7 +105,7 @@ export const DenseTable: FC<DenseTableProps> = ({ repository, detailsUrl }) => {
   const [filteredTableData, setFilteredTableData] = useState<Node[]>(
     repository.vulnerabilityAlerts.nodes,
   );
-  const [stateFilter, setStateFilter] = useState<StateFilter>('ALL');
+  const [stateFilter, setStateFilter] = useState<StateFilter>('OPEN');
 
   const filterAlerts = (newStateFilter: StateFilter) => {
     setStateFilter(newStateFilter);

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
@@ -38,7 +38,7 @@ const getElapsedTime = (start: string) => {
 
 export const SecurityInsightsTable = () => {
   const [insightsStatusFilter, setInsightsStatusFilter] =
-    useState<SecurityInsightFilterState>(null);
+    useState<SecurityInsightFilterState>('open');
   const [filteredTableData, setFilteredTableData] = useState<SecurityInsight[]>(
     [],
   );


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
This PR changes the Dependabot & Security Insights tab so that they show open issues by default. This addresses #1395 

![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/1874242/db588cfb-ceba-45c1-9aa2-153ee51de937)
![image](https://github.com/RoadieHQ/roadie-backstage-plugins/assets/1874242/e7e61f48-5e34-4107-9a1f-181a58764839)

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
