### PR TITLE
add preserveYamlComments input for roadiehq:utils:merge action

### DIFF
--- a/.changeset/chatty-cobras-fetch.md
+++ b/.changeset/chatty-cobras-fetch.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': minor
+---
+
+add preserveYamlComments input for roadiehq:utils:merge action

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -12,6 +12,7 @@ This contains a collection of actions to use in scaffolder templates:
 - [Serialise to JSON or YAML](#serialise)
 - [Parse and Transform JSON or YAML](#parse-and-transform-json-or-yaml)
 - [Merge new data into an existing JSON file](#merge-json)
+- [Merge](#merge)
 - [Append content to a file](#append)
 - [Write content to a file](#write-to-file)
 - [Replace in files](#replace-in-files)
@@ -568,6 +569,32 @@ spec:
       input:
         message: 'RemoteURL: ${{ steps["publish-pr"].output.remoteUrl }}'
 ```
+
+### Merge
+
+**Action name**: `roadiehq:utils:merge`
+
+**Required params:**
+
+- path: The file path for the file you want to edit.
+- content: The content you want to merge in, as a string or a YAML object.
+
+**Optional params:**
+
+- mergeArrays: If `true` then where a value is an array the merge function will concatenate the provided array value with the target array.
+- preserveYamlComments: If `true`, it will preserve standalone and inline comments in YAML files.
+- options: YAML stringify options to customize the output format.
+  - indent: (default: 2) - indentation width to use (in spaces).
+  - noArrayIndent: (default: false) - when true, will not add an indentation level to array elements.
+  - skipInvalid: (default: false) - do not throw on invalid types (like function in the safe schema) and skip pairs and single values with such types.
+  - flowLevel: (default: -1) - specifies level of nesting, when to switch from block to flow style for collections. -1 means block style everywhere.
+  - sortKeys: (default: false) - if true, sort keys when dumping YAML. If a function, use the function to sort the keys.
+  - lineWidth: (default: 80) - set max line width. Set -1 for unlimited width.
+  - noRefs: (default: false) - if true, don't convert duplicate objects into references.
+  - noCompatMode: (default: false) - if true, don't try to be compatible with older YAML versions. Currently: don't quote "yes", "no" and so on, as required for YAML 1.1.
+  - condenseFlow: (default: false) - if true, flow sequences will be condensed, omitting the space between a, b. Eg. '[a,b]', and omitting the space between key: value and quoting the key. Eg. '{"a":b}' Can be useful when using YAML for pretty URL query params as spaces are %-encoded.
+  - quotingType: (' or ", default: ') - strings will be quoted using this quoting style. If you specify single quotes, double quotes will still be used for non-printable characters.
+  - forceQuotes: (default: false) - if true, all non-key strings will be quoted even if they normally don't need to.
 
 ### Append
 

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
@@ -54,7 +54,8 @@
     "jsonata": "^2.0.4",
     "lodash": "^4.17.21",
     "winston": "^3.2.1",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "yawn-yaml": "^2.2.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.26.4",

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -522,7 +522,7 @@ scripts:
         'fake-file.yaml': '# This is a comment\nscripts:\n  lsltr: ls -ltr\n',
       },
     });
-  
+
     await action.handler({
       ...mockContext,
       workspacePath: 'fake-tmp-dir',

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -520,10 +520,11 @@ scripts:
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': `
-#Top-level comment
-scripts: #Trailing comment
-  #Nested comment
+# Top-level comment
+scripts: # Trailing comment
+  # Nested comment
   lsltr: ls -ltr
+  #Comment without space
 `,
       },
     });
@@ -544,9 +545,10 @@ scripts: #Trailing comment
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
-    expect(file).toContain('#Top-level comment');
-    expect(file).toContain('#Trailing comment');
-    expect(file).toContain('#Nested comment');
+    expect(file).toContain('# Top-level comment');
+    expect(file).toContain('# Trailing comment');
+    expect(file).toContain('# Nested comment');
+    expect(file).toContain('#Comment without space');
     expect(YAML.parse(file)).toEqual({
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });
@@ -556,10 +558,11 @@ scripts: #Trailing comment
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': `
-#Top-level comment
-scripts: #Trailing comment
-  #Nested comment
+# Top-level comment
+scripts: # Trailing comment
+  # Nested comment
   lsltr: ls -ltr
+  #Comment without space
 `,
       },
     });
@@ -580,9 +583,10 @@ scripts: #Trailing comment
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
-    expect(file).not.toContain('#Top-level comment');
-    expect(file).not.toContain('#Trailing comment');
-    expect(file).not.toContain('#Nested comment');
+    expect(file).not.toContain('# Top-level comment');
+    expect(file).not.toContain('# Trailing comment');
+    expect(file).not.toContain('# Nested comment');
+    expect(file).not.toContain('#Comment without space');
     expect(YAML.parse(file)).toEqual({
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -519,7 +519,12 @@ scripts:
   it('should preserve YAML comments when merging', async () => {
     mock({
       'fake-tmp-dir': {
-        'fake-file.yaml': '# This is a comment\nscripts:\n  lsltr: ls -ltr\n',
+        'fake-file.yaml': `
+# Top-level comment
+scripts:
+  # Nested comment
+  lsltr: ls -ltr
+`,
       },
     });
 
@@ -539,7 +544,8 @@ scripts:
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
-    expect(file).toContain('# This is a comment');
+    expect(file).toContain('# Top-level comment');
+    expect(file).toContain('# Nested comment');
     expect(YAML.parse(file)).toEqual({
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -550,4 +550,39 @@ scripts:
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });
   });
+
+  it('should not preserve YAML comments when preserveYamlComments is false', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': `
+# Top-level comment
+scripts:
+  # Nested comment
+  lsltr: ls -ltr
+`,
+      },
+    });
+
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        content: {
+          scripts: {
+            lsltrh: 'ls -ltrh',
+          },
+        },
+        preserveYamlComments: false,
+      },
+    });
+
+    expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
+    expect(file).not.toContain('# Top-level comment');
+    expect(file).not.toContain('# Nested comment');
+    expect(YAML.parse(file)).toEqual({
+      scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
+    });
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -529,6 +529,20 @@ scripts: # Trailing comment
       },
     });
 
+    const opts = {
+      indent: 3,
+      noArrayIndent: true,
+      skipInvalid: true,
+      flowLevel: 23,
+      sortKeys: true,
+      lineWidth: -1,
+      noRefs: true,
+      noCompatMode: true,
+      condenseFlow: true,
+      quotingType: '"' as const,
+      forceQuotes: true,
+    };
+
     await action.handler({
       ...mockContext,
       workspacePath: 'fake-tmp-dir',
@@ -540,6 +554,7 @@ scripts: # Trailing comment
           },
         },
         preserveYamlComments: true,
+        options: opts,
       },
     });
 

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -515,4 +515,33 @@ scripts:
       '/fake-tmp-dir/fake-file.json',
     );
   });
+
+  it('should preserve YAML comments when merging', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': '# This is a comment\nscripts:\n  lsltr: ls -ltr\n',
+      },
+    });
+  
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        content: {
+          scripts: {
+            lsltrh: 'ls -ltrh',
+          },
+        },
+        preserveYamlComments: true,
+      },
+    });
+
+    expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
+    const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
+    expect(file).toContain('# This is a comment');
+    expect(YAML.parse(file)).toEqual({
+      scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
+    });
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.test.ts
@@ -520,9 +520,9 @@ scripts:
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': `
-# Top-level comment
-scripts:
-  # Nested comment
+#Top-level comment
+scripts: #Trailing comment
+  #Nested comment
   lsltr: ls -ltr
 `,
       },
@@ -544,8 +544,9 @@ scripts:
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
-    expect(file).toContain('# Top-level comment');
-    expect(file).toContain('# Nested comment');
+    expect(file).toContain('#Top-level comment');
+    expect(file).toContain('#Trailing comment');
+    expect(file).toContain('#Nested comment');
     expect(YAML.parse(file)).toEqual({
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });
@@ -555,9 +556,9 @@ scripts:
     mock({
       'fake-tmp-dir': {
         'fake-file.yaml': `
-# Top-level comment
-scripts:
-  # Nested comment
+#Top-level comment
+scripts: #Trailing comment
+  #Nested comment
   lsltr: ls -ltr
 `,
       },
@@ -579,8 +580,9 @@ scripts:
 
     expect(fs.existsSync('fake-tmp-dir/fake-file.yaml')).toBe(true);
     const file = fs.readFileSync('fake-tmp-dir/fake-file.yaml', 'utf-8');
-    expect(file).not.toContain('# Top-level comment');
-    expect(file).not.toContain('# Nested comment');
+    expect(file).not.toContain('#Top-level comment');
+    expect(file).not.toContain('#Trailing comment');
+    expect(file).not.toContain('#Nested comment');
     expect(YAML.parse(file)).toEqual({
       scripts: { lsltr: 'ls -ltr', lsltrh: 'ls -ltrh' },
     });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -231,13 +231,16 @@ export function createMergeAction() {
           if (ctx.input.preserveYamlComments) {
             const yawn = new YAWN(originalContent);
             const parsedOriginal = yawn.json;
-            const mergedYamlContent = mergeWith(
+            const mergedJsonContent = mergeWith(
               parsedOriginal,
               newContent,
               ctx.input.mergeArrays ? mergeArrayCustomiser : undefined,
             );
-            yawn.json = mergedYamlContent;
-            mergedContent = yawn.yaml;
+            yawn.json = mergedJsonContent;
+            mergedContent = YAML.stringify(
+              YAML.parseDocument(yawn.yaml),
+              ctx.input.options,
+            );
           } else {
             mergedContent = YAML.stringify(
               mergeWith(

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -167,6 +167,13 @@ export function createMergeAction() {
             description:
               'Where a value is an array the merge function should concatenate the provided array value with the target array',
           },
+          preserveYamlComments: {
+            type: 'boolean',
+            default: false,
+            title: 'Preserve Comments?',
+            description:
+              'Will preserve standalone and inline comments in YAML files',
+          },
           options: {
             ...yamlOptionsSchema,
             description: `${yamlOptionsSchema.description}  (for YAML output only)`,
@@ -221,7 +228,9 @@ export function createMergeAction() {
               : ctx.input.content; // This supports the case where dynamic keys are required
           mergedContent = YAML.stringify(
             mergeWith(
-              YAML.parse(originalContent),
+              ctx.input.preserveYamlComments
+                ? YAML.parseDocument(originalContent)
+                : YAML.parse(originalContent),
               newContent,
               ctx.input.mergeArrays ? mergeArrayCustomiser : undefined,
             ),

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/merge/merge.ts
@@ -139,6 +139,7 @@ export function createMergeAction() {
     path: string;
     content: any;
     mergeArrays?: boolean;
+    preserveYamlComments?: boolean;
     options?: stringifyOptions;
   }>({
     id: 'roadiehq:utils:merge',

--- a/yarn.lock
+++ b/yarn.lock
@@ -30839,6 +30839,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-js@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/yaml-js/-/yaml-js-0.3.1.tgz#8f6f4300063364c2778be30f220736ae5e92c23c"
+  integrity sha512-LjoIFHCtSfkGzPsmYmfDsW+TShtQBcY7lwH1yLQ5brJHXRhjteUnVE2ThCbz1madq8JUZIAjFiavfnIFeTO8CQ==
+
 yaml@2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
@@ -30935,6 +30940,15 @@ yauzl@^3.0.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     pend "~1.2.0"
+
+yawn-yaml@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/yawn-yaml/-/yawn-yaml-2.2.0.tgz#aa9673725f7c277a8b97e8d12496d2333d701890"
+  integrity sha512-2SJvllxsNXwvbf6s8m7TNDtdn2zakLQpmrwpxIdCInLyEx+/WsZwSTScBOVk3zBbuFPeh7hc+yvUVtyKOgBeKQ==
+  dependencies:
+    js-yaml "^4.1.0"
+    lodash "^4.17.21"
+    yaml-js "^0.3.1"
 
 yml-loader@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
this adds an optional input that, if true, will use a new method to parse the source content which preserves comments

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
