### PR TITLE
Expose compatibility mode custom credentials for AWS providers

### DIFF
--- a/.changeset/kind-bottles-study.md
+++ b/.changeset/kind-bottles-study.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-aws': minor
+---
+
+Allow explicit temporary credentials construction for AWS entity providers to enable custom role assumption functionality.

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
@@ -39,21 +39,32 @@ export class AWSEC2Provider extends AWSEntityProvider {
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
+      useTemporaryCredentials?: boolean;
     },
   ) {
     const accountId = config.getString('accountId');
     const roleName = config.getString('roleName');
+    const roleArn = config.getOptionalString('roleArn');
     const externalId = config.getOptionalString('externalId');
     const region = config.getString('region');
 
     return new AWSEC2Provider(
-      { accountId, roleName, externalId, region },
+      { accountId, roleName, roleArn, externalId, region },
       options,
     );
   }
 
   getProviderName(): string {
     return `aws-ec2-provider-${this.accountId}-${this.providerId ?? 0}`;
+  }
+
+  private async getEc2() {
+    const credentials = this.useTemporaryCredentials
+      ? this.getCredentials()
+      : await this.getCredentialsProvider();
+    return this.useTemporaryCredentials
+      ? new EC2({ credentials, region: this.region })
+      : new EC2(credentials);
   }
 
   async run(): Promise<void> {
@@ -65,8 +76,7 @@ export class AWSEC2Provider extends AWSEntityProvider {
     this.logger.info(`Providing ec2 resources from aws: ${this.accountId}`);
     const ec2Resources: ResourceEntity[] = [];
 
-    const credentials = await this.getCredentialsProvider();
-    const ec2 = new EC2(credentials);
+    const ec2 = await this.getEc2();
 
     const defaultAnnotations = this.buildDefaultAnnotations();
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
@@ -40,21 +40,32 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
+      useTemporaryCredentials?: boolean;
     },
   ) {
     const accountId = config.getString('accountId');
     const roleName = config.getString('roleName');
+    const roleArn = config.getOptionalString('roleArn');
     const externalId = config.getOptionalString('externalId');
     const region = config.getString('region');
 
     return new AWSIAMRoleProvider(
-      { accountId, roleName, externalId, region },
+      { accountId, roleName, roleArn, externalId, region },
       options,
     );
   }
 
   getProviderName(): string {
     return `aws-iam-role-${this.accountId}-${this.providerId ?? 0}`;
+  }
+
+  private async getIam() {
+    const credentials = this.useTemporaryCredentials
+      ? this.getCredentials()
+      : await this.getCredentialsProvider();
+    return this.useTemporaryCredentials
+      ? new IAM({ credentials, region: this.region })
+      : new IAM(credentials);
   }
 
   async run(): Promise<void> {
@@ -68,11 +79,9 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
     );
     const roleResources: ResourceEntity[] = [];
 
-    const credentials = await this.getCredentialsProvider();
-
     const defaultAnnotations = this.buildDefaultAnnotations();
 
-    const iam = new IAM(credentials);
+    const iam = await this.getIam();
 
     const paginatorConfig = {
       client: iam,

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
@@ -36,21 +36,32 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
+      useTemporaryCredentials?: boolean;
     },
   ) {
     const accountId = config.getString('accountId');
     const roleName = config.getString('roleName');
+    const roleArn = config.getOptionalString('roleArn');
     const externalId = config.getOptionalString('externalId');
     const region = config.getString('region');
 
     return new AWSIAMUserProvider(
-      { accountId, roleName, externalId, region },
+      { accountId, roleName, roleArn, externalId, region },
       options,
     );
   }
 
   getProviderName(): string {
     return `aws-iam-user-${this.accountId}-${this.providerId ?? 0}`;
+  }
+
+  private async getIam() {
+    const credentials = this.useTemporaryCredentials
+      ? this.getCredentials()
+      : await this.getCredentialsProvider();
+    return this.useTemporaryCredentials
+      ? new IAM({ credentials, region: this.region })
+      : new IAM(credentials);
   }
 
   async run(): Promise<void> {
@@ -63,11 +74,9 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
     );
     const userResources: UserEntity[] = [];
 
-    const credentials = await this.getCredentialsProvider();
-
     const defaultAnnotations = this.buildDefaultAnnotations();
 
-    const iam = new IAM(credentials);
+    const iam = await this.getIam();
 
     const paginatorConfig = {
       client: iam,

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
@@ -40,21 +40,32 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
+      useTemporaryCredentials?: boolean;
     },
   ) {
     const accountId = config.getString('accountId');
     const roleName = config.getString('roleName');
+    const roleArn = config.getOptionalString('roleArn');
     const externalId = config.getOptionalString('externalId');
     const region = config.getString('region');
 
     return new AWSS3BucketProvider(
-      { accountId, roleName, externalId, region },
+      { accountId, roleName, roleArn, externalId, region },
       options,
     );
   }
 
   getProviderName(): string {
     return `aws-s3-bucket-${this.accountId}-${this.providerId ?? 0}`;
+  }
+
+  private async getS3() {
+    const credentials = this.useTemporaryCredentials
+      ? this.getCredentials()
+      : await this.getCredentialsProvider();
+    return this.useTemporaryCredentials
+      ? new S3({ credentials, region: this.region })
+      : new S3(credentials);
   }
 
   async run(): Promise<void> {
@@ -68,8 +79,7 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
     );
     const s3Resources: ResourceEntity[] = [];
 
-    const credentials = await this.getCredentialsProvider();
-    const s3 = new S3(credentials);
+    const s3 = await this.getS3();
 
     const defaultAnnotations = this.buildDefaultAnnotations();
 

--- a/plugins/backend/catalog-backend-module-aws/src/types.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/types.ts
@@ -61,6 +61,10 @@ export interface AWSAccountProviderConfig {
    */
   roleName: string;
   /**
+   * Role ARN to assume for this account ID
+   */
+  roleArn?: string;
+  /**
    * Region to use for this account ID
    */
   region?: string;
@@ -78,6 +82,7 @@ export interface AWSAccountProviderConfig {
 export type AccountConfig = {
   accountId: string;
   roleName: string;
+  roleArn?: string;
   externalId?: string;
   region: string;
 };


### PR DESCRIPTION
Allow explicit temporary credentials construction for AWS entity providers to enable custom role assumption functionality.
