### PR TITLE
Update README.md to fix roadiehq:utils:fs:parse example usage

### DIFF
--- a/.changeset/late-hotels-itch.md
+++ b/.changeset/late-hotels-itch.md
@@ -2,4 +2,4 @@
 '@roadiehq/scaffolder-backend-module-utils': patch
 ---
 
-fix readme documentation
+fix roadiehq:utils:fs:parse example on README.md file

--- a/.changeset/late-hotels-itch.md
+++ b/.changeset/late-hotels-itch.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': patch
+---
+
+fix readme documentation

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -248,7 +248,7 @@ spec:
         path: ${{ parameters.path }}
         parser: ${{ parameters.parser }}
   output:
-    content: ${{ steps.serialize.output.content }}
+    content: ${{ steps.parsefile.output.content }}
 ```
 
 ### Serialise to JSON or YAML


### PR DESCRIPTION
fix very small issue in usage example on roadiehq:utils:fs:parse

the output must be `steps.parsefile.output.content`

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
