### PR TITLE
Fix Homepage Markdown Github client use

### DIFF
--- a/.backstage/home-page.md
+++ b/.backstage/home-page.md
@@ -11,3 +11,5 @@ Pull requests
 Discord
 
 ![](https://github.com/RoadieHQ/roadie-backstage-plugins/blob/main/plugins/home/backstage-plugin-home-markdown/docs/home-page-markdown.png)
+
+![Amazon Alexa](https://img.shields.io/badge/amazon%20alexa-52b5f7?style=for-the-badge&logo=amazon%20alexa&logoColor=white)

--- a/.changeset/green-crabs-check.md
+++ b/.changeset/green-crabs-check.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': patch
+---
+
+Make sure the plugin uses the right GitHub Client

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.test.tsx
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.test.tsx
@@ -28,7 +28,10 @@ import {
   GetContentResponse,
   githubApiRef,
   GithubApi,
+  GithubClient,
 } from '../apis';
+
+jest.mock('../apis/GithubClient');
 
 const mockAccessToken = jest
   .fn()
@@ -86,6 +89,12 @@ const apis: [AnyApiRef, Partial<unknown>][] = [
 ];
 
 describe('<MarkdownContent>', () => {
+  beforeEach(() => {
+    const mockFromConfig = jest.fn().mockReturnValue(mockGithubApi);
+
+    GithubClient.fromConfig = mockFromConfig;
+  });
+
   it('should render sign in page', async () => {
     const mockGithubUnAuth = {
       getAccessToken: async (_: string[]) => 'test-token',

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
@@ -16,30 +16,18 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { Alert } from '@material-ui/lab';
-import { Progress, MarkdownContent } from '@backstage/core-components';
+import { MarkdownContent, Progress } from '@backstage/core-components';
 import {
-  useApi,
+  errorApiRef,
   githubAuthApiRef,
   SessionState,
+  useApi,
   useApiHolder,
-  ApiHolder,
-  errorApiRef,
-  ErrorApi,
 } from '@backstage/core-plugin-api';
 import { MarkdownContentProps } from './types';
-import { Button, Grid, Typography, Tooltip } from '@material-ui/core';
+import { Button, Grid, Tooltip, Typography } from '@material-ui/core';
 import useAsync from 'react-use/lib/useAsync';
 import { GithubClient } from '../apis';
-
-const getGithubClient = (apiHolder: ApiHolder, errorApi: ErrorApi) => {
-  const auth = apiHolder.get(githubAuthApiRef);
-  if (!auth) {
-    throw new Error(
-      'The MarkdownCard component Failed to get the github client',
-    );
-  }
-  return new GithubClient({ githubAuthApi: auth, errorApi });
-};
 
 const GithubFileContent = (props: MarkdownContentProps) => {
   const { preserveHtmlComments } = props;
@@ -47,7 +35,7 @@ const GithubFileContent = (props: MarkdownContentProps) => {
   const errorApi = useApi(errorApiRef);
 
   const { value, loading, error } = useAsync(async () => {
-    const githubClient = getGithubClient(apiHolder, errorApi);
+    const githubClient = GithubClient.fromConfig(apiHolder, errorApi);
     return githubClient.getContent({ ...props });
   }, [apiHolder]);
 

--- a/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
+++ b/plugins/home/backstage-plugin-home-markdown/src/MarkdownCard/Content.tsx
@@ -29,22 +29,16 @@ import {
 import { MarkdownContentProps } from './types';
 import { Button, Grid, Typography, Tooltip } from '@material-ui/core';
 import useAsync from 'react-use/lib/useAsync';
-import { githubApiRef, GithubClient, GithubApi } from '../apis';
+import { GithubClient } from '../apis';
 
 const getGithubClient = (apiHolder: ApiHolder, errorApi: ErrorApi) => {
-  let githubClient: GithubApi | undefined = apiHolder.get(githubApiRef);
-  if (!githubClient) {
-    const auth = apiHolder.get(githubAuthApiRef);
-    if (auth) {
-      githubClient = new GithubClient({ githubAuthApi: auth, errorApi });
-    }
-  }
-  if (!githubClient) {
+  const auth = apiHolder.get(githubAuthApiRef);
+  if (!auth) {
     throw new Error(
       'The MarkdownCard component Failed to get the github client',
     );
   }
-  return githubClient;
+  return new GithubClient({ githubAuthApi: auth, errorApi });
 };
 
 const GithubFileContent = (props: MarkdownContentProps) => {

--- a/plugins/home/backstage-plugin-home-markdown/src/apis/GithubClient.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/apis/GithubClient.ts
@@ -15,7 +15,12 @@
  */
 
 import { GithubApi } from './GithubApi';
-import { ErrorApi, OAuthApi } from '@backstage/core-plugin-api';
+import {
+  ApiHolder,
+  ErrorApi,
+  githubAuthApiRef,
+  OAuthApi,
+} from '@backstage/core-plugin-api';
 import { Octokit } from '@octokit/rest';
 
 const mimeTypeMap: Record<string, string> = {
@@ -44,6 +49,14 @@ export class GithubClient implements GithubApi {
 
   constructor(deps: { githubAuthApi: OAuthApi; errorApi: ErrorApi }) {
     this.githubAuthApi = deps.githubAuthApi;
+  }
+
+  static fromConfig(apiHolder: ApiHolder, errorApi: ErrorApi) {
+    const auth = apiHolder.get(githubAuthApiRef);
+    if (!auth) {
+      throw new Error('Failed to get the github client');
+    }
+    return new GithubClient({ githubAuthApi: auth, errorApi });
   }
 
   async getContent(props: {


### PR DESCRIPTION
It appears the GitHub client was not being used and we were using the generic client held by the apiHolder. 

This meant that logic defined in the custom client's getContent function was not being used. 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
