### PR TITLE
Fix private GitHub image rendering for Homepage Markdown 

### DIFF
--- a/.changeset/ten-turtles-leave.md
+++ b/.changeset/ten-turtles-leave.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-home-markdown': patch
+'app': patch
+---
+
+Fix private image rendering for GitHub

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -40,12 +40,6 @@ export const HomePage = () => {
             <HomePageYourOpenPullRequestsCard />
           </Grid>
           <Grid item xs={12} md={6}>
-            <HomePageRSS
-              feedURL="http://localhost:7007/api/proxy/aws-news-feed/"
-              title="AWS News"
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
             <CloudsmithStatsCard repo="roadie-npm" owner="roadie" />
           </Grid>
           <Grid item md={6} xs={12}>
@@ -56,6 +50,7 @@ export const HomePage = () => {
               feedURL="http://localhost:7007/api/proxy/reuters-news-feed/?best-topics=tech&post_type=best"
               title="Reuters News"
             />
+            s
           </Grid>
           <Grid item xs={12} md={6}>
             <HomePageMarkdown
@@ -63,15 +58,6 @@ export const HomePage = () => {
               owner="RoadieHQ"
               repo="roadie-backstage-plugins"
               path=".backstage/home-page.md"
-            />
-          </Grid>
-          <Grid item xs={12} md={6}>
-            <HomePageMarkdown
-              title="History"
-              owner="RoadieHQ"
-              repo="roadie-backstage-plugins"
-              path=".backstage/home-page-test.md"
-              branch="test-two-mdown"
             />
           </Grid>
           <Grid item xs={12} md={6}>

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -50,7 +50,6 @@ export const HomePage = () => {
               feedURL="http://localhost:7007/api/proxy/reuters-news-feed/?best-topics=tech&post_type=best"
               title="Reuters News"
             />
-            s
           </Grid>
           <Grid item xs={12} md={6}>
             <HomePageMarkdown

--- a/plugins/home/backstage-plugin-home-markdown/src/apis/GithubClient.ts
+++ b/plugins/home/backstage-plugin-home-markdown/src/apis/GithubClient.ts
@@ -105,12 +105,12 @@ export class GithubClient implements GithubApi {
           const contentResponse = await octokit.request(
             `GET /repos/${imageOwner}/${imageRepo}/contents/${filePath}`,
           );
-          const imageContent = Buffer.from(
-            contentResponse.data.content,
-            'base64',
-          ).toString('base64');
-          const encodedImage = encodeURIComponent(imageContent);
-          media[href] = `data:${mimeType};base64,${encodedImage}`;
+          media[
+            href
+          ] = `data:${mimeType};base64,${contentResponse.data.content.replaceAll(
+            '\n',
+            '',
+          )}`;
         } catch (e: any) {
           /* eslint no-console: ["error", { allow: ["warn"] }] */
           console.warn(


### PR DESCRIPTION

Before:
<img width="1473" alt="Screenshot 2024-06-21 at 17 41 40" src="https://github.com/RoadieHQ/roadie-backstage-plugins/assets/7934833/26d78848-e0bf-49b8-869c-3a656818e13a">


After:
<img width="1446" alt="Screenshot 2024-06-21 at 17 40 17" src="https://github.com/RoadieHQ/roadie-backstage-plugins/assets/7934833/5dba5ed8-48b9-4d05-b1b5-51c1d5456694">




#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
