### PR TITLE
buildkite plugin: optionally filter builds to specific branch

### DIFF
--- a/.changeset/fair-pets-bake.md
+++ b/.changeset/fair-pets-bake.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-buildkite': minor
+---
+
+Address issue #1459 by supporting the ability to optionally restrict the Buildkite builds table to only display builds of a particular branch, as specified by an optional `buildkite.com/branch` entity annotation.

--- a/packages/app/cypress/integration/buildkite.ts
+++ b/packages/app/cypress/integration/buildkite.ts
@@ -18,23 +18,47 @@
 import 'os';
 
 describe('Buildkite', () => {
-  beforeEach(() => {
-    cy.saveGithubToken();
-    cy.intercept(
-      'GET',
-      'http://localhost:7007/api/proxy/buildkite/api/organizations/exampleorganization/pipelines/exampleproject/builds?page=1&per_page=5 ',
-      { fixture: 'buildkite/builds.json' },
-    ).as('getBuilds');
+  describe('When the entity is configured to display all branch builds', () => {
+    beforeEach(() => {
+      cy.saveGithubToken();
+      cy.intercept(
+        'GET',
+        'http://localhost:7007/api/proxy/buildkite/api/organizations/exampleorganization/pipelines/exampleproject/builds?page=1&per_page=5',
+        { fixture: 'buildkite/builds.json' },
+      ).as('getBuilds');
+    });
+
+    describe('Navigate to CI/CD dashboard', () => {
+      it('should show Buildkite builds table', () => {
+        cy.visit('/catalog/default/component/sample-service-3/ci-cd');
+
+        cy.wait('@getBuilds');
+
+        cy.contains('Create PR to test');
+        cy.contains('Xantier-patch-1');
+      });
+    });
   });
 
-  describe('Navigate to CI/CD dashboard', () => {
-    it('should show Buildkite builds table', () => {
-      cy.visit('/catalog/default/component/sample-service-3/ci-cd');
+  describe('When the entity is configured to display the builds of a specific branch', () => {
+    beforeEach(() => {
+      cy.saveGithubToken();
+      cy.intercept(
+        'GET',
+        'http://localhost:7007/api/proxy/buildkite/api/organizations/exampleorganization/pipelines/exampleproject/builds?page=1&per_page=5&branch=main',
+        { fixture: 'buildkite/builds.json' },
+      ).as('getBuilds');
+    });
 
-      cy.wait('@getBuilds');
+    describe('Navigate to CI/CD dashboard', () => {
+      it('should show Buildkite builds table', () => {
+        cy.visit('/catalog/default/component/sample-service-4/ci-cd');
 
-      cy.contains('Create PR to test');
-      cy.contains('Xantier-patch-1');
+        cy.wait('@getBuilds');
+
+        cy.contains('Create PR to test');
+        cy.contains('Xantier-patch-1');
+      });
     });
   });
 });

--- a/packages/entities/test-entity.yaml
+++ b/packages/entities/test-entity.yaml
@@ -73,10 +73,25 @@ metadata:
     buildkite.com/project-slug: exampleorganization/exampleproject
     prometheus.io/alert: 'test alert name'
     prometheus.io/rule: node_memory_Active_bytes|instance,memUsage
-
 spec:
   type: service
   owner: roadie
   lifecycle: experimental
   providesApis:
     - sample-service-3
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sample-service-4
+  description: |
+    A service for testing the Buildkite plugin with a buildkite.com/branch annotation
+  annotations:
+    buildkite.com/project-slug: exampleorganization/exampleproject
+    buildkite.com/branch: main
+spec:
+  type: service
+  owner: roadie
+  lifecycle: experimental
+  providesApis:
+    - sample-service-4

--- a/plugins/frontend/backstage-plugin-buildkite/README.md
+++ b/plugins/frontend/backstage-plugin-buildkite/README.md
@@ -60,6 +60,10 @@ export const cicdContent = (
 metadata:
   annotations:
     buildkite.com/project-slug: [exampleorganization/exampleproject]
+    # Optional; the buildkite.com/branch annotation can be used to configure
+    # the plugin to only display builds of the specified branch name.
+    # If omitted, the plugin displays builds from all branches.
+    buildkite.com/branch: 'main'
 ```
 
 2. Get an api token from buildkite and export it to your shell.

--- a/plugins/frontend/backstage-plugin-buildkite/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/api/index.ts
@@ -56,10 +56,15 @@ export class BuildkiteApi {
     pipelineSlug: string,
     page: number,
     per_page: number,
+    branch?: string,
   ) {
     const ApiUrl = await this.getApiUrl();
+    let query = `?page=${page}&per_page=${per_page}`;
+    if (branch) {
+      query = `${query}&branch=${branch}`;
+    }
     const request = await this.fetchApi.fetch(
-      `${ApiUrl}/organizations/${orgSlug}/pipelines/${pipelineSlug}/builds?page=${page}&per_page=${per_page}`,
+      `${ApiUrl}/organizations/${orgSlug}/pipelines/${pipelineSlug}/builds${query}`,
     );
     if (!request.ok) {
       throw new Error(

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
@@ -149,10 +149,11 @@ export const CITableView: FC<TableProps> = ({
 );
 
 const BuildkiteBuildsTable: FC<{ entity: Entity }> = ({ entity }) => {
-  const { owner, repo } = useProjectEntity(entity);
+  const { owner, repo, branch } = useProjectEntity(entity);
   const [tableProps, { setPage, retry, setPageSize }] = useBuilds({
     owner,
     repo,
+    branch,
   });
 
   return (

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/useBuilds.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/useBuilds.ts
@@ -36,7 +36,15 @@ export const transform = (
   });
 };
 
-export const useBuilds = ({ owner, repo }: { owner: string; repo: string }) => {
+export const useBuilds = ({
+  owner,
+  repo,
+  branch,
+}: {
+  owner: string;
+  repo: string;
+  branch?: string;
+}) => {
   const api = useApi(buildKiteApiRef);
   const errorApi = useApi(errorApiRef);
 
@@ -47,7 +55,7 @@ export const useBuilds = ({ owner, repo }: { owner: string; repo: string }) => {
   const { value, loading, retry } = useAsyncRetry(async () => {
     let builds = [];
     try {
-      builds = await api.getBuilds(owner, repo, page + 1, pageSize);
+      builds = await api.getBuilds(owner, repo, page + 1, pageSize, branch);
     } catch (e: any) {
       errorApi.post(e);
     }

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/useProjectEntity.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/useProjectEntity.ts
@@ -15,13 +15,18 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
+import { BUILDKITE_ANNOTATION, BUILDKITE_BRANCH_ANNOTATION } from '../consts';
 
 export const useProjectEntity = (entity: Entity) => {
   const projectSlug = entity.metadata?.annotations?.[
-    'buildkite.com/project-slug'
+    BUILDKITE_ANNOTATION
+  ] as string;
+  const branch = entity.metadata?.annotations?.[
+    BUILDKITE_BRANCH_ANNOTATION
   ] as string;
   return {
     owner: projectSlug.split('/')[0],
     repo: projectSlug.split('/')[1],
+    branch: branch,
   };
 };

--- a/plugins/frontend/backstage-plugin-buildkite/src/consts.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/consts.ts
@@ -15,3 +15,4 @@
  */
 
 export const BUILDKITE_ANNOTATION = 'buildkite.com/project-slug';
+export const BUILDKITE_BRANCH_ANNOTATION = 'buildkite.com/branch';

--- a/plugins/frontend/backstage-plugin-buildkite/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/mocks/mocks.ts
@@ -22,6 +22,31 @@ export const entityMock = {
   },
 };
 
+export const entityMockWithBranchAnnotation = {
+  metadata: {
+    namespace: 'default',
+    annotations: {
+      'backstage.io/managed-by-location':
+        'url:https://github.com/mcalus3/sample-service/blob/master/buildkite-config.yaml',
+      'buildkite.com/project-slug': 'rbnetwork/example-pipeline',
+      'buildkite.com/branch': 'main',
+    },
+    name: 'sample-service',
+    description:
+      'A service for testing Backstage functionality. For example, we can trigger errors\non the sample-service, these are sent to Sentry, then we can view them in the \nBackstage plugin for Sentry.\n',
+    uid: '191a6877-8315-429a-bbd3-1051029de374',
+    etag: 'OWRkNmRiMTktZDYyYy00ZDM3LWFmNGItYjBhMWY2YTg4MDNk',
+    generation: 1,
+  },
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  spec: {
+    type: 'service',
+    owner: 'david@roadie.io',
+    lifecycle: 'experimental',
+  },
+};
+
 // http://localhost:7007/api/proxy/buildkite/api/organizations/rbnetwork/pipelines/example-pipeline/builds?page=1&per_page=5
 export const buildsResponseMock = [
   {


### PR DESCRIPTION
This addresses issue #1459 to support the ability to optionally restrict the Buildkite builds table to only display builds of a particular branch. The branch filter is controlled via an entity annotation. For example:

```yaml
metadata:
  annotations:
    'buildkite.com/branch': 'main'
```

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
