### PR TITLE
Sanitize AWS tags as labels

### DIFF
--- a/.changeset/quiet-readers-pay.md
+++ b/.changeset/quiet-readers-pay.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-aws': patch
+---
+
+Add label value/key sanitization to remove trailing unsupported characters.

--- a/plugins/backend/catalog-backend-module-aws/src/utils/tags.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/utils/tags.test.ts
@@ -62,6 +62,17 @@ describe('labelsFromTags and ownerFromTags', () => {
       ).toBe(true);
     });
 
+    it('should handle a url with a succeeding slash as a value', () => {
+      const tags = [
+        { Key: 'tag:one:two', Value: 'https://blha.com/blahblah/' },
+      ];
+      const result = labelsFromTags(tags);
+      expect(result).toEqual({ tag_one_two: 'https---blha.com-blahblah' });
+      expect(
+        KubernetesValidatorFunctions.isValidLabelValue(result.tag_one_two),
+      ).toBe(true);
+    });
+
     it('should ignore keys without values in an object of tags', () => {
       const tags = { 'tag:one': 'value1', 'tag:two': undefined };
       // @ts-ignore

--- a/plugins/backend/catalog-backend-module-aws/src/utils/tags.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/utils/tags.ts
@@ -30,6 +30,10 @@ const TAG_DOMAIN = 'domain';
 const dependencyTags = [TAG_DEPENDENCY_OF, TAG_DEPENDS_ON];
 const relationshipTags = [TAG_SYSTEM, TAG_DOMAIN];
 
+function stripTrailingChar(str: string, chr: string) {
+  return str.endsWith(chr) ? str.slice(0, -1) : str;
+}
+
 export const labelsFromTags = (tags?: Tag[] | Record<string, string>) => {
   if (!tags) {
     return {};
@@ -45,10 +49,15 @@ export const labelsFromTags = (tags?: Tag[] | Record<string, string>) => {
       )
       .reduce((acc: Record<string, string>, tag) => {
         if (tag.Key && tag.Value) {
-          const key = tag.Key.replaceAll(':', '_').replaceAll('/', '-');
-          acc[key] = tag.Value.replaceAll('/', '-')
+          let key = tag.Key.replaceAll(':', '_')
+            .replaceAll('/', '-')
+            .substring(0, 63);
+          key = stripTrailingChar(stripTrailingChar(key, '-'), '_');
+          let val = tag.Value.replaceAll('/', '-')
             .replaceAll(':', '-')
             .substring(0, 63);
+          val = stripTrailingChar(val, '-');
+          acc[key] = val;
         }
         return acc;
       }, {});


### PR DESCRIPTION
Add label value/key sanitization to remove trailing unsupported characters.
