### PR TITLE
fix: update payload to match spec for update argo project

### DIFF
--- a/.changeset/gold-chicken-approve.md
+++ b/.changeset/gold-chicken-approve.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-backend': patch
+---
+
+fix: update argo project payload to match spec for update argo project

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -374,13 +374,15 @@ export class ArgoService implements ArgoServiceApi {
     resourceVersion,
     destinationServer,
   }: UpdateArgoProjectProps): Promise<object> {
-    const data = this.buildArgoProjectPayload({
-      projectName,
-      namespace,
-      sourceRepo,
-      resourceVersion,
-      destinationServer,
-    });
+    const data = {
+      project: this.buildArgoProjectPayload({
+        projectName,
+        namespace,
+        sourceRepo,
+        resourceVersion,
+        destinationServer,
+      }),
+    };
 
     const options: RequestInit = {
       method: 'PUT',

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
@@ -1510,6 +1510,38 @@ describe('ArgoCD service', () => {
       );
     });
 
+    it('should send correct project payload', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoApp
+
+      await argoService.updateArgoProjectAndApp(data);
+
+      const fetchBody = JSON.parse(fetchMock.mock.calls[2][1]?.body as string);
+
+      expect(fetchBody).toStrictEqual(
+        expect.objectContaining({
+          project: {
+            metadata: expect.objectContaining({
+              name: 'projectName',
+            }),
+            spec: expect.objectContaining({
+              destinations: [
+                {
+                  name: 'local',
+                  namespace: 'namespace',
+                  server: 'https://kubernetes.default.svc',
+                },
+              ],
+              sourceRepos: ['sourceRepo'],
+            }),
+          },
+        }),
+      );
+    });
+
     it('should return true when app and project update succeeds', async () => {
       fetchMock
         .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
- update the update argo project payload to match the spec

Previous Payload: 

```json
{
  "metadata": {},
  "spec": {},
}
```

New Payload:

```json
{
  "project": {
    "metadata": {},
    "spec": {},
  }
}
```

Spec:
![image](https://github.com/user-attachments/assets/8df8fe3e-f70a-4ae7-a8a5-f4bce4959d0d)

Not working:
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/e3cd1814-50e0-4a21-8c32-a4a904a96ea9">

Working with updated spec:
<img width="944" alt="image" src="https://github.com/user-attachments/assets/ad0d770c-85a8-4f67-a5e5-c8470907bb4a">


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
