### PR TITLE
Expand params in SelectFieldFromApi Scaffolder field extension

### DIFF
--- a/.changeset/fifty-sloths-sleep.md
+++ b/.changeset/fifty-sloths-sleep.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/plugin-scaffolder-frontend-module-http-request-field': patch
+---
+
+Relax validation on params to allow an array of key-value pairs to be used as query params. Expands the usage to support params with duplicate keys.

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/src/types.ts
@@ -21,7 +21,10 @@ export type OAuthConfig = {
 };
 
 export const selectFieldFromApiConfigSchema = z.object({
-  params: z.record(z.string(), z.string()).optional(),
+  params: z
+    .record(z.string(), z.string())
+    .optional()
+    .or(z.array(z.record(z.string(), z.string())).optional()),
   path: z.string(),
   arraySelector: z.string().or(z.array(z.string())).optional(),
   valueSelector: z.string().or(z.array(z.string())).optional(),


### PR DESCRIPTION
 Relax validation on params to allow an array of key-value pairs to be used as query params. Expands the usage to support params with duplicate keys. 