### PR TITLE
feat(ai): make `RagModal` title customizable

### DIFF
--- a/.changeset/witty-dolphins-hear.md
+++ b/.changeset/witty-dolphins-hear.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai': patch
+---
+
+Added optional property `title` to component `RagModal`

--- a/plugins/frontend/rag-ai/src/components/RagModal/RagModal.tsx
+++ b/plugins/frontend/rag-ai/src/components/RagModal/RagModal.tsx
@@ -66,7 +66,7 @@ const useStyles = makeStyles(theme => ({
   viewResultsLink: { verticalAlign: '0.5em' },
 }));
 
-export const RagModal = () => {
+export const RagModal = ({ title = 'AI Assistant' }: { title?: string }) => {
   const classes = useStyles();
   const [showAiModal, setShowAiModal] = useState(false);
   const [thinking, setThinking] = useState(false);
@@ -97,7 +97,7 @@ export const RagModal = () => {
       maxWidth="lg"
     >
       <DialogTitle>
-        <Typography variant="h6">AI Assistant</Typography>
+        <Typography variant="h6">{title}</Typography>
         <IconButton
           aria-label="close"
           className={classes.closeButton}


### PR DESCRIPTION
This small PR adds support for customizing the title of `RagModal`.

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
