### PR TITLE
feat(ai): limit concurrency for generating TechDocs embeddings

### DIFF
--- a/.changeset/five-experts-sing.md
+++ b/.changeset/five-experts-sing.md
@@ -2,4 +2,4 @@
 '@roadiehq/rag-ai-backend-retrieval-augmenter': patch
 ---
 
-Added option `parallelismLimit` to `SplitterOptions` for limiting concurrency during creating TechDocs embeddings
+Added option `concurrencyLimit` to `SplitterOptions` for limiting concurrency during creating TechDocs embeddings

--- a/.changeset/five-experts-sing.md
+++ b/.changeset/five-experts-sing.md
@@ -2,4 +2,4 @@
 '@roadiehq/rag-ai-backend-retrieval-augmenter': patch
 ---
 
-Added option `concurrencyLimit` to `SplitterOptions` for limiting concurrency during creating TechDocs embeddings
+Added config parameter `ai.embeddings.concurrencyLimit` for limiting concurrency during creating TechDocs embeddings

--- a/.changeset/five-experts-sing.md
+++ b/.changeset/five-experts-sing.md
@@ -1,5 +1,7 @@
 ---
 '@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+'@roadiehq/rag-ai-backend-embeddings-openai': patch
+'@roadiehq/rag-ai-backend-embeddings-aws': patch
 ---
 
 Added config parameter `ai.embeddings.concurrencyLimit` for limiting concurrency during creating TechDocs embeddings

--- a/.changeset/five-experts-sing.md
+++ b/.changeset/five-experts-sing.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+---
+
+Added option `parallelismLimit` to `SplitterOptions` for limiting concurrency during creating TechDocs embeddings

--- a/.changeset/tidy-kiwis-beam.md
+++ b/.changeset/tidy-kiwis-beam.md
@@ -1,6 +1,7 @@
 ---
 '@roadiehq/rag-ai-backend-retrieval-augmenter': patch
 '@roadiehq/rag-ai-backend-embeddings-openai': patch
+'@roadiehq/rag-ai-backend-embeddings-aws': patch
 ---
 
 Rename `SplitterOptions` to `AugmentationOptions`

--- a/.changeset/tidy-kiwis-beam.md
+++ b/.changeset/tidy-kiwis-beam.md
@@ -4,4 +4,4 @@
 '@roadiehq/rag-ai-backend-embeddings-aws': patch
 ---
 
-Rename `SplitterOptions` to `AugmentationOptions`
+Renamed type `SplitterOptions` to `AugmentationOptions`

--- a/.changeset/tidy-kiwis-beam.md
+++ b/.changeset/tidy-kiwis-beam.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+'@roadiehq/rag-ai-backend-embeddings-openai': patch
+---
+
+Rename `SplitterOptions` to `AugmentationOptions`

--- a/plugins/backend/rag-ai-backend-embeddings-aws/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/src/index.ts
@@ -24,7 +24,7 @@ import { CatalogApi } from '@backstage/catalog-client';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { AwsCredentialIdentity, Provider } from '@aws-sdk/types';
 import { Config } from '@backstage/config';
-import { SplitterOptions } from '@roadiehq/rag-ai-backend-retrieval-augmenter';
+import { AugmentationOptions } from '@roadiehq/rag-ai-backend-retrieval-augmenter';
 
 export interface RoadieBedrockEmbeddingsConfig {
   logger: Logger;
@@ -51,11 +51,11 @@ export async function initializeBedrockEmbeddings({
   logger.info('Initializing Roadie AWS Bedrock Embeddings');
   const bedrockConfig = config.get<BedrockConfig>('ai.embeddings.bedrock');
   const embeddingsOptions = config.getOptionalConfig('ai.embeddings');
-  const splitterOptions: SplitterOptions = {};
+  const augmentationOptions: AugmentationOptions = {};
   if (embeddingsOptions) {
-    splitterOptions.chunkSize =
+    augmentationOptions.chunkSize =
       embeddingsOptions.getOptionalNumber('chunkSize');
-    splitterOptions.chunkOverlap =
+    augmentationOptions.chunkOverlap =
       embeddingsOptions.getOptionalNumber('chunkOverlap');
   }
   return new RoadieBedrockAugmenter({
@@ -66,6 +66,6 @@ export async function initializeBedrockEmbeddings({
     tokenManager,
     options,
     bedrockConfig,
-    splitterOptions,
+    augmentationOptions,
   });
 }

--- a/plugins/backend/rag-ai-backend-embeddings-aws/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/src/index.ts
@@ -57,7 +57,7 @@ export async function initializeBedrockEmbeddings({
       embeddingsOptions.getOptionalNumber('chunkSize');
     augmentationOptions.chunkOverlap =
       embeddingsOptions.getOptionalNumber('chunkOverlap');
-    augmentationOptions.parallelismLimit =
+    augmentationOptions.concurrencyLimit =
       embeddingsOptions.getOptionalNumber('concurrencyLimit');
   }
   return new RoadieBedrockAugmenter({

--- a/plugins/backend/rag-ai-backend-embeddings-aws/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/src/index.ts
@@ -57,6 +57,8 @@ export async function initializeBedrockEmbeddings({
       embeddingsOptions.getOptionalNumber('chunkSize');
     augmentationOptions.chunkOverlap =
       embeddingsOptions.getOptionalNumber('chunkOverlap');
+    augmentationOptions.parallelismLimit =
+      embeddingsOptions.getOptionalNumber('concurrencyLimit');
   }
   return new RoadieBedrockAugmenter({
     vectorStore,

--- a/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
@@ -54,7 +54,7 @@ export async function initializeOpenAiEmbeddings({
     vectorStore,
     catalogApi,
     discovery,
-    options: augmentationOptions,
+    augmentationOptions,
     logger: logger.child({ label: 'roadie-openai-embeddings' }),
     tokenManager,
     config: openAiConfig,

--- a/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
@@ -20,7 +20,7 @@ import { OpenAiConfig, RoadieOpenAiAugmenter } from './RoadieOpenAiAugmenter';
 import { CatalogApi } from '@backstage/catalog-client';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { Config } from '@backstage/config';
-import { SplitterOptions } from '@roadiehq/rag-ai-backend-retrieval-augmenter';
+import { AugmentationOptions } from '@roadiehq/rag-ai-backend-retrieval-augmenter';
 
 export interface RoadieBedrockEmbeddingsConfig {
   logger: Logger;
@@ -43,18 +43,18 @@ export async function initializeOpenAiEmbeddings({
   const openAiConfig = config.get<OpenAiConfig>('ai.embeddings.openai');
 
   const embeddingsOptions = config.getOptionalConfig('ai.embeddings');
-  const splitterOptions: SplitterOptions = {};
+  const augmentationOptions: AugmentationOptions = {};
   if (embeddingsOptions) {
-    splitterOptions.chunkSize =
+    augmentationOptions.chunkSize =
       embeddingsOptions.getOptionalNumber('chunkSize');
-    splitterOptions.chunkOverlap =
+    augmentationOptions.chunkOverlap =
       embeddingsOptions.getOptionalNumber('chunkOverlap');
   }
   return new RoadieOpenAiAugmenter({
     vectorStore,
     catalogApi,
     discovery,
-    splitterOptions,
+    options: augmentationOptions,
     logger: logger.child({ label: 'roadie-openai-embeddings' }),
     tokenManager,
     config: openAiConfig,

--- a/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
@@ -49,6 +49,8 @@ export async function initializeOpenAiEmbeddings({
       embeddingsOptions.getOptionalNumber('chunkSize');
     augmentationOptions.chunkOverlap =
       embeddingsOptions.getOptionalNumber('chunkOverlap');
+    augmentationOptions.parallelismLimit =
+      embeddingsOptions.getOptionalNumber('concurrencyLimit');
   }
   return new RoadieOpenAiAugmenter({
     vectorStore,

--- a/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
@@ -49,7 +49,7 @@ export async function initializeOpenAiEmbeddings({
       embeddingsOptions.getOptionalNumber('chunkSize');
     augmentationOptions.chunkOverlap =
       embeddingsOptions.getOptionalNumber('chunkOverlap');
-    augmentationOptions.parallelismLimit =
+    augmentationOptions.concurrencyLimit =
       embeddingsOptions.getOptionalNumber('concurrencyLimit');
   }
   return new RoadieOpenAiAugmenter({

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/config.d.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/config.d.ts
@@ -29,6 +29,10 @@ export interface Config {
        * The overlap between adjacent chunks of embeddings. The bigger the number, the more overlap..
        */
       chunkOverlap?: number;
+      /**
+       * The maximum number of concurrent requests when creating embeddings.
+       */
+      concurrencyLimit?: number;
     };
   };
 }

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/package.json
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/package.json
@@ -41,6 +41,7 @@
     "@roadiehq/rag-ai-node": "^0.1.2",
     "langchain": "^0.1.21",
     "node-fetch": "^2.6.7",
+    "p-limit": "^6.1.0",
     "winston": "^3.11.0",
     "yn": "^4.0.0"
   },

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/package.json
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/package.json
@@ -41,7 +41,7 @@
     "@roadiehq/rag-ai-node": "^0.1.2",
     "langchain": "^0.1.21",
     "node-fetch": "^2.6.7",
-    "p-limit": "^6.1.0",
+    "p-limit": "^3.0.2",
     "winston": "^3.11.0",
     "yn": "^4.0.0"
   },

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
@@ -38,7 +38,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   private readonly tokenManager: TokenManager;
   private readonly discovery: DiscoveryService;
 
-  private readonly options?: AugmentationOptions;
+  private readonly augmentationOptions?: AugmentationOptions;
 
   protected constructor({
     vectorStore,
@@ -47,7 +47,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     tokenManager,
     embeddings,
     discovery,
-    options,
+    augmentationOptions,
   }: {
     vectorStore: RoadieVectorStore;
     catalogApi: CatalogApi;
@@ -55,11 +55,11 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     tokenManager: TokenManager;
     embeddings: Embeddings;
     discovery: DiscoveryService;
-    options?: AugmentationOptions;
+    augmentationOptions?: AugmentationOptions;
   }) {
     vectorStore.connectEmbeddings(embeddings);
     this._vectorStore = vectorStore;
-    this.options = options;
+    this.augmentationOptions = augmentationOptions;
     this.catalogApi = catalogApi;
     this.logger = logger;
     this.tokenManager = tokenManager;
@@ -81,8 +81,8 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   protected getSplitter() {
     // Defaults to 1000 chars, 200 overlap
     return new RecursiveCharacterTextSplitter({
-      chunkSize: this.options?.chunkSize,
-      chunkOverlap: this.options?.chunkOverlap,
+      chunkSize: this.augmentationOptions?.chunkSize,
+      chunkOverlap: this.augmentationOptions?.chunkOverlap,
     });
   }
 
@@ -138,7 +138,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     source: EmbeddingsSource,
     filter?: EntityFilterShape,
   ) {
-    const limit = pLimit(this.options?.parallelismLimit ?? 10);
+    const limit = pLimit(this.augmentationOptions?.parallelismLimit ?? 10);
 
     switch (source) {
       case 'catalog': {

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
@@ -17,7 +17,7 @@
 import { TokenManager } from '@backstage/backend-common';
 import { CATALOG_FILTER_EXISTS, CatalogApi } from '@backstage/catalog-client';
 import { Logger } from 'winston';
-import { SearchIndex, SplitterOptions, TechDocsDocument } from './types';
+import { SearchIndex, AugmentationOptions, TechDocsDocument } from './types';
 import { Embeddings } from '@langchain/core/embeddings';
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
@@ -29,6 +29,7 @@ import {
   RoadieVectorStore,
 } from '@roadiehq/rag-ai-node';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
+import pLimit from 'p-limit';
 
 export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   private readonly _vectorStore: RoadieVectorStore;
@@ -37,7 +38,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   private readonly tokenManager: TokenManager;
   private readonly discovery: DiscoveryService;
 
-  private readonly splitterOptions?: SplitterOptions;
+  private readonly options?: AugmentationOptions;
 
   protected constructor({
     vectorStore,
@@ -46,7 +47,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     tokenManager,
     embeddings,
     discovery,
-    splitterOptions,
+    options,
   }: {
     vectorStore: RoadieVectorStore;
     catalogApi: CatalogApi;
@@ -54,11 +55,11 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     tokenManager: TokenManager;
     embeddings: Embeddings;
     discovery: DiscoveryService;
-    splitterOptions?: SplitterOptions;
+    options?: AugmentationOptions;
   }) {
     vectorStore.connectEmbeddings(embeddings);
     this._vectorStore = vectorStore;
-    this.splitterOptions = splitterOptions;
+    this.options = options;
     this.catalogApi = catalogApi;
     this.logger = logger;
     this.tokenManager = tokenManager;
@@ -80,8 +81,8 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   protected getSplitter() {
     // Defaults to 1000 chars, 200 overlap
     return new RecursiveCharacterTextSplitter({
-      chunkSize: this.splitterOptions?.chunkSize,
-      chunkOverlap: this.splitterOptions?.chunkOverlap,
+      chunkSize: this.options?.chunkSize,
+      chunkOverlap: this.options?.chunkOverlap,
     });
   }
 
@@ -137,6 +138,8 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     source: EmbeddingsSource,
     filter?: EntityFilterShape,
   ) {
+    const limit = pLimit(this.options?.parallelismLimit ?? 10);
+
     switch (source) {
       case 'catalog': {
         const { token } = await this.tokenManager.getToken();
@@ -171,37 +174,39 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
 
         const techDocsBaseUrl = await this.discovery.getBaseUrl('techdocs');
 
-        const documentsPromises = entitiesResponse.items.map(async entity => {
-          const { kind } = entity;
-          const { namespace = 'default', name } = entity.metadata;
+        const documentsPromises = entitiesResponse.items.map(entity =>
+          limit(async () => {
+            const { kind } = entity;
+            const { namespace = 'default', name } = entity.metadata;
 
-          const searchIndexUrl = `${techDocsBaseUrl}/static/docs/${namespace}/${kind}/${name}/search/search_index.json`;
+            const searchIndexUrl = `${techDocsBaseUrl}/static/docs/${namespace}/${kind}/${name}/search/search_index.json`;
 
-          try {
-            const searchIndexResponse = await fetch(searchIndexUrl, {
-              headers: {
-                Authorization: `Bearer ${token}`,
-              },
-            });
+            try {
+              const searchIndexResponse = await fetch(searchIndexUrl, {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              });
 
-            const searchIndex =
-              (await searchIndexResponse.json()) as SearchIndex;
+              const searchIndex =
+                (await searchIndexResponse.json()) as SearchIndex;
 
-            return searchIndex.docs.reduce<TechDocsDocument[]>((acc, doc) => {
-              // only filter sections that contain text
-              if (doc.location.includes('#') && doc.text)
-                acc.push({ text: doc.text, entity });
+              return searchIndex.docs.reduce<TechDocsDocument[]>((acc, doc) => {
+                // only filter sections that contain text
+                if (doc.location.includes('#') && doc.text)
+                  acc.push({ text: doc.text, entity });
 
-              return acc;
-            }, []);
-          } catch (e) {
-            this.logger.debug(
-              `Failed to retrieve tech docs search index for entity ${namespace}/${kind}/${name}`,
-              e,
-            );
-            return [];
-          }
-        });
+                return acc;
+              }, []);
+            } catch (e) {
+              this.logger.debug(
+                `Failed to retrieve tech docs search index for entity ${namespace}/${kind}/${name}`,
+                e,
+              );
+              return [];
+            }
+          }),
+        );
 
         const documents = (await Promise.all(documentsPromises)).flat();
 

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
@@ -138,7 +138,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
     source: EmbeddingsSource,
     filter?: EntityFilterShape,
   ) {
-    const limit = pLimit(this.augmentationOptions?.parallelismLimit ?? 10);
+    const limit = pLimit(this.augmentationOptions?.concurrencyLimit ?? 10);
 
     switch (source) {
       case 'catalog': {

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/index.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { DefaultVectorAugmentationIndexer } from './DefaultVectorAugmentationIndexer';
-export type { RoadieEmbeddingsConfig, SplitterOptions } from './types';
+export type { RoadieEmbeddingsConfig, AugmentationOptions } from './types';

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/types.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/types.ts
@@ -23,7 +23,7 @@ import { Entity } from '@backstage/catalog-model';
 export type AugmentationOptions = {
   chunkSize?: number;
   chunkOverlap?: number;
-  parallelismLimit?: number;
+  concurrencyLimit?: number;
 };
 
 export interface RoadieEmbeddingsConfig {

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/types.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/types.ts
@@ -20,9 +20,10 @@ import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { RoadieVectorStore } from '@roadiehq/rag-ai-node';
 import { Entity } from '@backstage/catalog-model';
 
-export type SplitterOptions = {
+export type AugmentationOptions = {
   chunkSize?: number;
   chunkOverlap?: number;
+  parallelismLimit?: number;
 };
 
 export interface RoadieEmbeddingsConfig {
@@ -31,7 +32,7 @@ export interface RoadieEmbeddingsConfig {
   vectorStore: RoadieVectorStore;
   catalogApi: CatalogApi;
   discovery: PluginEndpointDiscovery;
-  splitterOptions?: SplitterOptions;
+  options?: AugmentationOptions;
 }
 
 export type SearchIndex = {

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/types.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/types.ts
@@ -32,7 +32,7 @@ export interface RoadieEmbeddingsConfig {
   vectorStore: RoadieVectorStore;
   catalogApi: CatalogApi;
   discovery: PluginEndpointDiscovery;
-  options?: AugmentationOptions;
+  augmentationOptions?: AugmentationOptions;
 }
 
 export type SearchIndex = {

--- a/plugins/backend/rag-ai-backend/README.md
+++ b/plugins/backend/rag-ai-backend/README.md
@@ -57,6 +57,9 @@ ai:
     # (Optional) The overlap between adjacent chunks of embeddings. The bigger the number, the more overlap. Defaults to 200
     chunkOverlap: 200
 
+    # (Optional) The maximum number of concurrent requests when creating embeddings. Defaults to 10
+    concurrencyLimit: 10
+
     # AWS Bedrock Embeddings configuration
     awsBedrock:
       # (Required) Name of the Bedrock model to use to create Embeddings.

--- a/yarn.lock
+++ b/yarn.lock
@@ -12346,12 +12346,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@^18.0.0":
   version "18.2.25"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.25.tgz#2946a30081f53e7c8d585eb138277245caedc521"
   integrity sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==
   dependencies:
     "@types/react" "*"
+
+"@types/react-dom@<18.0.0":
+  version "17.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
+  integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
+  dependencies:
+    "@types/react" "^17"
 
 "@types/react-redux@^7.1.20":
   version "7.1.33"
@@ -12391,12 +12398,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
   version "18.2.79"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.79.tgz#c40efb4f255711f554d47b449f796d1c7756d865"
   integrity sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.13.1 || ^17.0.0", "@types/react@^17":
+  version "17.0.80"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
+  integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/recharts@^1.8.14":
@@ -12445,6 +12461,11 @@
   integrity sha512-DrH26m7CV6PB4YVckjbSIx+xloB7HBolr9Ctm0gZBffSu5dDV4yJKFQGPquJlReVW+xmg59gx+b/8/qYHxZEuw==
   dependencies:
     htmlparser2 "^4.1.0"
+
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.5.0":
   version "7.5.8"
@@ -24640,6 +24661,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.1.0.tgz#d91f9364d3fdff89b0a45c70d04ad4e0df30a0e8"
+  integrity sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==
+  dependencies:
+    yocto-queue "^1.1.1"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -30987,6 +31015,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
+  integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 yup@^1.0.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12346,19 +12346,12 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@^18.0.0":
-  version "18.2.25"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.25.tgz#2946a30081f53e7c8d585eb138277245caedc521"
-  integrity sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==
+"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
+  integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
   dependencies:
     "@types/react" "*"
-
-"@types/react-dom@<18.0.0":
-  version "17.0.25"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
-  integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
-  dependencies:
-    "@types/react" "^17"
 
 "@types/react-redux@^7.1.20":
   version "7.1.33"
@@ -12398,21 +12391,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
-  version "18.2.79"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.79.tgz#c40efb4f255711f554d47b449f796d1c7756d865"
-  integrity sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
+  version "18.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
+  integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.13.1 || ^17.0.0", "@types/react@^17":
-  version "17.0.80"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
-  integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/recharts@^1.8.14":
@@ -12461,11 +12445,6 @@
   integrity sha512-DrH26m7CV6PB4YVckjbSIx+xloB7HBolr9Ctm0gZBffSu5dDV4yJKFQGPquJlReVW+xmg59gx+b/8/qYHxZEuw==
   dependencies:
     htmlparser2 "^4.1.0"
-
-"@types/scheduler@^0.16":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
-  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.5.0":
   version "7.5.8"
@@ -24661,13 +24640,6 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.1.0.tgz#d91f9364d3fdff89b0a45c70d04ad4e0df30a0e8"
-  integrity sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==
-  dependencies:
-    yocto-queue "^1.1.1"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -31015,11 +30987,6 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-yocto-queue@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
-  integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 yup@^1.0.0:
   version "1.4.0"


### PR DESCRIPTION
This PR adds config parameter `ai.embeddings.concurrencyLimit` for limiting concurrency during creating TechDocs embeddings, as mentioned in [a comment](https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1491#discussion_r1688205228) of #1491.

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
- [x] Added or updated documentation (if applicable)