### PR TITLE
feat(ai): add source `all` for querying all sources simultaneously

### DIFF
--- a/.changeset/long-forks-trade.md
+++ b/.changeset/long-forks-trade.md
@@ -1,0 +1,8 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+'@roadiehq/rag-ai-backend': patch
+'@roadiehq/rag-ai-node': patch
+'@roadiehq/rag-ai': patch
+---
+
+Added source `all` for querying all sources simultaneously

--- a/.changeset/mighty-drinks-collect.md
+++ b/.changeset/mighty-drinks-collect.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-storage-pgvector': patch
+---
+
+Use `JSON.stringify` for passing the filter to the query

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/defaultInitializer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/defaultInitializer.ts
@@ -52,7 +52,7 @@ export const createDefaultRetrievalPipeline = ({
   });
 
   const sourceBasedRetrieverConfig = new Map();
-  ['catalog', 'tech-docs'].forEach(source => {
+  ['catalog', 'tech-docs', 'all'].forEach(source => {
     sourceBasedRetrieverConfig.set(source, [
       vectorEmbeddingsRetriever,
       searchRetriever,

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/retrieval/retrievers/VectorEmbeddingsRetriever.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/retrieval/retrievers/VectorEmbeddingsRetriever.ts
@@ -48,7 +48,7 @@ export class VectorEmbeddingsRetriever implements AugmentationRetriever {
     _filter?: EntityFilterShape,
   ): Promise<EmbeddingDoc[]> {
     const embeddings = await this.vectorStore.similaritySearch(query, {
-      source,
+      source: source !== 'all' ? source : undefined,
     });
 
     this.logger.info(

--- a/plugins/backend/rag-ai-backend/src/service/router.ts
+++ b/plugins/backend/rag-ai-backend/src/service/router.ts
@@ -44,7 +44,7 @@ const sourceValidator =
   (supportedSources: string[]) =>
   (req: Request, res: Response, next: NextFunction) => {
     const source = req.params.source;
-    if (!supportedSources.includes(source)) {
+    if (!supportedSources.includes(source) && source !== 'all') {
       return res.status(422).json({
         message: `Only ${supportedSources.join(
           ', ',

--- a/plugins/backend/rag-ai-node/src/types.ts
+++ b/plugins/backend/rag-ai-node/src/types.ts
@@ -15,12 +15,12 @@
  */
 import { Embeddings } from '@langchain/core/embeddings';
 
-export type EmbeddingsSource = 'catalog' | 'tech-docs';
+export type EmbeddingsSource = 'catalog' | 'tech-docs' | 'all';
 
-export type EmbeddingDocMetadata = {
+export type EmbeddingDocMetadata = Partial<{
   source: EmbeddingsSource;
   [key: string]: string;
-};
+}>;
 
 export type EntityFilterShape =
   | Record<string, string | symbol | (string | symbol)[]>[]

--- a/plugins/backend/rag-ai-storage-pgvector/src/service/RoadiePgVectorStore.ts
+++ b/plugins/backend/rag-ai-storage-pgvector/src/service/RoadiePgVectorStore.ts
@@ -222,7 +222,7 @@ export class RoadiePgVectorStore implements RoadieVectorStore {
     const documents = (
       await this.client.raw(queryString, {
         embeddingString,
-        filter: filter ?? '{}',
+        filter: JSON.stringify(filter || {}),
         amount,
       })
     ).rows;

--- a/plugins/backend/rag-ai-storage-pgvector/src/service/RoadiePgVectorStore.ts
+++ b/plugins/backend/rag-ai-storage-pgvector/src/service/RoadiePgVectorStore.ts
@@ -222,7 +222,7 @@ export class RoadiePgVectorStore implements RoadieVectorStore {
     const documents = (
       await this.client.raw(queryString, {
         embeddingString,
-        filter: JSON.stringify(filter || {}),
+        filter: JSON.stringify(filter ?? {}),
         amount,
       })
     ).rows;

--- a/plugins/frontend/rag-ai/src/components/RagModal/QuestionBox.tsx
+++ b/plugins/frontend/rag-ai/src/components/RagModal/QuestionBox.tsx
@@ -43,7 +43,7 @@ export const QuestionBox = (props: {
   const { onSubmit = () => {}, fullWidth = true, onClear } = props;
   const [label, setLabel] = useState('Ask the LLM');
   const [value, setValue] = useState<string>('');
-  const [source, setSource] = useState<string>('catalog');
+  const [source, setSource] = useState<string>('all');
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -142,6 +142,7 @@ export const QuestionBox = (props: {
             label="Source"
             onChange={e => setSource(e.target.value as string)}
           >
+            <MenuItem value="all">All</MenuItem>
             <MenuItem value="catalog">Catalog</MenuItem>
             <MenuItem value="tech-docs">TechDocs</MenuItem>
           </Select>


### PR DESCRIPTION
This PR adds a new source, `all`, for querying all sources simultaneously.

<img width="1151" alt="Schermafbeelding_2024-07-24_om_15 21 46-2" src="https://github.com/user-attachments/assets/8d8d5e4f-2eba-4d1a-aa48-d54d0502bc33">

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
