### PR TITLE
buildkite plugin: support 'defaultBranchOnly' property

### DIFF
--- a/.changeset/olive-bats-visit.md
+++ b/.changeset/olive-bats-visit.md
@@ -1,0 +1,34 @@
+---
+'@roadiehq/backstage-plugin-buildkite': patch
+---
+
+Address issue #1490 to support the ability to only display default branch builds.
+
+A `defaultBranchOnly` property can be set on the component, configuring the
+component to dynamically detect the entity's default branch and only display
+builds of that branch:
+
+```ts
+// packages/app/src/components/catalog/EntityPage.tsx
+export const cicdContent = (
+  <EntitySwitch>
+    <EntitySwitch.Case if={isBuildkiteAvailable}>
+      <EntityBuildkiteContent defaultBranchOnly />
+    </EntitySwitch.Case>
+    ...
+  </EntitySwitch>
+);
+```
+
+Alternatively, the configuration can be also be set on a per-entity basis via
+a `buildkite.com/default-branch-only` annotation whose value can be `true` or `false`:
+
+```yaml
+metadata:
+  annotations:
+    'buildkite.com/default-branch-only': 'true'
+```
+
+A `buildkite.com/branch` annotation takes precedence over both
+`<EntityBuildkiteContent defaultBranchOnly />` and per-entity
+`buildkite.com/default-branch-only` annotations.

--- a/packages/app/cypress/fixtures/buildkite/pipeline.json
+++ b/packages/app/cypress/fixtures/buildkite/pipeline.json
@@ -1,0 +1,3 @@
+{
+  "default_branch": "foo"
+}

--- a/packages/app/cypress/integration/buildkite.ts
+++ b/packages/app/cypress/integration/buildkite.ts
@@ -51,11 +51,40 @@ describe('Buildkite', () => {
     });
 
     describe('Navigate to CI/CD dashboard', () => {
-      it('should show Buildkite builds table', () => {
+      it('should show Buildkite builds table limited only to builds of the specified branch', () => {
         cy.visit('/catalog/default/component/sample-service-4/ci-cd');
 
         cy.wait('@getBuilds');
 
+        cy.contains('exampleorganization/exampleproject (main)');
+        cy.contains('Create PR to test');
+        cy.contains('Xantier-patch-1');
+      });
+    });
+  });
+
+  describe('When the entity is configured to display default branch builds only', () => {
+    beforeEach(() => {
+      cy.saveGithubToken();
+      cy.intercept(
+        'GET',
+        'http://localhost:7007/api/proxy/buildkite/api/organizations/exampleorganization/pipelines/exampleproject',
+        { fixture: 'buildkite/pipeline.json' },
+      ).as('getPipeline');
+      cy.intercept(
+        'GET',
+        'http://localhost:7007/api/proxy/buildkite/api/organizations/exampleorganization/pipelines/exampleproject/builds?page=1&per_page=5&branch=foo',
+        { fixture: 'buildkite/builds.json' },
+      ).as('getBuilds');
+    });
+
+    describe('Navigate to CI/CD dashboard', () => {
+      it('should show Buildkite builds table limited to the default branch builds', () => {
+        cy.visit('/catalog/default/component/sample-service-5/ci-cd');
+
+        cy.wait(['@getPipeline', '@getBuilds']);
+
+        cy.contains('exampleorganization/exampleproject (foo)');
         cy.contains('Create PR to test');
         cy.contains('Xantier-patch-1');
       });

--- a/packages/entities/test-entity.yaml
+++ b/packages/entities/test-entity.yaml
@@ -95,3 +95,19 @@ spec:
   lifecycle: experimental
   providesApis:
     - sample-service-4
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sample-service-5
+  description: |
+    A service for testing the Buildkite plugin with a buildkite.com/default-branch-only annotation
+  annotations:
+    buildkite.com/project-slug: exampleorganization/exampleproject
+    buildkite.com/default-branch-only: foo
+spec:
+  type: service
+  owner: roadie
+  lifecycle: experimental
+  providesApis:
+    - sample-service-5

--- a/plugins/frontend/backstage-plugin-buildkite/README.md
+++ b/plugins/frontend/backstage-plugin-buildkite/README.md
@@ -41,11 +41,27 @@ import {
 
 ```ts
 // packages/app/src/components/catalog/EntityPage.tsx
-
 export const cicdContent = (
   <EntitySwitch>
     <EntitySwitch.Case if={isBuildkiteAvailable}>
       <EntityBuildkiteContent />
+    </EntitySwitch.Case>
+    ...
+  </EntitySwitch>
+);
+```
+
+Alternatively, the plugin can be configured to only display default branch
+builds (However, this may be overwritten on a per-entity basis via a
+`buildkite.com/branch` or `buildkite.com/default-branch-only: false` entity
+annotations, as explained below):
+
+```ts
+// packages/app/src/components/catalog/EntityPage.tsx
+export const cicdContent = (
+  <EntitySwitch>
+    <EntitySwitch.Case if={isBuildkiteAvailable}>
+      <EntityBuildkiteContent defaultBranchOnly />
     </EntitySwitch.Case>
     ...
   </EntitySwitch>
@@ -62,8 +78,22 @@ metadata:
     buildkite.com/project-slug: [exampleorganization/exampleproject]
     # Optional; the buildkite.com/branch annotation can be used to configure
     # the plugin to only display builds of the specified branch name.
+    #
     # If omitted, the plugin displays builds from all branches.
+    #
+    # Note that 'buildkite.com/branch' takes precedence over a
+    # globally-configured <EntityBuildkiteContent defaultBranchOnly />.
     buildkite.com/branch: 'main'
+    # Optional; the buildkite.com/default-branch-only annotation can be used to
+    # configure the plugin to only display builds of the default branch name,
+    # the value of which is dynamically determined via the Buildkite API.
+    #
+    # Note that...
+    # A 'buildkite.com/branch' annotation takes precedence over 'buildkite.com/default-branch-only'.
+    # A 'buildkite.com/default-branch-only: false' takes precedence over a
+    # globally-configured <EntityBuildkiteContent defaultBranchOnly />.
+    # "true" and "false" are the only supported values.
+    buildkite.com/default-branch-only: 'true'
 ```
 
 2. Get an api token from buildkite and export it to your shell.

--- a/plugins/frontend/backstage-plugin-buildkite/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/api/index.ts
@@ -55,6 +55,19 @@ export class BuildkiteApi {
     return `${proxyUrl}${this.proxyPath}`;
   }
 
+  async getPipeline(orgSlug: string, pipelineSlug: string) {
+    const ApiUrl = await this.getApiUrl();
+    const request = await this.fetchApi.fetch(
+      `${ApiUrl}/organizations/${orgSlug}/pipelines/${pipelineSlug}`,
+    );
+    if (!request.ok) {
+      throw new Error(
+        `failed to fetch data, status ${request.status}: ${request.statusText}`,
+      );
+    }
+    return request.json();
+  }
+
   async getBuilds(
     orgSlug: string,
     pipelineSlug: string,

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
@@ -148,12 +148,22 @@ export const CITableView: FC<TableProps> = ({
   />
 );
 
-const BuildkiteBuildsTable: FC<{ entity: Entity }> = ({ entity }) => {
-  const { owner, repo, branch } = useProjectEntity(entity);
+export type BuildkiteBuildsTableProps = {
+  defaultBranchOnly?: boolean;
+  entity: Entity;
+};
+
+const BuildkiteBuildsTable = (props: BuildkiteBuildsTableProps) => {
+  const { entity, defaultBranchOnly } = props;
+  const { owner, repo, branchAnnotation, defaultBranchOnlyAnnotation } =
+    useProjectEntity(entity);
+
   const [tableProps, { setPage, retry, setPageSize }] = useBuilds({
     owner,
     repo,
-    branch,
+    defaultBranchOnly: Boolean(defaultBranchOnly),
+    defaultBranchOnlyAnnotation,
+    branchAnnotation,
   });
 
   return (

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/Router.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/Router.tsx
@@ -20,22 +20,47 @@ import { Entity } from '@backstage/catalog-model';
 import { MissingAnnotationEmptyState } from '@backstage/core-components';
 import BuildkiteBuildsTable from './BuildKiteBuildsTable';
 import BuildkiteBuildView from './BuildKiteBuildView';
-import { BUILDKITE_ANNOTATION } from '../consts';
+import {
+  BUILDKITE_ANNOTATION,
+  BUILDKITE_DEFAULT_BRANCH_ONLY_ANNOTATION,
+} from '../consts';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { buildKiteBuildRouteRef } from '../plugin';
 
 export const isBuildkiteAvailable = (entity: Entity) =>
   Boolean(entity?.metadata.annotations?.[BUILDKITE_ANNOTATION]);
 
-export const Router = () => {
+export type RouterProps = {
+  defaultBranchOnly?: boolean;
+};
+
+export const Router = (props: RouterProps) => {
+  let { defaultBranchOnly } = props;
   const { entity } = useEntity();
   if (!isBuildkiteAvailable(entity)) {
     return <MissingAnnotationEmptyState annotation={BUILDKITE_ANNOTATION} />;
   }
 
+  const defaultBranchOnlyAnnotation = Boolean(
+    entity?.metadata.annotations?.[BUILDKITE_DEFAULT_BRANCH_ONLY_ANNOTATION],
+  );
+
+  if (defaultBranchOnlyAnnotation) {
+    defaultBranchOnly = true;
+  }
+
   return (
     <Routes>
-      <Route path="/" element={<BuildkiteBuildsTable entity={entity} />} />
+      <Route
+        path="/"
+        element={
+          <BuildkiteBuildsTable
+            defaultBranchOnly={defaultBranchOnly}
+            entity={entity}
+          />
+        }
+      />
+
       <Route
         path={`/${buildKiteBuildRouteRef.path}`}
         element={<BuildkiteBuildView entity={entity} />}

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/useBuilds.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/useBuilds.ts
@@ -36,14 +36,42 @@ export const transform = (
   });
 };
 
+const showDefaultBranchOnly = ({
+  defaultBranchOnly,
+  defaultBranchOnlyAnnotation,
+  branchAnnotation,
+}: {
+  defaultBranchOnly: boolean;
+  defaultBranchOnlyAnnotation: boolean | null | undefined;
+  branchAnnotation: string;
+}) => {
+  if (branchAnnotation) {
+    return false;
+  }
+
+  if (defaultBranchOnlyAnnotation === false) {
+    return false;
+  }
+
+  if (defaultBranchOnlyAnnotation === true) {
+    return true;
+  }
+
+  return defaultBranchOnly;
+};
+
 export const useBuilds = ({
   owner,
   repo,
-  branch,
+  defaultBranchOnly,
+  defaultBranchOnlyAnnotation,
+  branchAnnotation,
 }: {
   owner: string;
   repo: string;
-  branch?: string;
+  defaultBranchOnly: boolean;
+  defaultBranchOnlyAnnotation: boolean | null | undefined;
+  branchAnnotation: string;
 }) => {
   const api = useApi(buildKiteApiRef);
   const errorApi = useApi(errorApiRef);
@@ -51,11 +79,41 @@ export const useBuilds = ({
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(5);
+  const [branch, setBranch] = useState('');
 
   const { value, loading, retry } = useAsyncRetry(async () => {
+    let branchParam = undefined;
+    if (branchAnnotation) {
+      branchParam = branchAnnotation;
+      setBranch(branchAnnotation);
+    }
+
+    const defaultBranch = showDefaultBranchOnly({
+      defaultBranchOnly,
+      defaultBranchOnlyAnnotation,
+      branchAnnotation,
+    });
+
+    if (defaultBranch) {
+      try {
+        const pipeline = await api.getPipeline(owner, repo);
+        setBranch(pipeline.default_branch);
+        branchParam = pipeline.default_branch;
+      } catch (e: any) {
+        errorApi.post(e);
+        return Promise.reject(e);
+      }
+    }
+
     let builds = [];
     try {
-      builds = await api.getBuilds(owner, repo, page + 1, pageSize, branch);
+      builds = await api.getBuilds(
+        owner,
+        repo,
+        page + 1,
+        pageSize,
+        branchParam,
+      );
     } catch (e: any) {
       errorApi.post(e);
     }
@@ -63,7 +121,7 @@ export const useBuilds = ({
     // eslint-disable-next-line
     const response = transform(builds ?? [], restartBuild) as any;
     return response;
-  }, [page, pageSize]);
+  }, [page, pageSize, branch]);
 
   const restartBuild = async (requestUrl: string) => {
     try {
@@ -76,7 +134,10 @@ export const useBuilds = ({
     }
   };
 
-  const projectName = `${owner}/${repo}`;
+  let projectName = `${owner}/${repo}`;
+  if (branch) {
+    projectName = `${projectName} (${branch})`;
+  }
 
   return [
     {

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/useProjectEntity.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/useProjectEntity.ts
@@ -15,18 +15,35 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { BUILDKITE_ANNOTATION, BUILDKITE_BRANCH_ANNOTATION } from '../consts';
+import {
+  BUILDKITE_ANNOTATION,
+  BUILDKITE_BRANCH_ANNOTATION,
+  BUILDKITE_DEFAULT_BRANCH_ONLY_ANNOTATION,
+} from '../consts';
 
 export const useProjectEntity = (entity: Entity) => {
   const projectSlug = entity.metadata?.annotations?.[
     BUILDKITE_ANNOTATION
   ] as string;
-  const branch = entity.metadata?.annotations?.[
+  const branchAnnotation = entity.metadata?.annotations?.[
     BUILDKITE_BRANCH_ANNOTATION
   ] as string;
+  const rawDefaultBranchOnlyAnnotation = entity.metadata?.annotations?.[
+    BUILDKITE_DEFAULT_BRANCH_ONLY_ANNOTATION
+  ] as string;
+
+  let defaultBranchOnlyAnnotation = undefined;
+  if (rawDefaultBranchOnlyAnnotation === 'true') {
+    defaultBranchOnlyAnnotation = true;
+  }
+  if (rawDefaultBranchOnlyAnnotation === 'false') {
+    defaultBranchOnlyAnnotation = false;
+  }
+
   return {
     owner: projectSlug.split('/')[0],
     repo: projectSlug.split('/')[1],
-    branch: branch,
+    branchAnnotation,
+    defaultBranchOnlyAnnotation,
   };
 };

--- a/plugins/frontend/backstage-plugin-buildkite/src/consts.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/consts.ts
@@ -16,3 +16,5 @@
 
 export const BUILDKITE_ANNOTATION = 'buildkite.com/project-slug';
 export const BUILDKITE_BRANCH_ANNOTATION = 'buildkite.com/branch';
+export const BUILDKITE_DEFAULT_BRANCH_ONLY_ANNOTATION =
+  'buildkite.com/default-branch-only';

--- a/plugins/frontend/backstage-plugin-buildkite/src/mocks/mocks.ts
+++ b/plugins/frontend/backstage-plugin-buildkite/src/mocks/mocks.ts
@@ -29,7 +29,57 @@ export const entityMockWithBranchAnnotation = {
       'backstage.io/managed-by-location':
         'url:https://github.com/mcalus3/sample-service/blob/master/buildkite-config.yaml',
       'buildkite.com/project-slug': 'rbnetwork/example-pipeline',
-      'buildkite.com/branch': 'main',
+      'buildkite.com/branch': 'some-branch',
+    },
+    name: 'sample-service',
+    description:
+      'A service for testing Backstage functionality. For example, we can trigger errors\non the sample-service, these are sent to Sentry, then we can view them in the \nBackstage plugin for Sentry.\n',
+    uid: '191a6877-8315-429a-bbd3-1051029de374',
+    etag: 'OWRkNmRiMTktZDYyYy00ZDM3LWFmNGItYjBhMWY2YTg4MDNk',
+    generation: 1,
+  },
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  spec: {
+    type: 'service',
+    owner: 'david@roadie.io',
+    lifecycle: 'experimental',
+  },
+};
+
+export const entityMockWithDefaultBranchOnlyAnnotation = {
+  metadata: {
+    namespace: 'default',
+    annotations: {
+      'backstage.io/managed-by-location':
+        'url:https://github.com/mcalus3/sample-service/blob/master/buildkite-config.yaml',
+      'buildkite.com/project-slug': 'rbnetwork/example-pipeline',
+      'buildkite.com/default-branch-only': 'true',
+    },
+    name: 'sample-service',
+    description:
+      'A service for testing Backstage functionality. For example, we can trigger errors\non the sample-service, these are sent to Sentry, then we can view them in the \nBackstage plugin for Sentry.\n',
+    uid: '191a6877-8315-429a-bbd3-1051029de374',
+    etag: 'OWRkNmRiMTktZDYyYy00ZDM3LWFmNGItYjBhMWY2YTg4MDNk',
+    generation: 1,
+  },
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  spec: {
+    type: 'service',
+    owner: 'david@roadie.io',
+    lifecycle: 'experimental',
+  },
+};
+
+export const entityMockWithDefaultBranchOnlyAnnotationFalse = {
+  metadata: {
+    namespace: 'default',
+    annotations: {
+      'backstage.io/managed-by-location':
+        'url:https://github.com/mcalus3/sample-service/blob/master/buildkite-config.yaml',
+      'buildkite.com/project-slug': 'rbnetwork/example-pipeline',
+      'buildkite.com/default-branch-only': 'false',
     },
     name: 'sample-service',
     description:
@@ -1476,3 +1526,7 @@ export const buildLogResponseMock = (
   size: 1234,
   header_times: [1652372752079541978],
 });
+
+export const pipelineResponseMock = {
+  default_branch: 'main',
+};


### PR DESCRIPTION
This addresses issue #1490 and enables the ability to configure the backstage-plugin-buildkite to only show default branch builds (without needing to hard-code a `buildkite.com/branch` annotation specifying that default branch name).

On a per-entity descriptor basis, the option can be configured via an annotation:

```yaml
metadata:
  annotations:
    'buildkite.com/default-branch-only': 'true'
```

Alternatively, the option can also be configured globally:

```ts
// packages/app/src/components/catalog/EntityPage.tsx export const cicdContent = (
  <EntitySwitch>
    <EntitySwitch.Case if={isBuildkiteAvailable}>
      <EntityBuildkiteContent defaultBranchOnly />
    </EntitySwitch.Case>
    ...
  </EntitySwitch>
);
```

The presence of a `buildkite.com/branch` annotation continues to take
precedence over both a globally-set `defaultBranchOnly` and a
`buildkite.com/default-branch-only` annotation, preserving backwards
compatibility.

Additionally, if the plugin has been configured to only display a
specific branch's builds, the branch name is now rendered in parentheses
beside the pipeline name.


#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
