### PR TITLE
Fix authentication issues with the http-requests against the proxy

### DIFF
--- a/.changeset/smart-peas-mate.md
+++ b/.changeset/smart-peas-mate.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Fix authentication to the proxy in the scaffolder action

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.test.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  generateBackstageUrl,
-  http,
-  getObjFieldCaseInsensitively,
-} from './helpers';
+import { generateBackstageUrl, http } from './helpers';
 import { HttpOptions } from './types';
 import { getRootLogger } from '@backstage/backend-common';
 import { Writable } from 'stream';
@@ -203,38 +199,6 @@ describe('http', () => {
               expect.stringContaining(`"error":"bad request"`),
             ]),
           );
-        });
-      });
-
-      describe('get auth header properly', () => {
-        const TOKEN = 'Bearer 12345';
-
-        it('finds auth token', async () => {
-          expect(
-            getObjFieldCaseInsensitively(
-              { Authorization: TOKEN },
-              'authorization',
-            ),
-          ).toEqual(TOKEN);
-          expect(
-            getObjFieldCaseInsensitively(
-              { AUTHORIZATION: TOKEN },
-              'authorization',
-            ),
-          ).toEqual(TOKEN);
-          expect(
-            getObjFieldCaseInsensitively(
-              { AuThOrIzAtIoN: TOKEN },
-              'authorization',
-            ),
-          ).toEqual(TOKEN);
-        });
-
-        it('No auth token', async () => {
-          expect(
-            getObjFieldCaseInsensitively({ Authorizatio: '' }, 'authorization'),
-          ).toEqual('');
-          expect(getObjFieldCaseInsensitively({}, 'authorization')).toEqual('');
         });
       });
 

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
@@ -86,12 +86,3 @@ export const http = async (
   }
   return { code: res.status, headers, body };
 };
-
-export const getObjFieldCaseInsensitively = (obj = {}, fieldName: string) => {
-  const [, value = ''] =
-    Object.entries<string>(obj).find(
-      ([key]) => key.toLowerCase() === fieldName.toLowerCase(),
-    ) || [];
-
-  return value;
-};

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/module.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/module.ts
@@ -31,11 +31,12 @@ export const scaffolderBackendModuleHttpRequest = createBackendModule({
     registerInit({
       deps: {
         scaffolder: scaffolderActionsExtensionPoint,
+        auth: coreServices.auth,
         discovery: coreServices.discovery,
       },
-      async init({ scaffolder, discovery }) {
+      async init({ scaffolder, auth, discovery }) {
         scaffolder.addActions(
-          backendModuleHttp.createHttpBackstageAction({ discovery }),
+          backendModuleHttp.createHttpBackstageAction({ auth, discovery }),
         );
       },
     });


### PR DESCRIPTION
The handler was using the old authentication setup instead of the new one using the new auth service. Let's use this instead and always set the token if defined. This is following the same idea as other upstream actions, such as the one to register a new component: https://github.com/backstage/backstage/blob/e6c52e7e7ec21ceb98cfbaad55c84b3e3683649f/plugins/scaffolder-backend/src/scaffolder/actions/builtin/catalog/fetch.ts#L93

In our setup, we needed to set the `credentials: dangerously-allow-unauthenticated` temporarily. I've tested it without them again and the requests weren't returning the 401 any more.

This should be fixing https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1475, and I followed the idea in https://github.com/backstage/backstage/issues/25096#issuecomment-2157710780

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
