### PR TITLE
fix(ai): fix TechDocs embeddings metadata

### DIFF
--- a/.changeset/silent-swans-repeat.md
+++ b/.changeset/silent-swans-repeat.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+---
+
+Fixed missing metadata from TechDocs embeddings

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
@@ -116,7 +116,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   ): Promise<EmbeddingDoc[]> {
     const splitter = this.getSplitter();
     let docs: EmbeddingDoc[] = [];
-    for (const { text, entity } of documents) {
+    for (const { text, entity, title, location } of documents) {
       const splits = await splitter.splitText(text);
       docs = docs.concat(
         splits.map((content: string, idx: number) => ({
@@ -126,6 +126,8 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
             source,
             entityRef: stringifyEntityRef(entity),
             kind: entity.kind,
+            title,
+            location,
           },
         })),
       );


### PR DESCRIPTION
This PR fixes an oversight in #1521 that resulted in missing metadata for TechDocs embeddings since it's hard to test generating embeddings outside of our codebase.

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
