### PR TITLE
chore(ai): bump @roadiehq/rag-ai-backend-retrieval-augmenter

### DIFF
--- a/.changeset/seven-cats-knock.md
+++ b/.changeset/seven-cats-knock.md
@@ -1,0 +1,7 @@
+---
+'@roadiehq/rag-ai-backend-embeddings-openai': patch
+'@roadiehq/rag-ai-backend-embeddings-aws': patch
+'backend': patch
+---
+
+Updated @roadiehq/rag-ai-backend-retrieval-augmenter to 0.3.6

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -48,7 +48,7 @@
     "@roadiehq/rag-ai-backend": "^0.3.3",
     "@roadiehq/rag-ai-backend-embeddings-aws": "^0.2.5",
     "@roadiehq/rag-ai-backend-embeddings-openai": "^0.2.5",
-    "@roadiehq/rag-ai-backend-retrieval-augmenter": "^0.3.4",
+    "@roadiehq/rag-ai-backend-retrieval-augmenter": "^0.3.6",
     "@roadiehq/rag-ai-storage-pgvector": "^0.1.4",
     "@roadiehq/scaffolder-backend-module-http-request": "^4.3.2",
     "@roadiehq/scaffolder-backend-module-utils": "^1.15.4",

--- a/plugins/backend/rag-ai-backend-embeddings-aws/package.json
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/package.json
@@ -41,7 +41,7 @@
     "@langchain/community": "^0.2.20",
     "@langchain/core": "^0.2.18",
     "@roadiehq/rag-ai-backend": "^0.3.3",
-    "@roadiehq/rag-ai-backend-retrieval-augmenter": "^0.3.4",
+    "@roadiehq/rag-ai-backend-retrieval-augmenter": "^0.3.6",
     "@roadiehq/rag-ai-node": "^0.1.4",
     "langchain": "^0.1.21",
     "winston": "^3.11.0"

--- a/plugins/backend/rag-ai-backend-embeddings-openai/package.json
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/package.json
@@ -38,7 +38,7 @@
     "@langchain/core": "^0.2.18",
     "@langchain/community": "^0.2.20",
     "@langchain/openai": "^0.2.5",
-    "@roadiehq/rag-ai-backend-retrieval-augmenter": "^0.3.4",
+    "@roadiehq/rag-ai-backend-retrieval-augmenter": "^0.3.6",
     "@roadiehq/rag-ai-node": "^0.1.4",
     "langchain": "^0.0.209",
     "winston": "^3.11.0"


### PR DESCRIPTION
This PR bumps `@roadiehq/rag-ai-backend-retrieval-augmenter` to `0.3.6`.

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
