### PR TITLE
add support for reach 18 in rag-ai plugin

### DIFF
--- a/.changeset/friendly-cats-protect.md
+++ b/.changeset/friendly-cats-protect.md
@@ -1,5 +1,5 @@
 ---
-'@roadiehq/rag-ai': patch
+'@roadiehq/rag-ai': major
 ---
 
-Add support for react 18.
+Add support for react 18, and release version 1.

--- a/.changeset/friendly-cats-protect.md
+++ b/.changeset/friendly-cats-protect.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai': patch
+---
+
+Add support for react 18.

--- a/plugins/frontend/rag-ai/package.json
+++ b/plugins/frontend/rag-ai/package.json
@@ -40,7 +40,7 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.26.4",


### PR DESCRIPTION
add support for react 18 in rag-ai plugin

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
