### PR TITLE
Improve log line in okta entity provider

### DIFF
--- a/.changeset/green-tools-march.md
+++ b/.changeset/green-tools-march.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Improved logging of the orgEntityProvider

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -247,7 +247,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
 
     if (!this.includeEmptyGroups) {
       this.logger.info(
-        `Found ${groupResources.length}, pruning the empty ones`,
+        `Found ${groupResources.length} groups in okta, pruning the empty ones`,
       );
       groupResources = new GroupTree(groupResources).getGroups({
         pruneEmptyMembers: true,


### PR DESCRIPTION
This message shows up like this in the logs:

```
{"level":"info","message":"Found 15, pruning the empty ones","plugin":"catalog","service":"backstage"}
```

And because the plugin is the `catalog` it's hard to know what it's talking about exactly.

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
