### PR TITLE
fix(jira): jira plugin no longer makes unnecessary separate api calls to get issue counts

### DIFF
--- a/plugins/frontend/backstage-plugin-jira/.changeset/silent-pots-sip.md
+++ b/plugins/frontend/backstage-plugin-jira/.changeset/silent-pots-sip.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-jira': patch
+---
+
+Jira tile no longer makes separate unnecessary API calls to get issue counts for issue types.

--- a/plugins/frontend/backstage-plugin-jira/src/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/types.ts
@@ -118,7 +118,7 @@ export type Status = {
   statuses: Array<{ name: string; statusCategory: { name: string } }>;
 };
 
-export type IssueCountSearchParams = {
+export type IssuesResponse = {
   startAt: number;
   maxResults: number;
   total: number;
@@ -151,7 +151,7 @@ export type Ticket = {
   };
 };
 
-export type IssueCountResult = {
+export type IssuesResult = {
   next: number | undefined;
   issues: Ticket[];
 };


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

Before this change, Jira tile was making API calls to fetch project information (includes issue types), all issues of the project, and issue counts for each issue type. This caused as many unnecessary API calls as there were issue types in the project (in our case ~90 unnecessary calls).

Because the issues themselves contain information about the issue type, we can just get the counts from all issues and project information (with issue types).

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
