### PR TITLE
feat(ai): add support for chat completion models

### DIFF
--- a/.changeset/chatty-pumpkins-shave.md
+++ b/.changeset/chatty-pumpkins-shave.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend': patch
+---
+
+Added support for chat completion models

--- a/plugins/backend/rag-ai-backend/src/service/LlmService.ts
+++ b/plugins/backend/rag-ai-backend/src/service/LlmService.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 import { BaseLLM } from '@langchain/core/language_models/llms';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { EmbeddingDoc } from '@roadiehq/rag-ai-node';
 import { Logger } from 'winston';
 import { createPromptTemplates } from './prompts';
 
 export class LlmService {
   private readonly logger: Logger;
-  private readonly model: BaseLLM;
+  private readonly model: BaseLLM | BaseChatModel;
   private readonly prompts: {
     prefixPrompt: (embedding: string) => string;
     suffixPrompt: (input: string) => string;
@@ -32,7 +33,7 @@ export class LlmService {
     configuredPrompts,
   }: {
     logger: Logger;
-    model: BaseLLM;
+    model: BaseLLM | BaseChatModel;
     configuredPrompts?: {
       prefix?: string;
       suffix?: string;
@@ -51,6 +52,7 @@ export class LlmService {
     const prompt = `Human:\n${this.prompts.prefixPrompt(
       promptEmbeddings,
     )}\n ---\n${this.prompts.suffixPrompt(query)}\nAssistant:`;
-    return await this.model.invoke(prompt);
+    const response = await this.model.invoke(prompt);
+    return typeof response === 'string' ? response : response.content;
   }
 }

--- a/plugins/backend/rag-ai-backend/src/service/router.ts
+++ b/plugins/backend/rag-ai-backend/src/service/router.ts
@@ -19,6 +19,7 @@ import Router from 'express-promise-router';
 import { Logger } from 'winston';
 import { AugmentationIndexer, RetrievalPipeline } from '@roadiehq/rag-ai-node';
 import { BaseLLM } from '@langchain/core/language_models/llms';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { LlmService } from './LlmService';
 import { RagAiController } from './RagAiController';
 import { isEmpty } from 'lodash';
@@ -36,7 +37,7 @@ export interface RouterOptions {
   logger: Logger;
   augmentationIndexer: AugmentationIndexer;
   retrievalPipeline: RetrievalPipeline;
-  model: BaseLLM;
+  model: BaseLLM | BaseChatModel;
   config: Config;
 }
 

--- a/plugins/backend/rag-ai-backend/src/service/types.ts
+++ b/plugins/backend/rag-ai-backend/src/service/types.ts
@@ -17,6 +17,7 @@ import { TokenManager } from '@backstage/backend-common';
 import { AugmentationIndexer, RetrievalPipeline } from '@roadiehq/rag-ai-node';
 import { Logger } from 'winston';
 import { BaseLLM } from '@langchain/core/language_models/llms';
+import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { Config } from '@backstage/config';
 
 export interface RagAiConfig {
@@ -24,6 +25,6 @@ export interface RagAiConfig {
   tokenManager: TokenManager;
   augmentationIndexer: AugmentationIndexer;
   retrievalPipeline: RetrievalPipeline;
-  model: BaseLLM;
+  model: BaseLLM | BaseChatModel;
   config: Config;
 }


### PR DESCRIPTION
This PR adds support for the newer [chat completion models](https://js.langchain.com/v0.2/docs/concepts/#chat-models), in addition to the currently supported [text completion models](https://js.langchain.com/v0.2/docs/concepts/#llms).

This allows you to use Langchain models like [`BedrockChat`](https://js.langchain.com/v0.2/docs/integrations/chat/bedrock), which in turn allow you to use models like Meta's Llama 3 70B:

```typescript
const model = new BedrockChat({
  model: 'meta.llama3-70b-instruct-v1:0',
  region: 'us-east-1',
  credentials: credProvider.sdkCredentialProvider,
});
```

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
