### PR TITLE
chore: add DPG Media to the list of adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,6 +1,7 @@
-| Organization                              | Contact                                      | Description of Use            |
-| ----------------------------------------- | -------------------------------------------- | ----------------------------- |
-| [Roadie](https://roadie.io)               | [@dtuite](https://github.com/dtuite)         | Development                   |
-| [Hopin](https://hopin.com)                | [@vglafirov](https://github.com/vglafirov)   | Development experience portal |
-| [OVO Energy](https://www.ovoenergy.com/)  | [@dlaird-ovo](https://github.com/dlaird-ovo) | Developer Portal              |
-| [Gynzy](https://www.gynzy.com/)           | [@fhp](https://github.com/fhp)               | Developer Portal              |
+| Organization                               | Contact                                                                                                                                                                  | Description of Use            |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- |
+| [Roadie](https://roadie.io)                | [@dtuite](https://github.com/dtuite)                                                                                                                                     | Development                   |
+| [Hopin](https://hopin.com)                 | [@vglafirov](https://github.com/vglafirov)                                                                                                                               | Development experience portal |
+| [OVO Energy](https://www.ovoenergy.com/)   | [@dlaird-ovo](https://github.com/dlaird-ovo)                                                                                                                             | Developer Portal              |
+| [Gynzy](https://www.gynzy.com/)            | [@fhp](https://github.com/fhp)                                                                                                                                           | Developer Portal              |
+| [DPG Media](https://www.dpgmediagroup.com) | [@benjidotsh](https://github.com/benjidotsh), [@lvstb](https://github.com/lvstb), [@ssliman](https://github.com/ssliman), [@edewel-beep](https://github.com/edewel-beep) | RAG AI plugin                 |


### PR DESCRIPTION
This PR adds us ([DPG Media](https://www.dpgmediagroup.com)) to the list of adopters.