### PR TITLE
fix(ai): add Content-Type header to query responses

### DIFF
--- a/.changeset/purple-tables-invite.md
+++ b/.changeset/purple-tables-invite.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend': patch
+---
+
+Added Content-Type header to query responses

--- a/plugins/backend/rag-ai-backend/package.json
+++ b/plugins/backend/rag-ai-backend/package.json
@@ -32,11 +32,11 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.21.7",
+    "@backstage/backend-plugin-api": "^0.6.17",
     "@backstage/config": "^1.2.0",
     "@langchain/core": "^0.2.27",
     "@roadiehq/rag-ai-node": "^0.1.4",
     "@types/express": "*",
-    "@backstage/backend-plugin-api": "^0.6.17",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "lodash": "^4.17.21",
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.26.4",
+    "@types/compression": "^1.7.5",
     "@types/supertest": "^2.0.8",
     "msw": "^1.0.0",
     "supertest": "^6.1.3"

--- a/plugins/backend/rag-ai-backend/src/service/RagAiController.ts
+++ b/plugins/backend/rag-ai-backend/src/service/RagAiController.ts
@@ -21,6 +21,8 @@ import {
   EmbeddingsSource,
   RetrievalPipeline,
 } from '@roadiehq/rag-ai-node';
+// @ts-ignore
+import type compression from 'compression';
 
 export class RagAiController {
   private static instance: RagAiController;
@@ -114,8 +116,7 @@ export class RagAiController {
     const entityFilter = req.body.entityFilter;
 
     res.writeHead(200, {
-      // TODO: investigate why this results in buffered responses in the frontend
-      // 'Content-Type': 'text/event-stream',
+      'Content-Type': 'text/event-stream',
       Connection: 'keep-alive',
       'Cache-Control': 'no-cache',
     });
@@ -139,6 +140,7 @@ export class RagAiController {
       const event = `event: response\n`;
       const data = `data: ${text}\n\n`;
       res.write(event + data);
+      res.flush?.();
     }
 
     res.end();

--- a/yarn.lock
+++ b/yarn.lock
@@ -13429,6 +13429,13 @@
   dependencies:
     "@types/tern" "*"
 
+"@types/compression@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.5.tgz#0f80efef6eb031be57b12221c4ba6bc3577808f7"
+  integrity sha512-AAQvK5pxMpaT+nDvhHrsBhLSYG5yQdtkaJE1WYieSNY2mVFKAgmU4ks65rkZD5oqnGCFLyQpUr1CqI4DmUMyDg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect-history-api-fallback@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz#7de71645a103056b48ac3ce07b3520b819c1d5b3"
@@ -13944,12 +13951,19 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@^18.0.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
   dependencies:
     "@types/react" "*"
+
+"@types/react-dom@<18.0.0":
+  version "17.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
+  integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
+  dependencies:
+    "@types/react" "^17"
 
 "@types/react-redux@^7.1.20":
   version "7.1.33"
@@ -13989,12 +14003,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
   version "18.3.4"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.4.tgz#dfdd534a1d081307144c00e325c06e00312c93a3"
   integrity sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.13.1 || ^17.0.0", "@types/react@^17":
+  version "17.0.80"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.80.tgz#a5dfc351d6a41257eb592d73d3a85d3b7dbcbb41"
+  integrity sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/recharts@^1.8.14":
@@ -14043,6 +14066,11 @@
   integrity sha512-DrH26m7CV6PB4YVckjbSIx+xloB7HBolr9Ctm0gZBffSu5dDV4yJKFQGPquJlReVW+xmg59gx+b/8/qYHxZEuw==
   dependencies:
     htmlparser2 "^4.1.0"
+
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@^7.3.12", "@types/semver@^7.5.0":
   version "7.5.8"


### PR DESCRIPTION
This PR resolves the remaining TODO in my previous PR #1561 by adding the `Content-Type` header to query responses and using the `compression` middleware's `flush` function after sending an event.

The `@ts-ignore` comment is there because otherwise it complains that I don't use the type `compression`, but we need it for the global `Response` type to contain the `flush` function. I'm not sure if this is possible any other way.

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
