### PR TITLE
chore: patch changeset to release new jira plugin

### DIFF
--- a/.changeset/lemon-candles-collect.md
+++ b/.changeset/lemon-candles-collect.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-jira': patch
+---
+
+Changeset to release jira plugin with the latest patch. (jira plugin no longer makes unnecessary separate api calls to get counts for each issue type)


### PR DESCRIPTION
Jira plugin was not released with the new patch a couple weeks ago, this patch changeset should release it.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
