### PR TITLE
fix(github-pull-requests): introduce max 1000 item paging

### DIFF
--- a/.changeset/fuzzy-lies-beg.md
+++ b/.changeset/fuzzy-lies-beg.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Limit paging to max 1000 results due to GitHub search API restrictions.

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.tsx
@@ -24,6 +24,7 @@ import {
   Box,
   ButtonGroup,
   Button,
+  Tooltip,
 } from '@material-ui/core';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import ClearIcon from '@material-ui/icons/Clear';
@@ -118,6 +119,7 @@ type Props = {
   prData?: PullRequest[];
   onChangePage: (page: number) => void;
   total: number;
+  totalResults: number;
   pageSize: number;
   onChangePageSize: (pageSize: number) => void;
   StateFilterComponent?: FC<{}>;
@@ -133,6 +135,7 @@ export const PullRequestsTableView: FC<Props> = ({
   onChangePage,
   onChangePageSize,
   total,
+  totalResults,
   StateFilterComponent,
   SearchComponent,
 }) => {
@@ -165,10 +168,32 @@ export const PullRequestsTableView: FC<Props> = ({
             alignItems="center"
           >
             <GitHubIcon />
-            <Box mr={1} />
-            <Typography variant="h6" noWrap>
-              {projectName}
-            </Typography>
+            <Box
+              ml={1}
+              display="flex"
+              flexDirection="row"
+              alignItems="baseline"
+            >
+              <Typography variant="h6" noWrap>
+                {projectName}
+              </Typography>
+              {totalResults > 1000 && (
+                <Tooltip
+                  title={`Search results are limited to a maximum of ${(1000).toLocaleString()} 
+                          items. To refine your results, consider adjusting the search query.`}
+                  arrow
+                >
+                  <Typography
+                    variant="body1"
+                    noWrap
+                    color="primary"
+                    style={{ marginLeft: 10, cursor: 'pointer' }}
+                  >
+                    Total {totalResults.toLocaleString()}
+                  </Typography>
+                </Tooltip>
+              )}
+            </Box>
           </Box>
           <Box
             position="absolute"

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequests.ts
@@ -52,10 +52,16 @@ export function usePullRequests({
   const auth = useApi(githubAuthApiRef);
   const baseUrl = useBaseUrl();
   const [total, setTotal] = useState(0);
+  const [totalResults, setTotalResults] = useState(0);
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(5);
   const getElapsedTime = (start: string): string | null => {
     return DateTime.fromISO(start).toRelative();
+  };
+
+  const handleTotal = (total_count: number) => {
+    setTotal(total_count > 1000 ? 1000 : total_count);
+    setTotalResults(total_count);
   };
 
   const {
@@ -88,7 +94,7 @@ export function usePullRequests({
             pullRequestsData: SearchPullRequestsResponseData;
           }) => {
             if (total_count >= 0) {
-              setTotal(total_count);
+              handleTotal(total_count);
             }
             return items.map(
               ({
@@ -135,6 +141,7 @@ export function usePullRequests({
       prData,
       projectName: `${owner}/${repo}`,
       total,
+      totalResults,
       error,
     },
     {


### PR DESCRIPTION
## Description
GitHub Search API has limit of [max 1000 results](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28). 
This causes 422 errors when the search returns more than 1000 items.

```
{
  "message": "Only the first 1000 search results are available",
  "documentation_url": "https://docs.github.com/v3/search/",
  "status": "422"
}
```

## Modifications
Restrict pagination to a maximum of 1000 items. Show users when additional results are available, suggesting in a tooltip that they can refine their query to retrieve more specific results.

Before:
![Screenshot from 2024-09-11 15-21-54](https://github.com/user-attachments/assets/8a8631cd-0f95-46b2-9ff0-a4f89a911921)

After:
![Screenshot from 2024-09-11 17-19-07](https://github.com/user-attachments/assets/2a67ebd1-8319-451b-b688-c67aeb995733)

https://github.com/user-attachments/assets/d9898013-9cd7-4fec-94bf-47955748c1c4

## Fixes
#1596 


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [X] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
