### PR TITLE
[Argo-CD] Fix pluginId metadata

### DIFF
--- a/.changeset/witty-geese-lay.md
+++ b/.changeset/witty-geese-lay.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-backend': patch
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+fix: Align pluginId metadata to id set during plugin initialization

--- a/plugins/backend/backstage-plugin-argo-cd-backend/package.json
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/package.json
@@ -11,7 +11,7 @@
   },
   "backstage": {
     "role": "backend-plugin",
-    "pluginId": "backstage-plugin-argo-cd-backend",
+    "pluginId": "argocd",
     "pluginPackages": [
       "@roadiehq/backstage-plugin-argo-cd",
       "@roadiehq/backstage-plugin-argo-cd-backend"

--- a/plugins/frontend/backstage-plugin-argo-cd/package.json
+++ b/plugins/frontend/backstage-plugin-argo-cd/package.json
@@ -21,7 +21,7 @@
   },
   "backstage": {
     "role": "frontend-plugin",
-    "pluginId": "backstage-plugin-argo-cd",
+    "pluginId": "argocd",
     "pluginPackages": [
       "@roadiehq/backstage-plugin-argo-cd",
       "@roadiehq/backstage-plugin-argo-cd-backend"


### PR DESCRIPTION
Hey 👋,

A small change to the plugin metadata for the Argo CD plugin to align with [Package Metadata documentation](https://backstage.io/docs/tooling/package-metadata/#backstagepluginid), where the `pluginId` should be the same id passed to `createPlugin`.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
