### PR TITLE
feat(rag-ai): instantiate default api client

### DIFF
--- a/.changeset/serious-camels-search.md
+++ b/.changeset/serious-camels-search.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai': patch
+---
+
+Provide a default implementation of the RAG AI API client

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -23,12 +23,9 @@ import {
   AnyApiFactory,
   configApiRef,
   createApiFactory,
-  discoveryApiRef,
   fetchApiRef,
-  identityApiRef,
 } from '@backstage/core-plugin-api';
 import fetch from 'cross-fetch';
-import { ragAiApiRef, RoadieRagAiClient } from '@roadiehq/rag-ai';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -42,23 +39,6 @@ export const apis: AnyApiFactory[] = [
     deps: {},
     factory: () => {
       return { fetch: fetch.bind(window) };
-    },
-  }),
-  createApiFactory({
-    api: ragAiApiRef,
-    deps: {
-      configApi: configApiRef,
-      discoveryApi: discoveryApiRef,
-      fetchApi: fetchApiRef,
-      identityApi: identityApiRef,
-    },
-    factory: ({ discoveryApi, fetchApi, configApi, identityApi }) => {
-      return new RoadieRagAiClient({
-        discoveryApi,
-        fetchApi,
-        configApi,
-        identityApi,
-      });
     },
   }),
 ];

--- a/plugins/frontend/rag-ai/README.md
+++ b/plugins/frontend/rag-ai/README.md
@@ -24,46 +24,6 @@ To configure the frontend plugin, you need to do two things:
 - Create an API client for the frontend plugin
 - Add the exposed UI element into the application
 
-### Creating an API client
-
-The RAG AI plugin exposes an API client which needs to be configured for your Backstage application frontend to be able to use the RAG AI functionality. You can do that by adding a new API factory into your `apis.ts` file. See configuration example below:
-
-```ts
-// packages/app/src/apis.ts
-
-import {
-  AnyApiFactory,
-  configApiRef,
-  createApiFactory,
-  discoveryApiRef,
-  fetchApiRef,
-  identityApiRef,
-} from '@backstage/core-plugin-api';
-import fetch from 'cross-fetch';
-import { ragAiApiRef, RoadieRagAiClient } from '@roadiehq/rag-ai';
-
-export const apis: AnyApiFactory[] = [
-  // ... Other APIs
-  createApiFactory({
-    api: ragAiApiRef,
-    deps: {
-      configApi: configApiRef,
-      discoveryApi: discoveryApiRef,
-      fetchApi: fetchApiRef,
-      identityApi: identityApiRef,
-    },
-    factory: ({ discoveryApi, fetchApi, configApi, identityApi }) => {
-      return new RoadieRagAiClient({
-        discoveryApi,
-        fetchApi,
-        configApi,
-        identityApi,
-      });
-    },
-  }),
-];
-```
-
 ### Adding the UI components into the application
 
 The plugin exposes a single UI component which is used to communicate with the application Backend. You can register this

--- a/plugins/frontend/rag-ai/src/plugin.ts
+++ b/plugins/frontend/rag-ai/src/plugin.ts
@@ -14,12 +14,36 @@
  * limitations under the License.
  */
 import {
+  configApiRef,
+  createApiFactory,
   createComponentExtension,
   createPlugin,
+  discoveryApiRef,
+  fetchApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
+import { ragAiApiRef, RoadieRagAiClient } from './api';
 
 export const ragAiPlugin = createPlugin({
   id: 'rag-ai',
+  apis: [
+    createApiFactory({
+      api: ragAiApiRef,
+      deps: {
+        configApi: configApiRef,
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+        identityApi: identityApiRef,
+      },
+      factory: ({ configApi, discoveryApi, fetchApi, identityApi }) =>
+        new RoadieRagAiClient({
+          configApi,
+          discoveryApi,
+          fetchApi,
+          identityApi,
+        }),
+    }),
+  ],
 });
 
 export const RagModal = ragAiPlugin.provide(

--- a/plugins/frontend/rag-ai/src/setupTests.ts
+++ b/plugins/frontend/rag-ai/src/setupTests.ts
@@ -15,3 +15,8 @@
  */
 
 import '@testing-library/jest-dom';
+
+Object.defineProperty(global, 'TransformStream', {
+  value: require('node:stream/web').TransformStream,
+  writable: true,
+});


### PR DESCRIPTION
Include a default implementation of the api client so consumer won't have to define this themselves in their app

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
