### PR TITLE
refactor(rag-pgvector): use LoggerService instead of winston

### DIFF
--- a/.changeset/hip-lamps-cheat.md
+++ b/.changeset/hip-lamps-cheat.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-storage-pgvector': major
+---
+
+Switch from winston to `LoggerService` interface to support new backend system

--- a/plugins/backend/rag-ai-storage-pgvector/package.json
+++ b/plugins/backend/rag-ai-storage-pgvector/package.json
@@ -34,11 +34,11 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.24.0",
+    "@backstage/backend-plugin-api": "^0.8.0",
     "@backstage/config": "^1.2.0",
     "@langchain/core": "^0.2.27",
     "@roadiehq/rag-ai-node": "^0.1.6",
-    "knex": "^3.0.0",
-    "winston": "^3.2.1"
+    "knex": "^3.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.0",

--- a/plugins/backend/rag-ai-storage-pgvector/src/service/RoadiePgVectorStore.ts
+++ b/plugins/backend/rag-ai-storage-pgvector/src/service/RoadiePgVectorStore.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   EmbeddingDocMetadata,
   EmbeddingDoc,
@@ -20,10 +21,9 @@ import {
 } from '@roadiehq/rag-ai-node';
 import { Embeddings } from '@langchain/core/embeddings';
 import { Knex } from 'knex';
-import { Logger } from 'winston';
 
 export interface RoadiePgVectorStoreConfig {
-  logger: Logger;
+  logger: LoggerService;
   db: Knex;
   /**
    * The amount of documents to chunk by when
@@ -47,7 +47,7 @@ export class RoadiePgVectorStore implements RoadieVectorStore {
   private readonly chunkSize;
   private readonly amount;
   private embeddings?: Embeddings;
-  private readonly logger: Logger;
+  private readonly logger: LoggerService;
 
   /**
    * Initializes the RoadiePgVectorStore.
@@ -132,7 +132,7 @@ export class RoadiePgVectorStore implements RoadieVectorStore {
 
       await this.client.batchInsert(this.tableName, rows, this.chunkSize);
     } catch (e) {
-      this.logger.error(e);
+      this.logger.error((e as Error).message);
       throw new Error(`Error inserting: ${(e as Error).message}`);
     }
   }

--- a/plugins/backend/rag-ai-storage-pgvector/src/service/index.ts
+++ b/plugins/backend/rag-ai-storage-pgvector/src/service/index.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Logger } from 'winston';
 import { PluginDatabaseManager } from '@backstage/backend-common';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { applyDatabaseMigrations } from '../database/migrations';
 
 import { RoadieVectorStore } from '@roadiehq/rag-ai-node';
@@ -22,7 +22,7 @@ import { RoadiePgVectorStore } from './RoadiePgVectorStore';
 import { Config } from '@backstage/config';
 
 export interface PgVectorStoreInitConfig {
-  logger: Logger;
+  logger: LoggerService;
   database: PluginDatabaseManager;
   config: Config;
 }


### PR DESCRIPTION
Switch to `LoggerService` interface to allow new backend system apps to remove usages of the deprecated `loggerToWinstonLogger` utility while still being backwards compatible with winston 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
