### PR TITLE
fix(DefaultVectorAugmentationIndexer): fix plugin auth

### DIFF
--- a/.changeset/fair-spoons-taste.md
+++ b/.changeset/fair-spoons-taste.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+---
+
+Fix auth when indexing TechDocs documents

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
@@ -179,7 +179,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
       case 'tech-docs': {
         const { token } = await this.auth.getPluginRequestToken({
           onBehalfOf: await this.auth.getOwnServiceCredentials(),
-          targetPluginId: 'techdocs',
+          targetPluginId: 'catalog',
         });
 
         const entitiesResponse = await this.catalogApi.getEntities(
@@ -202,9 +202,15 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
             const searchIndexUrl = `${techDocsBaseUrl}/static/docs/${namespace}/${kind}/${name}/search/search_index.json`;
 
             try {
+              const { token: techDocsToken } =
+                await this.auth.getPluginRequestToken({
+                  onBehalfOf: await this.auth.getOwnServiceCredentials(),
+                  targetPluginId: 'techdocs',
+                });
+
               const searchIndexResponse = await fetch(searchIndexUrl, {
                 headers: {
-                  Authorization: `Bearer ${token}`,
+                  Authorization: `Bearer ${techDocsToken}`,
                 },
               });
 


### PR DESCRIPTION
Fix bug in my previous change where the wrong target plugin token was used to hit the catalog api

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
