### PR TITLE
Upgrade Okta plugin to new backend system

### DIFF
--- a/.changeset/six-pugs-explode.md
+++ b/.changeset/six-pugs-explode.md
@@ -1,0 +1,13 @@
+---
+'@roadiehq/catalog-backend-module-okta': major
+---
+
+Upgrade the catalog module to the backend system.
+
+BREAKING:
+
+- Interfaces have been updated to favour backend system configurations over legacy system ones.
+- Original provider factory interface has been changed to accept only okta configurations.
+- Configuration has been modified to contain schedules
+
+Adds default configurations for the provider that can be added in. Leaves a customizable module construction option so more use cases can be covered.

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -17,6 +17,13 @@ catalog:
     okta:
       - orgUrl: 'https://tenant.okta.com'
         token: ${OKTA_TOKEN}
+        schedule:
+          frequency:
+            minutes: 5
+          timeout:
+            minutes: 10
+          initialDelay:
+            minutes: 1
 ```
 
 ### OAuth 2.0 Scoped Authentication
@@ -32,9 +39,16 @@ catalog:
           clientId: ${OKTA_OAUTH_CLIENT_ID},
           keyId: ${OKTA_OAUTH_KEY_ID},
           privateKey: ${OKTA_OAUTH_PRIVATE_KEY},
+        schedule:
+          frequency:
+            minutes: 5
+          timeout:
+            minutes: 10
+          initialDelay:
+            minutes: 1
 ```
 
-Note: `keyId` is optional but _must_ be passed wen using a PEM as the `privateKey`
+Note: `keyId` is optional but _must_ be passed when using a PEM as the `privateKey`
 
 ### Filter Users and Groups
 
@@ -48,17 +62,74 @@ catalog:
         token: ${OKTA_TOKEN}
         userFilter: profile.department eq "engineering"
         groupFilter: profile.name eq "Everyone"
+        schedule:
+          frequency:
+            minutes: 5
+          timeout:
+            minutes: 10
+          initialDelay:
+            minutes: 1
 ```
 
-There are two ways that you can configure the Entity providers. You can either use the `OktaOrgEntityProvider` which loads both users and groups. Or you can load user or groups separately user the `OktaUserEntityProvider` and `OktaGroupEntityProvider` providers.
+## Adding the provider with default configuration
 
-## Load Users and Groups Together
+The Okta catalog module provides default implementations of 3 entity providers that can be used with the Backstage backend system.
 
-### OktaOrgEntityProvider
+To integrate these into your application, you can use the following lines in your Backstage backend entry file:
+
+```typescript
+backend.add(
+  import('@roadiehq/catalog-backend-module-okta/okta-entity-provider'),
+);
+backend.add(
+  import('@roadiehq/catalog-backend-module-okta/org-provider-factory'),
+);
+```
+
+You need to register the `okta-entity-provider` module and one of three options for the provider factory. The provider factory decides which kind of entities are provided for you. You can either use the `OktaOrgEntityProvider` found as `org-provider-factory` which loads both users and groups. Or you can load user or groups separately user the `OktaUserEntityProvider` (`user-provider-factory`) and `OktaGroupEntityProvider` (`group-provider-factory`) providers.
+
+Note that this is the automatic configuration of provider factories and does not allow customization of naming strategies or other configurations.
+
+## Adding provider(s) with customized configuration
+
+You can also tailor the entity providers to handle different configurations if there is a need to add specific logic for example naming strategies for your entities.
+
+### Load Users and Groups Together - OktaOrgEntityProvider
+
+You can construct your own configuration of OktaOrgEntityProvider factory and register it into the backend:
+
+```typescript
+export const oktaOrgEntityProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'default-okta-org-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        provider: oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+        logger: coreServices.logger,
+      },
+      async init({ provider, logger }) {
+        const factory: EntityProviderFactory = (oktaConfig: Config) =>
+          OktaOrgEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
+            userNamingStrategy: 'strip-domain-email',
+            groupNamingStrategy: 'kebab-case-name',
+          });
+
+        provider.setEntityProviderFactory(factory);
+      },
+    });
+  },
+});
+
+// ...snip...
+
+backend.add(oktaOrgEntityProviderModule);
+```
 
 You can configure the provider with different naming strategies. The configured strategy will be used to generate the discovered entity's `metadata.name` field. The currently supported strategies are the following:
 
-User naming stategies:
+#### User naming strategies
 
 - id (default) | User entities will be named by the user id.
 - kebab-case-email | User entities will be named by their profile email converted to kebab case.
@@ -71,7 +142,7 @@ export const customUserNamingStrategy: UserNamingStrategy = user =>
   user.profile.customField;
 ```
 
-Group naming strategies:
+#### Group naming strategies
 
 - id (default) | Group entities will be named by the group id.
 - kebab-case-name | Group entities will be named by their group profile name converted to kebab case.
@@ -84,48 +155,14 @@ export const customGroupNamingStrategy: GroupNamingStrategy = group =>
   group.profile.customField;
 ```
 
-### Example configuration:
-
-```typescript
-import { OktaOrgEntityProvider } from '@roadiehq/catalog-backend-module-okta';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const builder = await CatalogBuilder.create(env);
-
-  const orgProvider = OktaOrgEntityProvider.fromConfig(env.config, {
-    logger: env.logger,
-    userNamingStrategy: 'strip-domain-email',
-    groupNamingStrategy: 'kebab-case-name',
-  });
-
-  builder.addEntityProvider(orgProvider);
-
-  const { processingEngine, router } = await builder.build();
-
-  orgProvider.run();
-
-  await processingEngine.start();
-
-  // ...
-
-  return router;
-}
-```
+#### Hierarchy config
 
 You can optionally provide the ability to create a hierarchy of groups by providing `hierarchyConfig`.
 
 ```typescript
-import { OktaOrgEntityProvider } from '@roadiehq/catalog-backend-module-okta';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const builder = await CatalogBuilder.create(env);
-
-  const orgProvider = OktaOrgEntityProvider.fromConfig(env.config, {
-    logger: env.logger,
+const factory: EntityProviderFactory = (oktaConfig: Config) =>
+  OktaOrgEntityProvider.fromConfig(oktaConfig, {
+    logger: logger,
     userNamingStrategy: 'strip-domain-email',
     groupNamingStrategy: 'kebab-case-name',
     hierarchyConfig: {
@@ -133,20 +170,11 @@ export default async function createPlugin(
       parentKey: 'profile.parentOrgId',
     },
   });
-
-  builder.addEntityProvider(orgProvider);
-
-  const { processingEngine, router } = await builder.build();
-
-  orgProvider.run();
-
-  await processingEngine.start();
-
-  // ...
-
-  return router;
-}
 ```
+
+#### Custom Transformers
+
+The module supports also custom transformers that can be configured as part of the customized registration.
 
 In case you want to customize the emitted entities, the provider allows to pass custom transformers for users and groups by providing `userTransformer` and `groupTransformer`.
 
@@ -196,8 +224,23 @@ function myGroupTransformer(
 2. Configure the provider with the transformer:
 
 ```typescript
+const factory: EntityProviderFactory = (oktaConfig: Config) =>
+  OktaOrgEntityProvider.fromConfig(oktaConfig, {
+    logger: logger,
+    userNamingStrategy: 'strip-domain-email',
+    groupNamingStrategy: 'kebab-case-name',
+    groupTransformer: myGroupTransformer,
+  });
+```
+
+#### Legacy backend
+
+<details>
+
+<summary>Expand for example legacy configuration</summary>
+
+```typescript
 import { OktaOrgEntityProvider } from '@roadiehq/catalog-backend-module-okta';
-import { myGroupTransformer } from './myGroupTransformer';
 
 export default async function createPlugin(
   env: PluginEnvironment,
@@ -208,7 +251,6 @@ export default async function createPlugin(
     logger: env.logger,
     userNamingStrategy: 'strip-domain-email',
     groupNamingStrategy: 'kebab-case-name',
-    groupTransformer: myGroupTransformer,
   });
 
   builder.addEntityProvider(orgProvider);
@@ -219,15 +261,45 @@ export default async function createPlugin(
 
   await processingEngine.start();
 
-  // ...
+  // ...snip...
 
   return router;
 }
 ```
 
-## Load Users and Groups Separately
+</details>
 
-### OktaUserEntityProvider
+### Load Users and Groups Separately - OktaUserEntityProvider
+
+You can construct your own configuration of OktaUserEntityProvider factory and register it into the backend:
+
+```typescript
+export const oktaUserEntityProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'default-okta-user-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        provider: oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+        logger: coreServices.logger,
+      },
+      async init({ provider, logger }) {
+        const factory: EntityProviderFactory = (oktaConfig: Config) =>
+          OktaUserEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
+            namingStrategy: 'strip-domain-email',
+          });
+
+        provider.setEntityProviderFactory(factory);
+      },
+    });
+  },
+});
+
+// ...snip...
+
+backend.add(oktaUserEntityProviderModule);
+```
 
 You can configure the provider with different naming strategies. The configured strategy will be used to generate the discovered entity's `metadata.name` field. The currently supported strategies are the following:
 
@@ -279,39 +351,48 @@ function myUserTransformer(
 2. Configure the provider with the transformer:
 
 ```typescript
-import { OktaUserEntityProvider } from '@roadiehq/catalog-backend-module-okta';
-import { myUserTransformer } from './myUserTransformer';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const builder = await CatalogBuilder.create(env);
-
-  const userProvider = OktaUserEntityProvider.fromConfig(env.config, {
-    logger: env.logger,
-    namingStrategy: 'strip-domain-email',
-    userTransformer: myUserTransformer,
-  });
-
-  builder.addEntityProvider(userProvider);
-
-  const { processingEngine, router } = await builder.build();
-
-  userProvider.run();
-
-  await processingEngine.start();
-
-  // ...
-
-  return router;
+const factory: EntityProviderFactory = (oktaConfig: Config) =>
+    OktaUserEntityProvider.fromConfig(oktaConfig, {
+        logger: logger,
+        userNamingStrategy: 'strip-domain-email',
+        groupNamingStrategy: 'kebab-case-name',
+        groupTransformer: myUserTransformer,
+    });
 }
 ```
 
-### OktaGroupEntityProvider
+### Load Users and Groups Separately - OktaGroupEntityProvider
+
+You can manually construct your own configuration of OktaGroupEntityProvider factory and register it into the backend:
+
+```typescript
+export const oktaGroupEntityProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'default-okta-group-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        provider: oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+        logger: coreServices.logger,
+      },
+      async init({ provider, logger }) {
+        const factory: EntityProviderFactory = (oktaConfig: Config) =>
+          OktaGroupEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
+            userNamingStrategy: 'strip-domain-email',
+            namingStrategy: 'kebab-case-name',
+          });
+
+        provider.setEntityProviderFactory(factory);
+      },
+    });
+  },
+});
+```
 
 You can configure the provider with different naming strategies. The configured strategy will be used to generate the discovered entities `metadata.name` field. The currently supported strategies are the following:
 
-User naming stategies:
+User naming strategies:
 
 - id (default) | User entities will be named by the user id.
 - kebab-case-email | User entities will be named by their profile email converted to kebab case.
@@ -339,92 +420,7 @@ export const customGroupNamingStrategy: GroupNamingStrategy = group =>
 
 Make sure you use the OktaUserEntityProvider's naming strategy for the OktaGroupEntityProvider's user naming strategy.
 
-### Example configuration:
-
-```typescript
-import {
-  OktaUserEntityProvider,
-  OktaGroupEntityProvider,
-} from '@roadiehq/catalog-backend-module-okta';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const builder = await CatalogBuilder.create(env);
-
-  const oktaConfig =
-    env.config.getOptionalConfigArray('catalog.providers.okta') || [];
-  const userProvider = OktaUserEntityProvider.fromConfig(oktaConfig[0], {
-    logger: env.logger,
-    namingStrategy: 'strip-domain-email',
-  });
-  const groupProvider = OktaGroupEntityProvider.fromConfig(oktaConfig[0], {
-    logger: env.logger,
-    userNamingStrategy: 'strip-domain-email',
-    groupNamingStrategy: 'kebab-case-name',
-  });
-
-  builder.addEntityProvider(userProvider);
-  builder.addEntityProvider(groupProvider);
-
-  const { processingEngine, router } = await builder.build();
-
-  userProvider.run();
-  groupProvider.run();
-
-  await processingEngine.start();
-
-  // ...
-
-  return router;
-}
-```
-
-You can optionally provide the ability to create a hierarchy of groups by providing the `hierarchyConfig`.
-
-```typescript
-import {
-  OktaUserEntityProvider,
-  OktaGroupEntityProvider,
-} from '@roadiehq/catalog-backend-module-okta';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const builder = await CatalogBuilder.create(env);
-
-  const oktaConfig = env.config.getOptionalConfigArray(
-    'catalog.providers.okta',
-  );
-  const userProvider = OktaUserEntityProvider.fromConfig(oktaConfig[0], {
-    logger: env.logger,
-    namingStrategy: 'strip-domain-email',
-  });
-  const groupProvider = OktaGroupEntityProvider.fromConfig(oktaConfig[0], {
-    logger: env.logger,
-    userNamingStrategy: 'strip-domain-email',
-    groupNamingStrategy: 'kebab-case-name',
-    hierarchyConfig: {
-      key: 'profile.orgId',
-      parentKey: 'profile.parentOrgId',
-    },
-  });
-
-  builder.addEntityProvider(userProvider);
-  builder.addEntityProvider(groupProvider);
-
-  const { processingEngine, router } = await builder.build();
-
-  userProvider.run();
-  groupProvider.run();
-
-  await processingEngine.start();
-
-  // ...
-
-  return router;
-}
-```
+You can optionally provide the ability to create a hierarchy of groups by providing the `hierarchyConfig`. See example of OrgEntityProvider above for usage instructions.
 
 In case you want to customize the emitted entities, the provider allows to pass custom transformer by providing `groupTransformer`.
 
@@ -474,44 +470,9 @@ function myGroupTransformer(
 2. Configure the provider with the transformer:
 
 ```typescript
-import { OktaGroupEntityProvider } from '@roadiehq/catalog-backend-module-okta';
-import { myGroupTransformer } from './myGroupTransformer';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const builder = await CatalogBuilder.create(env);
-
-  const groupProvider = OktaGroupEntityProvider.fromConfig(env.config, {
-    logger: env.logger,
-    userNamingStrategy: 'strip-domain-email',
-    groupNamingStrategy: 'kebab-case-name',
-    groupTransformer: myGroupTransformer,
-  });
-
-  builder.addEntityProvider(groupProvider);
-
-  const { processingEngine, router } = await builder.build();
-
-  groupProvider.run();
-
-  await processingEngine.start();
-
-  // ...
-
-  return router;
-}
-```
-
-## New backend system
-
-```typescript
-import { coreServices } from '@backstage/backend-plugin-api';
-import { oktaCatalogBackendEntityProviderFactoryExtensionPoint } from '@roadiehq/catalog-backend-module-okta/new-backend';
-
-export const oktaCatalogBackendModule = createBackendModule({
+export const oktaGroupEntityProviderModule = createBackendModule({
   pluginId: 'catalog',
-  moduleId: 'okta-entity-provider-custom',
+  moduleId: 'default-okta-group-entity-provider',
   register(env) {
     env.registerInit({
       deps: {
@@ -520,10 +481,11 @@ export const oktaCatalogBackendModule = createBackendModule({
       },
       async init({ provider, logger }) {
         const factory: EntityProviderFactory = (oktaConfig: Config) =>
-          OktaOrgEntityProvider.fromConfig(oktaConfig, {
-            logger: loggerToWinstonLogger(logger),
+          OktaGroupEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
             userNamingStrategy: 'strip-domain-email',
-            groupNamingStrategy: 'kebab-case-name',
+            namingStrategy: 'kebab-case-name',
+            groupTransformer: myGroupTransformer,
           });
 
         provider.setEntityProviderFactory(factory);

--- a/plugins/backend/catalog-backend-module-okta/config.d.ts
+++ b/plugins/backend/catalog-backend-module-okta/config.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { SchedulerServiceTaskScheduleDefinitionConfig } from '@backstage/backend-plugin-api';
+
 export interface Config {
   catalog?: {
     providers?: {
@@ -36,6 +38,7 @@ export interface Config {
         };
         userFilter?: string;
         groupFilter?: string;
+        schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
       }[];
     };
   };

--- a/plugins/backend/catalog-backend-module-okta/package.json
+++ b/plugins/backend/catalog-backend-module-okta/package.json
@@ -8,7 +8,11 @@
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json",
-    "./new-backend": "./src/new-backend.ts"
+    "./new-backend": "./src/new-backend.ts",
+    "./okta-entity-provider": "./src/new-backend.ts",
+    "./user-provider-factory": "./src/user-entity-provider.ts",
+    "./group-provider-factory": "./src/group-entity-provider.ts",
+    "./org-provider-factory": "./src/org-entity-provider.ts"
   },
   "typesVersions": {
     "*": {
@@ -45,9 +49,9 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.24.0",
-    "@backstage/catalog-client": "^1.6.6",
     "@backstage/backend-plugin-api": "^0.8.0",
     "@backstage/backend-tasks": "^0.6.0",
+    "@backstage/catalog-client": "^1.6.6",
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/config": "^1.2.0",
     "@backstage/errors": "^1.2.4",

--- a/plugins/backend/catalog-backend-module-okta/src/entity-provider-modules.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/entity-provider-modules.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import {
+  EntityProviderFactory,
+  oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+} from './extensions';
+import { Config } from '@backstage/config';
+import {
+  OktaGroupEntityProvider,
+  OktaOrgEntityProvider,
+  OktaUserEntityProvider,
+} from './providers';
+
+export const oktaOrgEntityProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'default-okta-org-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        provider: oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+        logger: coreServices.logger,
+      },
+      async init({ provider, logger }) {
+        const factory: EntityProviderFactory = (oktaConfig: Config) =>
+          OktaOrgEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
+            userNamingStrategy: 'strip-domain-email',
+            groupNamingStrategy: 'kebab-case-name',
+          });
+
+        provider.setEntityProviderFactory(factory);
+      },
+    });
+  },
+});
+
+export const oktaUserEntityProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'default-okta-user-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        provider: oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+        logger: coreServices.logger,
+      },
+      async init({ provider, logger }) {
+        const factory: EntityProviderFactory = (oktaConfig: Config) =>
+          OktaUserEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
+            namingStrategy: 'strip-domain-email',
+          });
+
+        provider.setEntityProviderFactory(factory);
+      },
+    });
+  },
+});
+
+export const oktaGroupEntityProviderModule = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'default-okta-group-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        provider: oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+        logger: coreServices.logger,
+      },
+      async init({ provider, logger }) {
+        const factory: EntityProviderFactory = (oktaConfig: Config) =>
+          OktaGroupEntityProvider.fromConfig(oktaConfig, {
+            logger: logger,
+            userNamingStrategy: 'strip-domain-email',
+            namingStrategy: 'kebab-case-name',
+          });
+
+        provider.setEntityProviderFactory(factory);
+      },
+    });
+  },
+});

--- a/plugins/backend/catalog-backend-module-okta/src/extensions.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/extensions.ts
@@ -18,7 +18,7 @@ import { OktaEntityProvider } from './providers/OktaEntityProvider';
 import { OktaUserEntityTransformer } from './providers/types';
 import { Config } from '@backstage/config';
 
-export type EntityProviderFactory = (oktaConfig: Config) => OktaEntityProvider;
+export type EntityProviderFactory = (oktaConfigs: Config) => OktaEntityProvider;
 
 export interface OktaCatalogBackendEntityProviderFactoryExtensionPoint {
   setEntityProviderFactory(factory: EntityProviderFactory): void;

--- a/plugins/backend/catalog-backend-module-okta/src/group-entity-provider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/group-entity-provider.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { oktaGroupEntityProviderModule as default } from './entity-provider-modules';

--- a/plugins/backend/catalog-backend-module-okta/src/module.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/module.ts
@@ -18,7 +18,6 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { readTaskScheduleDefinitionFromConfig } from '@backstage/backend-tasks';
 import {
   EntityProviderFactory,
   oktaCatalogBackendEntityProviderFactoryExtensionPoint,
@@ -26,6 +25,7 @@ import {
 } from './extensions';
 import { OktaUserEntityTransformer } from './providers/types';
 import { userEntityFromOktaUser } from './providers/userEntityFromOktaUser';
+import { readSchedulerServiceTaskScheduleDefinitionFromConfig } from '@backstage/backend-plugin-api';
 
 export const oktaCatalogBackendModule = createBackendModule({
   pluginId: 'catalog',
@@ -74,10 +74,9 @@ export const oktaCatalogBackendModule = createBackendModule({
         for (const oktaConfig of oktaConfigs) {
           const provider = entityFactory(oktaConfig);
           catalog.addEntityProvider(provider);
-
-          // Workaround inspired by https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1310#issuecomment-2037783918
-          // Can be reworked when the support for the old backend system is dropped
-          const schedule = readTaskScheduleDefinitionFromConfig(oktaConfig);
+          const schedule = readSchedulerServiceTaskScheduleDefinitionFromConfig(
+            oktaConfig.getConfig('schedule'),
+          );
           await scheduler.scheduleTask({
             id: `okta-entity-provider-${provider.getProviderName()}`,
             fn: async () => {

--- a/plugins/backend/catalog-backend-module-okta/src/org-entity-provider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/org-entity-provider.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { oktaOrgEntityProviderModule as default } from './entity-provider-modules';

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
@@ -24,7 +24,7 @@ class ConcreteEntityProvider extends OktaEntityProvider {
     throw new Error('Method not implemented.');
   }
   constructor(accountConfig: AccountConfig) {
-    super([accountConfig], {
+    super(accountConfig, {
       logger: getVoidLogger(),
     });
   }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
@@ -18,7 +18,6 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import { Logger } from 'winston';
 import { AccountConfig } from '../types';
 import { Client, User, Group } from '@okta/okta-sdk-nodejs';
 
@@ -26,21 +25,22 @@ import {
   ANNOTATION_LOCATION,
   ANNOTATION_ORIGIN_LOCATION,
 } from '@backstage/catalog-model';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export type OktaScope = 'okta.groups.read' | 'okta.users.read';
 
 export abstract class OktaEntityProvider implements EntityProvider {
-  protected readonly accounts: AccountConfig[];
-  protected readonly logger: Logger;
+  protected readonly account: AccountConfig;
+  protected readonly logger: LoggerService;
   protected connection?: EntityProviderConnection;
 
   public abstract getProviderName(): string;
 
   protected constructor(
-    accounts: AccountConfig[],
-    options: { logger: Logger },
+    account: AccountConfig,
+    options: { logger: LoggerService },
   ) {
-    this.accounts = accounts;
+    this.account = account;
     this.logger = options.logger;
   }
 
@@ -48,12 +48,7 @@ export abstract class OktaEntityProvider implements EntityProvider {
     orgUrl: string,
     oauthScopes: OktaScope[] | undefined = undefined,
   ): Client {
-    const account = this.accounts.find(
-      acccountConfig => acccountConfig.orgUrl === orgUrl,
-    );
-    if (!account) {
-      throw new Error(`accountConfig for ${orgUrl} not found`);
-    }
+    const account = this.account;
 
     if (account.oauth && oauthScopes) {
       // use OAuth authentication strategy

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -15,7 +15,6 @@
  */
 
 import { GroupEntity } from '@backstage/catalog-model';
-import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { OktaEntityProvider } from './OktaEntityProvider';
 import {
@@ -35,6 +34,7 @@ import { isError } from '@backstage/errors';
 import { getOktaGroups } from './getOktaGroups';
 import { getParentGroup } from './getParentGroup';
 import { OktaGroupEntityTransformer } from './types';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
  * Provides entities from Okta Group service.
@@ -51,7 +51,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: LoggerService;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
       groupTransformer?: OktaGroupEntityTransformer;
@@ -80,7 +80,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
   constructor(
     accountConfig: AccountConfig,
     options: {
-      logger: winston.Logger;
+      logger: LoggerService;
       namingStrategy?: GroupNamingStrategies | GroupNamingStrategy;
       userNamingStrategy?: UserNamingStrategies | UserNamingStrategy;
       customAttributesToAnnotationAllowlist?: string[];
@@ -91,7 +91,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
       groupTransformer?: OktaGroupEntityTransformer;
     },
   ) {
-    super([accountConfig], options);
+    super(accountConfig, options);
     this.namingStrategy = groupNamingStrategyFactory(options.namingStrategy);
     this.userNamingStrategy = userNamingStrategyFactory(
       options.userNamingStrategy,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
@@ -70,17 +70,9 @@ const logger = getVoidLogger();
 
 describe('OktaOrgEntityProvider', () => {
   const config = new ConfigReader({
-    catalog: {
-      providers: {
-        okta: [
-          {
-            orgUrl: 'https://okta',
-            token: 'secret',
-            userFilter: 'profile.organization eq "engineering"',
-          },
-        ],
-      },
-    },
+    orgUrl: 'https://okta',
+    token: 'secret',
+    userFilter: 'profile.organization eq "engineering"',
   });
 
   describe('where there is no groups', () => {

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -15,7 +15,6 @@
  */
 
 import { UserEntity } from '@backstage/catalog-model';
-import * as winston from 'winston';
 import { Config } from '@backstage/config';
 import { OktaEntityProvider } from './OktaEntityProvider';
 import {
@@ -28,6 +27,7 @@ import { userEntityFromOktaUser as defaultUserEntityFromOktaUser } from './userE
 import { getAccountConfig } from './accountConfig';
 import { isError } from '@backstage/errors';
 import { OktaUserEntityTransformer } from './types';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
  * Provides entities from Okta User service.
@@ -42,7 +42,7 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: LoggerService;
       customAttributesToAnnotationAllowlist?: string[];
       namingStrategy?: UserNamingStrategies | UserNamingStrategy;
       userTransformer?: OktaUserEntityTransformer;
@@ -56,13 +56,13 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
   constructor(
     accountConfig: AccountConfig,
     options: {
-      logger: winston.Logger;
+      logger: LoggerService;
       customAttributesToAnnotationAllowlist?: string[];
       namingStrategy?: UserNamingStrategies | UserNamingStrategy;
       userTransformer?: OktaUserEntityTransformer;
     },
   ) {
-    super([accountConfig], options);
+    super(accountConfig, options);
     this.namingStrategy = userNamingStrategyFactory(options.namingStrategy);
     this.userEntityFromOktaUser =
       options.userTransformer || defaultUserEntityFromOktaUser;

--- a/plugins/backend/catalog-backend-module-okta/src/providers/getOktaGroups.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/getOktaGroups.ts
@@ -16,15 +16,15 @@
 import get from 'lodash/get';
 import { isError } from '@backstage/errors';
 import { Group, Client } from '@okta/okta-sdk-nodejs';
-import { Logger } from 'winston';
 import { GroupNamingStrategy } from './groupNamingStrategies';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 type GetOktaGroupsOptions = {
   client: Client;
   groupFilter: string | undefined;
   key: string | undefined;
   groupNamingStrategy: GroupNamingStrategy;
-  logger: Logger;
+  logger: LoggerService;
 };
 
 export const getOktaGroups = async (opts: GetOktaGroupsOptions) => {

--- a/plugins/backend/catalog-backend-module-okta/src/user-entity-provider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/user-entity-provider.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { oktaUserEntityProviderModule as default } from './entity-provider-modules';


### PR DESCRIPTION
* Updates interfaces in a breaking manner to favour backend system configurations over legacy system ones.
* Changes original provider factory interface to accept only okta configurations.
* Modifies plugin configuration to contain schedules
* Adds default configurations for the provider that can be added in. Leaves a customizable module construction option so more use cases can be covered.

