### PR TITLE
fix(rag-ai): properly clean up old techdoc vectors

### DIFF
--- a/.changeset/sweet-elephants-glow.md
+++ b/.changeset/sweet-elephants-glow.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend-retrieval-augmenter': patch
+---
+
+Fix issue with cleaning up old TechDocs vectors

--- a/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
+++ b/plugins/backend/rag-ai-backend-retrieval-augmenter/src/indexing/DefaultVectorAugmentationIndexer.ts
@@ -37,6 +37,10 @@ import {
 } from '@backstage/backend-plugin-api';
 import pLimit from 'p-limit';
 
+const TECHDOCS_ENTITY_FILTER = {
+  'metadata.annotations.backstage.io/techdocs-ref': CATALOG_FILTER_EXISTS,
+};
+
 export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
   private readonly _vectorStore: RoadieVectorStore;
   private readonly catalogApi: CatalogApi;
@@ -184,10 +188,7 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
 
         const entitiesResponse = await this.catalogApi.getEntities(
           {
-            filter: {
-              'metadata.annotations.backstage.io/techdocs-ref':
-                CATALOG_FILTER_EXISTS,
-            },
+            filter: TECHDOCS_ENTITY_FILTER,
           },
           { token },
         );
@@ -273,8 +274,10 @@ export class DefaultVectorAugmentationIndexer implements AugmentationIndexer {
       targetPluginId: 'catalog',
     });
 
+    const entityFilter =
+      source === 'tech-docs' ? TECHDOCS_ENTITY_FILTER : filter;
     const entities = (
-      await this.catalogApi.getEntities({ filter }, { token })
+      await this.catalogApi.getEntities({ filter: entityFilter }, { token })
     ).items.map(stringifyEntityRef);
 
     for (const entityRef of entities) {


### PR DESCRIPTION
Addresses issue where outdated techdocs vectors weren't being properly cleaned up when reindexing 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
