### PR TITLE
Fix for #1665 to not trigger login required for contributors card in entity page

### DIFF
--- a/.changeset/fuzzy-ads-sleep.md
+++ b/.changeset/fuzzy-ads-sleep.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-insights': patch
+---
+
+Fix to not trigger LoginRequired screen for ContributorsCard in EntityPage

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -62,6 +62,7 @@ import {
 } from '@roadiehq/backstage-plugin-aws-lambda';
 import {
   EntityGithubInsightsContent,
+  EntityGithubInsightsContributorsCard,
   EntityGithubInsightsLanguagesCard,
   EntityGithubInsightsReadmeCard,
   EntityGithubInsightsReleasesCard,
@@ -239,6 +240,9 @@ const overviewContent = (
     </EntitySwitch>
     <EntitySwitch>
       <EntitySwitch.Case if={e => Boolean(isGithubInsightsAvailable(e))}>
+        <Grid item md={3}>
+          <EntityGithubInsightsContributorsCard />
+        </Grid>
         <Grid item md={6}>
           <EntityGithubInsightsLanguagesCard />
           <EntityGithubInsightsReleasesCard />

--- a/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
+++ b/plugins/frontend/backstage-plugin-github-insights/src/components/Widgets/ContributorsCard/ContributorsCard.tsx
@@ -45,25 +45,16 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const ContributorsCard = () => {
+const ContributorsCardContent = () => {
   const { entity } = useEntity();
   const classes = useStyles();
   const { value, loading, error } = useRequest(entity, 'contributors', 10);
   const { hostname } = useEntityGithubScmIntegration(entity);
   const projectAlert = isGithubInsightsAvailable(entity);
   const { owner, repo } = useProjectEntity(entity);
-  const isLoggedIn = useGithubLoggedIn();
   if (!projectAlert) {
     return (
       <MissingAnnotationEmptyState annotation={GITHUB_INSIGHTS_ANNOTATION} />
-    );
-  }
-
-  if (!isLoggedIn) {
-    return (
-      <InfoCard title="Contributors" className={classes.infoCard}>
-        <GithubNotAuthorized />
-      </InfoCard>
     );
   }
 
@@ -93,6 +84,19 @@ const ContributorsCard = () => {
       className={classes.infoCard}
     >
       <ContributorsList contributors={value || []} />
+    </InfoCard>
+  );
+};
+
+const ContributorsCard = () => {
+  const classes = useStyles();
+  const isLoggedIn = useGithubLoggedIn();
+
+  return isLoggedIn ? (
+    <ContributorsCardContent />
+  ) : (
+    <InfoCard title="Contributors" className={classes.infoCard}>
+      <GithubNotAuthorized />
     </InfoCard>
   );
 };


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->
Fix for #1665 to not trigger Login Required screen for contributors card in entity page.
Before:
<img width="1719" alt="Screenshot 2024-10-22 at 17 57 37" src="https://github.com/user-attachments/assets/b80f287f-fed3-4e74-936d-d7862b2559df">
After:
<img width="1713" alt="Screenshot 2024-10-22 at 17 58 18" src="https://github.com/user-attachments/assets/25cfc653-6690-49d5-a273-0c04b4160016">


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
