### PR TITLE
feat(rag-ai): allow specifying custom openai url

### DIFF
--- a/.changeset/metal-books-beam.md
+++ b/.changeset/metal-books-beam.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/rag-ai-backend-embeddings-openai': minor
+'@roadiehq/rag-ai-backend': minor
+---
+
+Add support for specifying a custom OpenAI baseURL via config

--- a/plugins/backend/rag-ai-backend-embeddings-openai/README.md
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/README.md
@@ -30,7 +30,10 @@ ai:
     # OpenAI Embeddings configuration
     openai:
       # (Optional) The API key for accessing OpenAI services. Defaults to process.env.OPENAI_API_KEY
-      openAIApiKey: 'sk-123...'
+      openAiApiKey: 'sk-123...'
+
+      # (Optional) Specify URL of self-hosted OpenAI compliant endpoint. Defaults to OpenAI's public API https://api.openai.com
+      openAiBaseUrl: ''
 
       # (Optional) Name of the OpenAI model to use to create Embeddings. Defaults to text-embedding-3-large
       modelName: 'text-embedding-3-large'

--- a/plugins/backend/rag-ai-backend-embeddings-openai/config.d.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/config.d.ts
@@ -25,7 +25,12 @@ export interface Config {
         /**
          * The API key for accessing OpenAI services. Defaults to process.env.OPENAI_API_KEY
          */
-        openAIApiKey?: string;
+        openAiApiKey?: string;
+
+        /**
+         * Specify URL of self-hosted OpenAI compliant endpoint. Defaults to OpenAI's public API https://api.openai.com
+         */
+        openAiBaseUrl?: string;
 
         /**
          * Name of the OpenAI model to use to create Embeddings. Defaults to text-embedding-3-small

--- a/plugins/backend/rag-ai-backend-embeddings-openai/src/RoadieOpenAiAugmenter.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/src/RoadieOpenAiAugmenter.ts
@@ -24,6 +24,7 @@ export type OpenAiConfig = {
   openAiApiKey?: string;
   batchSize?: number;
   embeddingsDimensions?: number;
+  openAiBaseUrl?: string;
 };
 
 export class RoadieOpenAiAugmenter extends DefaultVectorAugmentationIndexer {
@@ -33,6 +34,9 @@ export class RoadieOpenAiAugmenter extends DefaultVectorAugmentationIndexer {
     },
   ) {
     const embeddings = new OpenAIEmbeddings({
+      configuration: {
+        baseURL: config.config.openAiBaseUrl,
+      },
       openAIApiKey: config.config.openAiApiKey, // In Node.js defaults to process.env.OPENAI_API_KEY
       batchSize: config.config.batchSize, // Default value if omitted is 512. Max is 2048
       modelName: config.config.modelName

--- a/plugins/backend/rag-ai-backend/README.md
+++ b/plugins/backend/rag-ai-backend/README.md
@@ -70,7 +70,10 @@ ai:
     # OpenAI Embeddings configuration
     openai:
       # (Optional) The API key for accessing OpenAI services. Defaults to process.env.OPENAI_API_KEY
-      openAIApiKey: 'sk-123...'
+      openAiApiKey: 'sk-123...'
+
+      # (Optional) Specify URL of self-hosted OpenAI compliant endpoint. Defaults to OpenAI's public API https://api.openai.com
+      openAiBaseUrl: ''
 
       # (Optional) Name of the OpenAI model to use to create Embeddings. Defaults to text-embedding-3-small
       modelName: 'text-embedding-3-small'


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

Addresses https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1469

Makes the baseURL for OpenAi configurable to allow use of a self-hosted OpenAI endpoint. 

Verified functionality using a self-hosted OpenAI URL:

https://github.com/user-attachments/assets/61b9f87b-a0ae-4d40-9401-9ffb31b0202e


#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
  - Config-only change, don't believe tests are necessary
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
