### PR TITLE
[catalog-backend-module-okta] Export extensions

### DIFF
--- a/.changeset/many-plants-tell.md
+++ b/.changeset/many-plants-tell.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Export provider extensions

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -99,6 +99,18 @@ You can also tailor the entity providers to handle different configurations if t
 You can construct your own configuration of OktaOrgEntityProvider factory and register it into the backend:
 
 ```typescript
+import {
+    coreServices,
+    createBackendModule,
+} from "@backstage/backend-plugin-api";
+import { Config } from "@backstage/config";
+
+// Okta Catalog imports
+import {
+    OktaOrgEntityProvider,
+    oktaCatalogBackendEntityProviderFactoryExtensionPoint,
+} from "@roadiehq/catalog-backend-module-okta";
+
 export const oktaOrgEntityProviderModule = createBackendModule({
   pluginId: 'catalog',
   moduleId: 'default-okta-org-entity-provider',

--- a/plugins/backend/catalog-backend-module-okta/src/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './providers';
+export * from './extensions';


### PR DESCRIPTION
Exports plugin extension points in catalog-backend-module-okta. Also added imports to the example in the README.md

Unless I was missing an export somewhere else, these are needed for examples and I believe intended to be exported?

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
