### PR TITLE
fix(security-insights): set filtered table data on initial load

### DIFF
--- a/.changeset/fifty-forks-cheat.md
+++ b/.changeset/fifty-forks-cheat.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-security-insights': patch
+---
+
+fix bug where security insights tab was empty on initial render until clicking one of the filter buttons

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
@@ -65,6 +65,11 @@ export const SecurityInsightsTable = () => {
     );
     const data = response.data as SecurityInsight[];
     setTableData(data);
+    if (insightsStatusFilter) {
+      setFilteredTableData(
+        data.filter(entry => entry.state === insightsStatusFilter),
+      );
+    }
     return data;
   }, []);
 


### PR DESCRIPTION
[This PR](https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1397) updated this component to filter to `open` on initial load. However, on initial load only `tableData` was being set previously. 

Fixes: https://github.com/RoadieHQ/roadie-backstage-plugins/issues/1492

There is a check in the JSX to render `filteredTableData` if `insightsStatusFilter` is set. Since `insightsStatusFilter` is set with the default state value now (`const [insightsStatusFilter, setInsightsStatusFilter] = useState<SecurityInsightFilterState>('open');`), this was rendering `filteredTableData` on the first render which was null. Clicking on `Open` would display data but may give uses a false sense of security that they have no security insights with a quick glance at the tab. 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
  - there are no existing tests for this component
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
  - Tested this on one of our components that has security insights but don't really want to post screenshots because security
- [ ] Added or updated documentation (if applicable)
  - N/A - bug fix
