### PR TITLE
feat(scaffolder-module-utils): deprecate new-backend.ts re-export from index.ts

### DIFF
--- a/.changeset/neat-adults-march.md
+++ b/.changeset/neat-adults-march.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': major
+---
+
+Deprecated the exports from `new-backend.ts` and re-export from `index.ts` as part of the transition to the new backend system

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/README.md
@@ -111,7 +111,7 @@ import { createBackendModule } from '@backstage/backend-plugin-api';
 const backend = createBackend();
 backend.add(import('@backstage/plugin-proxy-backend/alpha'));
 backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
-backend.add(import('@roadiehq/scaffolder-backend-module-utils/new-backend'));
+backend.add(import('@roadiehq/scaffolder-backend-module-utils'));
 backend.start();
 ```
 

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/index.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/index.ts
@@ -13,9 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './actions/zip';
-export * from './actions/fs';
-export * from './actions/merge';
-export * from './actions/sleep';
-export * from './actions/jsonata';
-export * from './actions/serialize';
+export * from './actions';
+export { scaffolderBackendModuleUtils as default } from './module';

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/new-backend.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/new-backend.ts
@@ -13,5 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * @deprecated Please import from the root path instead.
+ */
 export * from './module';
 export { scaffolderBackendModuleUtils as default } from './module';


### PR DESCRIPTION
Deprecated the export within `new-backend.ts` and re-exported from `index.ts`. Followed the "Deprecate the `/alpha` subpath if exists" portion of the [Building Plugins & Modules / Migration Guide](https://backstage.io/docs/backend-system/building-plugins-and-modules/migrating#deprecate-the-alpha-subpath-if-it-exists).

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
