### PR TITLE
feat: upgrading logger

### DIFF
--- a/.changeset/two-knives-hammer.md
+++ b/.changeset/two-knives-hammer.md
@@ -1,0 +1,13 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': minor
+'@roadiehq/scaffolder-backend-argocd': minor
+'@roadiehq/backstage-plugin-argo-cd-backend': minor
+'@roadiehq/rag-ai-backend-embeddings-openai': minor
+'@roadiehq/catalog-backend-module-aws': minor
+'@roadiehq/backstage-plugin-aws-auth': minor
+'@roadiehq/backstage-plugin-aws-backend': minor
+'@roadiehq/rag-ai-backend': minor
+'backend': minor
+---
+
+We are making the logger compatible with Backstage's LoggerService and winston's Logger so that Roadie can be used with newer and older versions of Backstage.

--- a/packages/backend/src/plugins/proxy.ts
+++ b/packages/backend/src/plugins/proxy.ts
@@ -16,11 +16,15 @@
 import { createRouter } from '@backstage/plugin-proxy-backend';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
+import { loggerToWinstonLogger } from '@backstage/backend-common';
+import { Logger } from 'winston';
 
 export default async function createPlugin({
   logger,
   config,
   discovery,
 }: PluginEnvironment): Promise<Router> {
-  return await createRouter({ logger, config, discovery });
+  const winstonLogger =
+    logger instanceof Logger ? logger : loggerToWinstonLogger(logger);
+  return await createRouter({ logger: winstonLogger, config, discovery });
 }

--- a/packages/backend/src/plugins/scaffolder.ts
+++ b/packages/backend/src/plugins/scaffolder.ts
@@ -16,6 +16,7 @@
 import {
   ContainerRunner,
   DockerContainerRunner,
+  loggerToWinstonLogger,
 } from '@backstage/backend-common';
 import { CatalogClient } from '@backstage/catalog-client';
 import { TemplateAction } from '@backstage/plugin-scaffolder-node';
@@ -49,6 +50,7 @@ import { ScmIntegrations } from '@backstage/integration';
 import { Config } from '@backstage/config';
 import { DiscoveryApi } from '@backstage/plugin-permission-common';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
+import { Logger } from 'winston';
 
 export const createActions = (options: {
   reader: UrlReaderService;
@@ -98,8 +100,11 @@ export default async function createPlugin({
 
   const catalogClient = new CatalogClient({ discoveryApi: discovery });
 
+  const winstonLogger =
+    logger instanceof Logger ? logger : loggerToWinstonLogger(logger);
+
   return await createRouter({
-    logger,
+    logger: winstonLogger,
     config,
     database,
     catalogClient,

--- a/packages/backend/src/plugins/techdocs.ts
+++ b/packages/backend/src/plugins/techdocs.ts
@@ -20,6 +20,8 @@ import {
   Preparers,
   Publisher,
 } from '@backstage/plugin-techdocs-backend';
+import { Logger } from 'winston';
+import { loggerToWinstonLogger } from '@backstage/backend-common';
 import Docker from 'dockerode';
 import { Router } from 'express';
 import { PluginEnvironment } from '../types';
@@ -58,11 +60,14 @@ export default async function createPlugin({
   // checks if the publisher is working and logs the result
   await publisher.getReadiness();
 
+  const winstonLogger =
+    logger instanceof Logger ? logger : loggerToWinstonLogger(logger);
+
   return await createRouter({
     preparers,
     generators,
     publisher,
-    logger,
+    logger: winstonLogger,
     config,
     discovery,
     cache,

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import {
   PluginCacheManager,
@@ -26,7 +27,7 @@ import { PluginTaskScheduler } from '@backstage/backend-tasks';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 export type PluginEnvironment = {
-  logger: Logger;
+  logger: Logger | LoggerService;
   cache: PluginCacheManager;
   database: PluginDatabaseManager;
   config: Config;

--- a/plugins/backend/backstage-aws-backend/package.json
+++ b/plugins/backend/backstage-aws-backend/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-plugin-api": "^1.0.1",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/config": "^1.3.0",
     "@types/express": "^4.17.6",

--- a/plugins/backend/backstage-aws-backend/src/service/router.ts
+++ b/plugins/backend/backstage-aws-backend/src/service/router.ts
@@ -19,12 +19,13 @@ import { Config } from '@backstage/config';
 import express, { Request } from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { CloudControl } from '@aws-sdk/client-cloudcontrol';
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { Account } from '../types';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: Logger | LoggerService;
   config: Config;
 }
 

--- a/plugins/backend/backstage-aws-backend/src/service/standaloneServer.ts
+++ b/plugins/backend/backstage-aws-backend/src/service/standaloneServer.ts
@@ -20,12 +20,13 @@ import {
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { createRouter } from './router';
 
 export interface ServerOptions {
   port: number;
   enableCors: boolean;
-  logger: Logger;
+  logger: Logger | LoggerService;
 }
 
 export async function startStandaloneServer(

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -1,6 +1,7 @@
 import { Config } from '@backstage/config';
 import fetch from 'cross-fetch';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { timer } from './timer.services';
 
 import {
@@ -45,7 +46,7 @@ export class ArgoService implements ArgoServiceApi {
     private readonly username: string,
     private readonly password: string,
     private readonly config: Config,
-    private readonly logger: Logger,
+    private readonly logger: Logger | LoggerService,
   ) {
     this.instanceConfigs = this.config
       .getConfigArray('argocd.appLocatorMethods')

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
@@ -7,7 +7,7 @@ import {
 } from './argocdTestResponses';
 import fetchMock from 'jest-fetch-mock';
 import { timer } from './timer.services';
-import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { ResourceItem, UpdateArgoProjectAndAppProps } from './types';
 import { mocked } from 'jest-mock';
 
@@ -18,7 +18,7 @@ jest.mock('./timer.services', () => ({
 const loggerMock = {
   error: jest.fn(),
   info: jest.fn(),
-} as unknown as Logger;
+} as unknown as LoggerService;
 
 const getConfig = (options: {
   token?: string;

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/router.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/router.ts
@@ -3,11 +3,12 @@ import { Config } from '@backstage/config';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { ArgoService } from './argocd.service';
 import { getArgoConfigByInstanceName } from '../utils/getArgoConfig';
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: Logger | LoggerService;
   config: Config;
 }
 export type Response = {

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/standaloneServer.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/standaloneServer.ts
@@ -4,12 +4,13 @@ import {
 } from '@backstage/backend-common';
 import { Server } from 'http';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { createRouter } from './router';
 
 export interface ServerOptions {
   port: number;
   enableCors: boolean;
-  logger: Logger;
+  logger: Logger | LoggerService;
 }
 
 export async function startStandaloneServer(

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/types.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/types.ts
@@ -1,5 +1,6 @@
 import { Config } from '@backstage/config';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export type getRevisionDataResp = {
   author: string;
@@ -61,7 +62,7 @@ export interface CreateArgoResourcesProps {
   sourceRepo: string;
   sourcePath: string;
   labelValue: string;
-  logger: Logger;
+  logger: Logger | LoggerService;
 }
 
 export interface UpdateArgoProjectAndAppProps {

--- a/plugins/backend/backstage-plugin-aws-auth/package.json
+++ b/plugins/backend/backstage-plugin-aws-auth/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-plugin-api": "^1.0.1",
     "@types/express": "^4.17.11",
     "aws-sdk": "^2.902.0",
     "cors": "^2.8.5",

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/aws-api.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/aws-api.ts
@@ -16,6 +16,7 @@
 
 import express from 'express';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { generateTemporaryCredentials } from './generateTemporaryCredentials';
 
 export type LambdaData = {
@@ -35,7 +36,7 @@ export function getAwsApiGenerateTempCredentialsForwarder({
 }: {
   AWS_ACCESS_KEY_ID?: string;
   AWS_ACCESS_KEY_SECRET?: string;
-  logger: Logger;
+  logger: Logger | LoggerService;
 }) {
   return async function forwardRequest(
     _: express.Request,

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/router.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/router.ts
@@ -15,11 +15,14 @@
  */
 
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import Router from 'express-promise-router';
 import express from 'express';
 import { getAwsApiGenerateTempCredentialsForwarder } from './aws-api';
 
-export async function createRouter(logger: Logger): Promise<express.Router> {
+export async function createRouter(
+  logger: Logger | LoggerService,
+): Promise<express.Router> {
   const router = Router();
   router.use(express.json());
 

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneApplication.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneApplication.ts
@@ -23,10 +23,11 @@ import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { createRouter } from './router';
 
 export async function createStandaloneApplication(
-  logger: Logger,
+  logger: Logger | LoggerService,
 ): Promise<express.Application> {
   const app = express();
 

--- a/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneServer.ts
+++ b/plugins/backend/backstage-plugin-aws-auth/src/service/standaloneServer.ts
@@ -15,10 +15,11 @@
  */
 import { Server } from 'http';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { createStandaloneApplication } from './standaloneApplication';
 
 export async function startStandaloneServer(
-  parentLogger: Logger,
+  parentLogger: Logger | LoggerService,
 ): Promise<Server> {
   const logger = parentLogger.child({ service: 'scaffolder-backend' });
   logger.debug('Creating application...');

--- a/plugins/backend/catalog-backend-module-aws/package.json
+++ b/plugins/backend/catalog-backend-module-aws/package.json
@@ -54,6 +54,7 @@
     "@aws-sdk/lib-dynamodb": "^3.696.0",
     "@backstage/integration-aws-node": "^0.1.13",
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-plugin-api": "^1.0.1",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/plugin-kubernetes-common": "^0.9.0",
     "@backstage/catalog-model": "^1.7.1",

--- a/plugins/backend/catalog-backend-module-aws/src/processors/AWSCatalogProcessor.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/processors/AWSCatalogProcessor.ts
@@ -17,17 +17,18 @@
 import { CatalogProcessor } from '@backstage/plugin-catalog-backend';
 import { CatalogApi } from '@backstage/catalog-client';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 export abstract class AWSCatalogProcessor implements CatalogProcessor {
   protected readonly catalogApi: CatalogApi;
-  protected readonly logger: Logger;
+  protected readonly logger: Logger | LoggerService;
   public abstract getProcessorName(): string;
   constructor({
     catalogApi,
     logger,
   }: {
     catalogApi: CatalogApi;
-    logger: Logger;
+    logger: Logger | LoggerService;
   }) {
     this.catalogApi = catalogApi;
     this.logger = logger;

--- a/plugins/backend/catalog-backend-module-aws/src/processors/AWSIAMRoleProcessor.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/processors/AWSIAMRoleProcessor.ts
@@ -30,6 +30,7 @@ import {
 import { ANNOTATION_AWS_IAM_ROLE_ARN } from '../annotations';
 import { Config } from '@backstage/config';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { PluginEndpointDiscovery } from '@backstage/backend-common';
 import { CatalogClient, CatalogApi } from '@backstage/catalog-client';
 import { arnToName } from '../utils/arnToName';
@@ -37,7 +38,10 @@ import { arnToName } from '../utils/arnToName';
 export class AWSIAMRoleProcessor extends AWSCatalogProcessor {
   static fromConfig(
     _config: Config,
-    options: { logger: winston.Logger; discovery: PluginEndpointDiscovery },
+    options: {
+      logger: winston.Logger | LoggerService;
+      discovery: PluginEndpointDiscovery;
+    },
   ) {
     const catalogApi: CatalogApi = new CatalogClient({
       discoveryApi: options.discovery,

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.ts
@@ -31,6 +31,7 @@ import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
 import { merge } from 'lodash';
 import { mapColumnsToEntityValues } from '../utils/columnMapper';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   ANNOTATION_ACCOUNT_ID,
   ANNOTATION_AWS_DDB_TABLE_ARN,
@@ -51,11 +52,14 @@ export class AWSDynamoDbTableDataProvider implements EntityProvider {
   private readonly accountId: string;
   private readonly roleArn: string;
   private readonly tableDataConfig: DdbTableDataConfigOptions;
-  private readonly logger: winston.Logger;
+  private readonly logger: winston.Logger | LoggerService;
 
   private connection?: EntityProviderConnection;
 
-  static fromConfig(config: Config, options: { logger: winston.Logger }) {
+  static fromConfig(
+    config: Config,
+    options: { logger: winston.Logger | LoggerService },
+  ) {
     return new AWSDynamoDbTableDataProvider(
       config.getString('accountId'),
       config.getString('roleName'),
@@ -68,7 +72,7 @@ export class AWSDynamoDbTableDataProvider implements EntityProvider {
     accountId: string,
     roleArn: string,
     options: DdbTableDataConfigOptions,
-    logger: winston.Logger,
+    logger: winston.Logger | LoggerService,
   ) {
     this.accountId = accountId;
     this.roleArn = roleArn;
@@ -168,7 +172,7 @@ export class AWSDynamoDbTableDataProvider implements EntityProvider {
         })),
       });
     } catch (e) {
-      this.logger.error(e);
+      this.logger.error((e as Error).message, e as Error);
     }
   }
 }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
@@ -17,6 +17,7 @@
 import { DynamoDB, paginateListTables } from '@aws-sdk/client-dynamodb';
 import { Config } from '@backstage/config';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ResourceEntity } from '@backstage/catalog-model';
 import { ANNOTATION_AWS_DDB_TABLE_ARN } from '../annotations';
@@ -37,7 +38,7 @@ export class AWSDynamoDbTableProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
 import { EC2 } from '@aws-sdk/client-ec2';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_EC2_INSTANCE_ID } from '../annotations';
@@ -37,7 +38,7 @@ export class AWSEC2Provider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.ts
@@ -17,6 +17,7 @@
 import { ResourceEntity } from '@backstage/catalog-model';
 import { EKS, paginateListClusters } from '@aws-sdk/client-eks';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import {
@@ -49,7 +50,7 @@ export class AWSEKSClusterProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -73,7 +74,7 @@ export class AWSEKSClusterProvider extends AWSEntityProvider {
   constructor(
     account: AccountConfig,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
@@ -19,6 +19,7 @@ import {
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { AccountConfig, DynamicAccountConfig } from '../types';
 import { STS } from '@aws-sdk/client-sts';
 import {
@@ -36,7 +37,7 @@ import { LabelValueMapper, labelsFromTags, Tag } from '../utils/tags';
 export abstract class AWSEntityProvider implements EntityProvider {
   protected readonly useTemporaryCredentials: boolean;
   protected readonly providerId?: string;
-  protected readonly logger: winston.Logger;
+  protected readonly logger: winston.Logger | LoggerService;
   protected connection?: EntityProviderConnection;
   private readonly ownerTag: string | undefined;
   protected readonly catalogApi?: CatalogApi;
@@ -52,7 +53,7 @@ export abstract class AWSEntityProvider implements EntityProvider {
   protected constructor(
     account: AccountConfig,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
 import { IAM, paginateListRoles } from '@aws-sdk/client-iam';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_IAM_ROLE_ARN } from '../annotations';
@@ -38,7 +39,7 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_VIEW_URL, UserEntity } from '@backstage/catalog-model';
 import { IAM, paginateListUsers } from '@aws-sdk/client-iam';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_IAM_USER_ARN } from '../annotations';
@@ -34,7 +35,7 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
 import { Lambda, paginateListFunctions } from '@aws-sdk/client-lambda';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import {
@@ -41,7 +42,7 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -113,7 +114,10 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
             });
             tags = tagsResponse?.Tags ?? {};
           } catch (e) {
-            this.logger.warn('Unable to get tags for Lambda functions', e);
+            this.logger.warn(
+              'Unable to get tags for Lambda functions',
+              e as Error,
+            );
           }
 
           const annotations: { [name: string]: string } = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
@@ -22,6 +22,7 @@ import {
   paginateListTagsForResource,
 } from '@aws-sdk/client-organizations';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import {
@@ -46,7 +47,7 @@ export class AWSOrganizationAccountsProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
@@ -29,6 +29,7 @@ import {
 import { CatalogApi } from '@backstage/catalog-client';
 import { DynamicAccountConfig } from '../types';
 import { duration } from '../utils/timer';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
  * Provides entities from AWS Relational Database Service.
@@ -37,7 +38,7 @@ export class AWSRDSProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       useTemporaryCredentials?: boolean;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
 import { S3, Tag } from '@aws-sdk/client-s3';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_S3_BUCKET_ARN } from '../annotations';
@@ -38,7 +39,7 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
 import { SNS, paginateListTopics } from '@aws-sdk/client-sns';
 import * as winston from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { AWSEntityProvider } from './AWSEntityProvider';
 import { ANNOTATION_AWS_SNS_TOPIC_ARN } from '../annotations';
@@ -37,7 +38,7 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
   static fromConfig(
     config: Config,
     options: {
-      logger: winston.Logger;
+      logger: winston.Logger | LoggerService;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;

--- a/plugins/backend/rag-ai-backend-embeddings-openai/package.json
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@backstage/backend-common": "^0.25.0",
+    "@backstage/backend-plugin-api": "^1.0.1",
     "@backstage/catalog-client": "^1.8.0",
     "@backstage/config": "^1.3.0",
     "@langchain/core": "^0.2.27",

--- a/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-openai/src/index.ts
@@ -15,6 +15,7 @@
  */
 import { TokenManager } from '@backstage/backend-common';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { AugmentationIndexer, RoadieVectorStore } from '@roadiehq/rag-ai-node';
 import { OpenAiConfig, RoadieOpenAiAugmenter } from './RoadieOpenAiAugmenter';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -23,7 +24,7 @@ import { Config } from '@backstage/config';
 import { AugmentationOptions } from '@roadiehq/rag-ai-backend-retrieval-augmenter';
 
 export interface RoadieBedrockEmbeddingsConfig {
-  logger: Logger;
+  logger: Logger | LoggerService;
   tokenManager: TokenManager;
   vectorStore: RoadieVectorStore;
   catalogApi: CatalogApi;

--- a/plugins/backend/rag-ai-backend/src/service/LlmService.ts
+++ b/plugins/backend/rag-ai-backend/src/service/LlmService.ts
@@ -17,10 +17,11 @@ import { BaseLLM } from '@langchain/core/language_models/llms';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { EmbeddingDoc } from '@roadiehq/rag-ai-node';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { createPromptTemplates } from './prompts';
 
 export class LlmService {
-  private readonly logger: Logger;
+  private readonly logger: Logger | LoggerService;
   private readonly model: BaseLLM | BaseChatModel;
   private readonly prompts: {
     prefixPrompt: (embedding: string) => string;
@@ -32,7 +33,7 @@ export class LlmService {
     model,
     configuredPrompts,
   }: {
-    logger: Logger;
+    logger: Logger | LoggerService;
     model: BaseLLM | BaseChatModel;
     configuredPrompts?: {
       prefix?: string;

--- a/plugins/backend/rag-ai-backend/src/service/RagAiController.ts
+++ b/plugins/backend/rag-ai-backend/src/service/RagAiController.ts
@@ -15,6 +15,8 @@
  */
 import { Request, Response } from 'express';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
+
 import { LlmService } from './LlmService';
 import {
   AugmentationIndexer,
@@ -35,10 +37,10 @@ export class RagAiController {
   private readonly llmService: LlmService;
   private readonly augmentationIndexer: AugmentationIndexer;
   private readonly retrievalPipeline?: RetrievalPipeline;
-  private logger: Logger;
+  private logger: Logger | LoggerService;
 
   constructor(
-    logger: Logger,
+    logger: Logger | LoggerService,
     llmService: LlmService,
     augmentationIndexer: AugmentationIndexer,
     retrievalPipeline?: RetrievalPipeline,
@@ -55,7 +57,7 @@ export class RagAiController {
     augmentationIndexer,
     retrievalPipeline,
   }: {
-    logger: Logger;
+    logger: Logger | LoggerService;
     llmService: LlmService;
     augmentationIndexer: AugmentationIndexer;
     retrievalPipeline?: RetrievalPipeline;

--- a/plugins/backend/rag-ai-backend/src/service/router.ts
+++ b/plugins/backend/rag-ai-backend/src/service/router.ts
@@ -17,6 +17,7 @@ import { errorHandler } from '@backstage/backend-common';
 import express, { NextFunction, Request, Response } from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { AugmentationIndexer, RetrievalPipeline } from '@roadiehq/rag-ai-node';
 import { BaseLLM } from '@langchain/core/language_models/llms';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
@@ -34,7 +35,7 @@ type AiBackendConfig = {
 };
 
 export interface RouterOptions {
-  logger: Logger;
+  logger: Logger | LoggerService;
   augmentationIndexer: AugmentationIndexer;
   retrievalPipeline: RetrievalPipeline;
   model: BaseLLM | BaseChatModel;

--- a/plugins/backend/rag-ai-backend/src/service/types.ts
+++ b/plugins/backend/rag-ai-backend/src/service/types.ts
@@ -16,12 +16,13 @@
 import { TokenManager } from '@backstage/backend-common';
 import { AugmentationIndexer, RetrievalPipeline } from '@roadiehq/rag-ai-node';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { BaseLLM } from '@langchain/core/language_models/llms';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { Config } from '@backstage/config';
 
 export interface RagAiConfig {
-  logger: Logger;
+  logger: Logger | LoggerService;
   tokenManager: TokenManager;
   augmentationIndexer: AugmentationIndexer;
   retrievalPipeline: RetrievalPipeline;

--- a/plugins/scaffolder-actions/scaffolder-backend-argocd/src/actions/run/argocd.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-argocd/src/actions/run/argocd.ts
@@ -17,8 +17,12 @@ import { Config } from '@backstage/config';
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { ArgoService } from '@roadiehq/backstage-plugin-argo-cd-backend';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 
-export const createArgoCdResources = (config: Config, logger: Logger) => {
+export const createArgoCdResources = (
+  config: Config,
+  logger: Logger | LoggerService,
+) => {
   return createTemplateAction<{
     argoInstance: string;
     namespace: string;

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/helpers.ts
@@ -16,6 +16,7 @@
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { fetch } from 'cross-fetch';
 import { Logger } from 'winston';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import { HttpOptions } from './types';
 
 class HttpError extends Error {}
@@ -40,7 +41,7 @@ export const generateBackstageUrl = async (
 
 export const http = async (
   options: HttpOptions,
-  logger: Logger,
+  logger: Logger | LoggerService,
   continueOnBadResponse: boolean = false,
 ): Promise<any> => {
   let res: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4946,7 +4946,7 @@
     knex "^3.0.0"
     luxon "^3.0.0"
 
-"@backstage/backend-plugin-api@^1.0.2":
+"@backstage/backend-plugin-api@^1.0.1", "@backstage/backend-plugin-api@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-1.0.2.tgz#d0a17dbf66e32d7d56756bc7fd6ecd0fb854f40f"
   integrity sha512-XcTOx4ARR3JmV1y28jsi0SevQXxDF5KvOTn5D50G9XRIUnnlDMHiJjBg22kxDOZrckTlC7WWGuVe5LHnSTkcrA==
@@ -33110,7 +33110,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -33184,7 +33193,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -33197,6 +33206,13 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -35527,7 +35543,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -35540,6 +35556,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

We are making the logger compatible with Backstage's `LoggerService` and winston's `Logger` so that Roadie can be used with newer and older versions of Backstage.

We are doing this by accepting both types of loggers

All the type definitions with a logger have been changed to 
```
import { Logger } from 'winston';
import { LoggerService } from '@backstage/backend-plugin-api';
....
logger: Logger | LoggerService
....
```

Whenever it is required that a logger is from `winston` we do this 
```
import { loggerToWinstonLogger } from '@backstage/backend-common';
import { Logger } from 'winston';

....

const winstonLogger = logger instanceof Logger ? logger : loggerToWinstonLogger(logger);
createRouter({ logger: winstonLogger, config, discovery });

....
```
This way we check to see what type of logger it is and if it is a `LoggerService` type then we will change it to a `winston` `Logger`

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
