### PR TITLE
docs(ai): add ai.embeddings.bedrock.maxRetries to README of @roadiehq/rag-ai-backend

### DIFF
--- a/.changeset/khaki-mice-wash.md
+++ b/.changeset/khaki-mice-wash.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend': patch
+---
+
+Added `ai.embeddings.bedrock.maxRetries` to README

--- a/plugins/backend/rag-ai-backend/README.md
+++ b/plugins/backend/rag-ai-backend/README.md
@@ -65,6 +65,9 @@ ai:
       # (Required) Name of the Bedrock model to use to create Embeddings.
       modelName: 'amazon.titan-embed-text-v1'
 
+      # (Optional) Maximum number of retries for the AWS SDK client
+      maxRetries: 3
+
       ## AWS Bedrock uses integration-aws-node package to configure credentials. See the package README for more info.
 
     # OpenAI Embeddings configuration


### PR DESCRIPTION
I noticed that the README of `@roadiehq/rag-ai-backend` didn't cover the newly added property in #1755 yet, so this PR adds that.

(not sure if this actually requires a changeset though - maybe only for getting the README correct on npm)

#### :heavy_check_mark: Checklist

- [x] Added changeset (run `yarn changeset` in the root)
- [x] Added or updated documentation (if applicable)
