### PR TITLE
chore: move moment usage to luxon

### DIFF
--- a/.changeset/honest-icons-talk.md
+++ b/.changeset/honest-icons-talk.md
@@ -1,0 +1,10 @@
+---
+'@roadiehq/backstage-plugin-bitbucket-pullrequest': patch
+'@roadiehq/backstage-plugin-security-insights': patch
+'@roadiehq/backstage-plugin-aws-lambda': patch
+'@roadiehq/backstage-plugin-buildkite': patch
+'@roadiehq/backstage-plugin-argo-cd': patch
+'@roadiehq/backstage-plugin-jira': patch
+---
+
+chore: use luxon library insteaad of moment

--- a/.changeset/lazy-mugs-fry.md
+++ b/.changeset/lazy-mugs-fry.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-travis-ci': patch
+'@roadiehq/backstage-plugin-datadog': patch
+---
+
+chore: remove unused dependency moment

--- a/plugins/frontend/backstage-plugin-argo-cd/package.json
+++ b/plugins/frontend/backstage-plugin-argo-cd/package.json
@@ -76,7 +76,7 @@
     "io-ts": "^2.2.16",
     "io-ts-promise": "^2.0.2",
     "io-ts-reporters": "^1.2.2",
-    "moment": "^2.29.1",
+    "luxon": "^3.5.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
@@ -89,12 +89,12 @@
     "@backstage/cli": "^0.29.2",
     "@backstage/core-app-api": "^1.15.2",
     "@backstage/dev-utils": "^1.1.4",
+    "@backstage/frontend-test-utils": "^0.2.3",
     "@backstage/test-utils": "^1.7.2",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
-    "@backstage/frontend-test-utils": "^0.2.3",
     "esbuild": "^0.11.13",
     "jest-environment-jsdom": "^29.2.1",
     "msw": "^1.0.1",

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDDetailsCard.tsx
@@ -24,7 +24,7 @@ import {
   Button,
 } from '@material-ui/core';
 import { Entity } from '@backstage/catalog-model';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import {
   ARGOCD_ANNOTATION_APP_NAME,
   useArgoCDAppData,
@@ -90,7 +90,7 @@ const MessageComponent = ({
 };
 
 const getElapsedTime = (start: string) => {
-  return moment(start).fromNow();
+  return DateTime.fromISO(start).toRelative();
 };
 
 const getLastSyncState = (operationState: any) => {
@@ -230,12 +230,12 @@ const OverviewComponent = ({
           : '',
       customSort: (a: any, b: any) => {
         return (
-          moment(
+          DateTime.fromISO(
             a.status.operationState?.finishedAt || '3000-01-01T00:00:00.000Z',
-          ).valueOf() -
-          moment(
+          ).toMillis() -
+          DateTime.fromISO(
             b.status.operationState?.finishedAt || '3000-01-01T00:00:00.000Z',
-          ).valueOf()
+          ).toMillis()
         );
       },
     },

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryTable.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryTable.tsx
@@ -19,7 +19,7 @@ import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { Link, List, ListItem } from '@material-ui/core';
 import React from 'react';
 import SyncIcon from '@material-ui/icons/Sync';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import {
   ArgoCDAppDeployRevisionDetails,
   ArgoCDAppHistoryDetails,
@@ -90,24 +90,23 @@ export const ArgoCDHistoryTable = ({
         <List dense style={{ padding: '0px' }}>
           <ListItem style={{ paddingLeft: '0px' }}>
             {row.deployedAt
-              ? `Deployed at ${moment(row.deployedAt)
-                  .local()
-                  .format('DD MMM YYYY, H:mm:ss')}`
+              ? `Deployed at ${DateTime.fromISO(row.deployedAt)
+                  .toLocal()
+                  .toFormat('dd MMM yyyy, HH:mm:ss')}`
               : null}
           </ListItem>
           <ListItem style={{ paddingLeft: '0px' }}>
-            {row.deployedAt
-              ? `Run ${moment(row.deployStartedAt).local().fromNow()}`
+            {row.deployStartedAt
+              ? `Run ${DateTime.fromISO(row.deployStartedAt)
+                  .toLocal()
+                  .toRelative()}`
               : null}
           </ListItem>
           <ListItem style={{ paddingLeft: '0px' }}>
             {row.deployedAt && row.deployStartedAt
-              ? `Took
-            ${moment
-              .duration(
-                moment(row.deployStartedAt).diff(moment(row.deployedAt)),
-              )
-              .humanize()}`
+              ? `Took ${DateTime.fromISO(row.deployStartedAt)
+                  .diff(DateTime.fromISO(row.deployedAt))
+                  .toFormat('hh:mm:ss')}`
               : null}
           </ListItem>
         </List>

--- a/plugins/frontend/backstage-plugin-aws-lambda/package.json
+++ b/plugins/frontend/backstage-plugin-aws-lambda/package.json
@@ -53,7 +53,7 @@
     "aws-sdk": "^2.876.0",
     "cross-fetch": "^3.1.4",
     "history": "^5.0.0",
-    "moment": "^2.29.1",
+    "luxon": "^3.5.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/plugins/frontend/backstage-plugin-aws-lambda/src/components/AWSLambdaOverview/AWSLambdaOverview.tsx
+++ b/plugins/frontend/backstage-plugin-aws-lambda/src/components/AWSLambdaOverview/AWSLambdaOverview.tsx
@@ -166,7 +166,7 @@ const OverviewComponent = ({ lambda }: { lambda: LambdaData }) => {
           </AboutField>
           <AboutField
             label="Last modified"
-            value={getElapsedTime(lambda.lastModifiedDate!)}
+            value={getElapsedTime(lambda.lastModifiedDate!) ?? undefined}
             gridSizes={{ xs: 12, sm: 6, lg: 4 }}
           />
 

--- a/plugins/frontend/backstage-plugin-aws-lambda/src/components/AWSLambdaOverview/AWSLambdaOverview.tsx
+++ b/plugins/frontend/backstage-plugin-aws-lambda/src/components/AWSLambdaOverview/AWSLambdaOverview.tsx
@@ -29,7 +29,7 @@ import {
   Tooltip,
 } from '@material-ui/core';
 import { Entity } from '@backstage/catalog-model';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { useLambda } from '../../hooks/useLambda';
 import { LambdaData } from '../../types';
 import {
@@ -72,7 +72,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const getElapsedTime = (start: string) => {
-  return moment(start).fromNow();
+  return DateTime.fromISO(start).toRelative();
 };
 
 const AboutField = ({

--- a/plugins/frontend/backstage-plugin-bitbucket-pullrequest/package.json
+++ b/plugins/frontend/backstage-plugin-bitbucket-pullrequest/package.json
@@ -47,7 +47,7 @@
     "react-use": "^17.2.4",
     "@backstage/plugin-catalog-react": "^1.14.2",
     "@backstage/catalog-model": "^1.7.1",
-    "moment": "^2.29.1",
+    "luxon": "^3.0.0",
     "msw": "^1.0.1",
     "cross-fetch": "4.0.0"
   },

--- a/plugins/frontend/backstage-plugin-bitbucket-pullrequest/src/components/PullRequestList.tsx
+++ b/plugins/frontend/backstage-plugin-bitbucket-pullrequest/src/components/PullRequestList.tsx
@@ -22,7 +22,7 @@ import {
   MarkdownContent,
   Link,
 } from '@backstage/core-components';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { useApi } from '@backstage/core-plugin-api';
 import { Box } from '@material-ui/core';
 import { isBITBUCKETSlugSet } from '../utils/isBITBUCKETSlugSet';
@@ -54,7 +54,7 @@ const PullRequestList: React.FC = () => {
   }, [stateFilter, projectName, repoName, bitbucketApi]);
 
   const GetElapsedTime = ({ start }: { start: string }) =>
-    moment(start).fromNow();
+    DateTime.fromISO(start).toRelative();
   const RenderStateIcon = ({ status }: { status: string }) => {
     switch (status) {
       case 'OPEN':

--- a/plugins/frontend/backstage-plugin-buildkite/package.json
+++ b/plugins/frontend/backstage-plugin-buildkite/package.json
@@ -52,7 +52,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "4.0.0-alpha.57",
     "history": "^5.0.0",
-    "moment": "^2.29.1",
+    "luxon": "^3.0.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildView/components/ActionOutput.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildView/components/ActionOutput.tsx
@@ -65,7 +65,9 @@ export const ActionOutput: FC<{
   // eslint-disable-next-line no-nested-ternary
   const timeElapsed = job.finished_at
     ? Duration.fromMillis(
-        DateTime.fromISO(job.finished_at).diff(DateTime.fromISO(job.started_at)).toMillis()
+        DateTime.fromISO(job.finished_at)
+          .diff(DateTime.fromISO(job.started_at))
+          .toMillis(),
       ).toHuman()
     : job.started_at
     ? 'In Progress'

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildView/components/ActionOutput.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildView/components/ActionOutput.tsx
@@ -23,11 +23,12 @@ import {
   Typography,
   Box,
 } from '@material-ui/core';
+
+import { DateTime, Duration } from 'luxon';
 import { LogViewer } from '@backstage/core-components';
 import { makeStyles } from '@material-ui/core/styles';
 import Alert from '@material-ui/lab/Alert';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import moment from 'moment';
 import { useLog } from '../../useLog';
 import { generateRequestUrl } from '../../utils';
 
@@ -63,11 +64,9 @@ export const ActionOutput: FC<{
 
   // eslint-disable-next-line no-nested-ternary
   const timeElapsed = job.finished_at
-    ? moment
-        .duration(
-          moment(job.finished_at || moment()).diff(moment(job.started_at)),
-        )
-        .humanize()
+    ? Duration.fromMillis(
+        DateTime.fromISO(job.finished_at).diff(DateTime.fromISO(job.started_at)).toMillis()
+      ).toHuman()
     : job.started_at
     ? 'In Progress'
     : 'Pending';

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
@@ -22,7 +22,7 @@ import RetryIcon from '@material-ui/icons/Replay';
 import SyncIcon from '@material-ui/icons/Sync';
 import GitHubIcon from '@material-ui/icons/GitHub';
 import { Entity } from '@backstage/catalog-model';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { buildKiteBuildRouteRef } from '../../plugin';
 import { useBuilds } from '../useBuilds';
 import { useProjectEntity } from '../useProjectEntity';
@@ -30,7 +30,7 @@ import { BuildkiteStatus } from './components/BuildKiteRunStatus';
 import { BuildkiteBuildInfo, TableProps } from '../types';
 
 const getElapsedTime = (start: string) => {
-  return moment(start).fromNow();
+    return DateTime.fromISO(start).toRelative();
 };
 
 const generatedColumns = [

--- a/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
+++ b/plugins/frontend/backstage-plugin-buildkite/src/components/BuildKiteBuildsTable/BuildKiteBuildsTable.tsx
@@ -30,7 +30,7 @@ import { BuildkiteStatus } from './components/BuildKiteRunStatus';
 import { BuildkiteBuildInfo, TableProps } from '../types';
 
 const getElapsedTime = (start: string) => {
-    return DateTime.fromISO(start).toRelative();
+  return DateTime.fromISO(start).toRelative();
 };
 
 const generatedColumns = [

--- a/plugins/frontend/backstage-plugin-datadog/package.json
+++ b/plugins/frontend/backstage-plugin-datadog/package.json
@@ -66,7 +66,6 @@
     "@material-ui/lab": "4.0.0-alpha.57",
     "cross-fetch": "^3.1.4",
     "history": "^5.0.0",
-    "moment": "^2.29.1",
     "re-resizable": "^6.9.0",
     "react-use": "^17.2.4"
   },
@@ -82,14 +81,14 @@
     "@backstage/dev-utils": "^1.1.4",
     "@backstage/frontend-test-utils": "^0.2.3",
     "@backstage/test-utils": "^1.7.2",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-node-resolve": "^15.0.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "esbuild": "^0.11.13",
     "jest-environment-jsdom": "^29.2.1",
     "msw": "^1.0.1",
     "rollup-plugin-dts": "^5.2.0",
-    "@rollup/plugin-commonjs": "^24.0.1",
-    "@rollup/plugin-node-resolve": "^15.0.1",
     "rollup-plugin-esbuild": "^5.0.0"
   },
   "files": [

--- a/plugins/frontend/backstage-plugin-jira/package.json
+++ b/plugins/frontend/backstage-plugin-jira/package.json
@@ -58,7 +58,7 @@
     "history": "^5.0.0",
     "html-react-parser": "^0.14.1",
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
+    "luxon": "^3.0.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-use": "^17.2.4",

--- a/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
@@ -16,7 +16,7 @@
 
 import { useEffect, useCallback } from 'react';
 import convert from 'xml-js';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { v4 as uuidv4 } from 'uuid';
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsyncFn } from 'react-use';
@@ -32,7 +32,7 @@ const getPropertyValue = (
   entry: ActivityStreamEntry,
   property: ActivityStreamKeys,
 ): string => entry[property]?._text;
-const getElapsedTime = (start: string) => moment(start).fromNow();
+const getElapsedTime = (start: string) => DateTime.fromISO(start).toRelative();;
 const decodeHtml = (html: string) => {
   const txt = document.createElement('textarea');
   txt.innerHTML = html;

--- a/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
@@ -81,7 +81,7 @@ export const useActivityStream = (
           return {
             id: id,
             time: {
-              elapsed: getElapsedTime(time),
+              elapsed: getElapsedTime(time)!,
               value: new Date(time).toLocaleTimeString('en-US', {
                 weekday: 'long',
                 year: 'numeric',

--- a/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/hooks/useActivityStream.ts
@@ -32,7 +32,7 @@ const getPropertyValue = (
   entry: ActivityStreamEntry,
   property: ActivityStreamKeys,
 ): string => entry[property]?._text;
-const getElapsedTime = (start: string) => DateTime.fromISO(start).toRelative();;
+const getElapsedTime = (start: string) => DateTime.fromISO(start).toRelative();
 const decodeHtml = (html: string) => {
   const txt = document.createElement('textarea');
   txt.innerHTML = html;

--- a/plugins/frontend/backstage-plugin-security-insights/package.json
+++ b/plugins/frontend/backstage-plugin-security-insights/package.json
@@ -58,7 +58,6 @@
     "cross-fetch": "^3.1.4",
     "history": "^5.0.0",
     "luxon": "^3.0.0",
-    "moment": "^2.27.0",
     "react-minimal-pie-chart": "^8.2.0",
     "react-use": "^17.2.4"
   },

--- a/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
+++ b/plugins/frontend/backstage-plugin-security-insights/src/components/SecurityInsightsTable/SecurityInsightsTable.tsx
@@ -22,7 +22,7 @@ import { Progress, Table, TableColumn } from '@backstage/core-components';
 import Alert from '@material-ui/lab/Alert';
 import { Octokit } from '@octokit/rest';
 import { useAsync } from 'react-use';
-import moment from 'moment';
+import { DateTime } from 'luxon';
 import { useProjectName } from '../useProjectName';
 import { useProjectEntity } from '../useProjectEntity';
 import { UpdateSeverityStatusModal } from '../UpdateSeverityStatusModal';
@@ -33,7 +33,7 @@ import { SecurityInsight, SecurityInsightFilterState } from '../../types';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
 const getElapsedTime = (start: string) => {
-  return moment(start).fromNow();
+  return DateTime.fromISO(start).toRelative();
 };
 
 export const SecurityInsightsTable = () => {

--- a/plugins/frontend/backstage-plugin-travis-ci/package.json
+++ b/plugins/frontend/backstage-plugin-travis-ci/package.json
@@ -56,7 +56,6 @@
     "cross-fetch": "^3.1.3",
     "date-fns": "^2.18.0",
     "history": "^5.0.0",
-    "moment": "^2.29.1",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
@@ -66,18 +65,18 @@
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
-    "@backstage/core-app-api": "^1.15.2",
     "@backstage/cli": "^0.29.2",
+    "@backstage/core-app-api": "^1.15.2",
     "@backstage/dev-utils": "^1.1.4",
     "@backstage/test-utils": "^1.7.2",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-node-resolve": "^15.0.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
     "jest-environment-jsdom": "^29.2.1",
     "msw": "^1.0.1",
     "rollup-plugin-dts": "^5.2.0",
-    "@rollup/plugin-commonjs": "^24.0.1",
-    "@rollup/plugin-node-resolve": "^15.0.1",
     "rollup-plugin-esbuild": "^5.0.0"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16255,11 +16255,9 @@
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
-  integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
-  dependencies:
-    "@types/react" "*"
+  version "18.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
+  integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
 
 "@types/react-redux@^7.1.20":
   version "7.1.33"
@@ -16293,9 +16291,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
-  version "18.3.12"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
-  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
+  version "18.3.16"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.16.tgz#5326789125fac98b718d586ad157442ceb44ff28"
+  integrity sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -27480,7 +27478,7 @@ luxon@^3.0.0, luxon@^3.0.1, luxon@^3.4.3, luxon@~3.4.0:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.4.tgz#cf20dc27dc532ba41a169c43fdcc0063601577af"
   integrity sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==
 
-luxon@^3.2.1:
+luxon@^3.2.1, luxon@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
   integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
@@ -28656,11 +28654,6 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
-
-moment@^2.27.0, moment@^2.29.1:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moo@^0.5.0:
   version "0.5.2"


### PR DESCRIPTION
Hey :wave:


- Remove moment and replace it by luxon
- Also remove moment from some plugins that did not use it.

=> This should help reducing bundle sizes, as most packages already moved to luxon, following the [Backstage ADR010](https://backstage.io/docs/architecture-decisions/adrs-adr010)
Similar in scope to #922

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
