### PR TITLE
fix(backstage-plugin-argo-cd-backend): adding finalizer to allow deleting of application

### DIFF
--- a/.changeset/hip-files-sleep.md
+++ b/.changeset/hip-files-sleep.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-backend': patch
+---
+
+Adding the `resources-finalizer.argocd.argoproj.io` finalizer when creating a project. This allows the ability to delete the project first without getting stuck when deleting the application afterwards. This fix will allow the application to delete and not get stuck deleting.

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -306,6 +306,7 @@ export class ArgoService implements ArgoServiceApi {
       metadata: {
         name: projectName,
         resourceVersion,
+        finalizers: ['resources-finalizer.argocd.argoproj.io'],
       },
       spec: {
         destinations: [
@@ -350,6 +351,7 @@ export class ArgoService implements ArgoServiceApi {
       },
       body: JSON.stringify(data),
     };
+
     const resp = await fetch(`${baseUrl}/api/v1/projects`, options);
     const responseData = await resp.json();
     if (resp.status === 403) {

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.test.ts
@@ -342,6 +342,39 @@ describe('ArgoCD service', () => {
         },
       });
     });
+
+    it('creates project with resources-finalizer.argocd.argoproj.io finalizer', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          argocdCreateProjectResp,
+        }),
+      );
+      const service = new ArgoService(
+        'testusername',
+        'testpassword',
+        getConfig({
+          token: 'token',
+        }),
+        loggerMock,
+      );
+
+      await service.createArgoProject({
+        baseUrl: 'baseUrl',
+        argoToken: 'token',
+        projectName: 'projectName',
+        namespace: 'namespace',
+        sourceRepo: 'sourceRepo',
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: expect.stringContaining(
+            '{"metadata":{"name":"projectName","finalizers":["resources-finalizer.argocd.argoproj.io"]}',
+          ),
+        }),
+      );
+    });
   });
 
   describe('createArgoApplication', () => {

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/types.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/types.ts
@@ -287,6 +287,7 @@ export type Metadata = {
   deletionTimestamp?: string;
   deletionGracePeriodSeconds?: number;
   resourceVersion?: string;
+  finalizers?: string[];
 };
 
 export type ResourceItem = {


### PR DESCRIPTION
Adding the `resources-finalizer.argocd.argoproj.io` finalizer when creating a project. This allows the ability to delete the project first without getting stuck when deleting the application afterwards. This fix will allow the application to delete and not get stuck deleting.

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
