### PR TITLE
feat(catalog-backend-module-okta): export EntityTransformer types, including example factory usage

### DIFF
--- a/.changeset/20250115.md
+++ b/.changeset/20250115.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': minor
+---
+
+export EntityTransformer types, including example factory usage

--- a/plugins/backend/catalog-backend-module-okta/src/providers/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/index.ts
@@ -19,3 +19,7 @@ export { OktaUserEntityProvider } from './OktaUserEntityProvider';
 export { OktaOrgEntityProvider } from './OktaOrgEntityProvider';
 export * from './groupNamingStrategies';
 export * from './userNamingStrategies';
+export type {
+  OktaGroupEntityTransformer,
+  OktaUserEntityTransformer,
+} from './types';


### PR DESCRIPTION
Export types for OktaGroupEntityTransformer & OktaUserEntityTransformer, and show how they can be used to stack/modify other transformers.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes - N/A, functional change is two exports only
- [X] Added changeset (run `yarn changeset` in the root)
- [X] Screenshots of before and after attached (for UI changes) - N/A
- [X] Added or updated documentation (if applicable)
