### PR TITLE
feat(catalog-backend-module-okta): Align closer to new backend system

### DIFF
--- a/.changeset/rude-wasps-laugh.md
+++ b/.changeset/rude-wasps-laugh.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Align closer to new backend system provider by fixing scheduling race condition

--- a/plugins/backend/catalog-backend-module-okta/package.json
+++ b/plugins/backend/catalog-backend-module-okta/package.json
@@ -26,7 +26,7 @@
   },
   "backstage": {
     "role": "backend-plugin-module",
-    "pluginId": "catalog-backend-module-okta",
+    "pluginId": "catalog",
     "pluginPackage": "@backstage/plugin-catalog-backend"
   },
   "homepage": "https://roadie.io",

--- a/plugins/backend/catalog-backend-module-okta/src/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './providers';
+export { oktaCatalogBackendModule as default } from './module';

--- a/plugins/backend/catalog-backend-module-okta/src/module.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/module.ts
@@ -70,7 +70,8 @@ export const oktaCatalogBackendModule = createBackendModule({
         }
         userTransformer ??= userEntityFromOktaUser;
 
-        const oktaConfigs = config.getConfigArray('catalog.providers.okta');
+        const oktaConfigs =
+          config.getOptionalConfigArray('catalog.providers.okta') ?? [];
         for (const oktaConfig of oktaConfigs) {
           const provider = entityFactory(oktaConfig);
           catalog.addEntityProvider(provider);

--- a/plugins/backend/catalog-backend-module-okta/src/module.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/module.ts
@@ -73,18 +73,15 @@ export const oktaCatalogBackendModule = createBackendModule({
         const oktaConfigs =
           config.getOptionalConfigArray('catalog.providers.okta') ?? [];
         for (const oktaConfig of oktaConfigs) {
-          const provider = entityFactory(oktaConfig);
-          catalog.addEntityProvider(provider);
-          const schedule = readSchedulerServiceTaskScheduleDefinitionFromConfig(
-            oktaConfig.getConfig('schedule'),
+          const schedule = scheduler.createScheduledTaskRunner(
+            readSchedulerServiceTaskScheduleDefinitionFromConfig(
+              oktaConfig.getConfig('schedule'),
+            ),
           );
-          await scheduler.scheduleTask({
-            id: `okta-entity-provider-${provider.getProviderName()}`,
-            fn: async () => {
-              await provider.run();
-            },
-            ...schedule,
-          });
+
+          const provider = entityFactory(oktaConfig);
+          provider.schedule(schedule);
+          catalog.addEntityProvider(provider);
         }
       },
     });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -34,7 +34,10 @@ import { isError } from '@backstage/errors';
 import { getOktaGroups } from './getOktaGroups';
 import { getParentGroup } from './getParentGroup';
 import { OktaGroupEntityTransformer } from './types';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
 
 /**
  * Provides entities from Okta Group service.
@@ -64,6 +67,7 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
         parentKey: string;
         key?: string;
       };
+      schedule?: 'manual' | SchedulerServiceTaskRunner;
     },
   ) {
     const accountConfig = getAccountConfig(config);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -27,7 +27,10 @@ import { userEntityFromOktaUser as defaultUserEntityFromOktaUser } from './userE
 import { getAccountConfig } from './accountConfig';
 import { isError } from '@backstage/errors';
 import { OktaUserEntityTransformer } from './types';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  SchedulerServiceTaskRunner,
+} from '@backstage/backend-plugin-api';
 
 /**
  * Provides entities from Okta User service.
@@ -46,6 +49,7 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
       customAttributesToAnnotationAllowlist?: string[];
       namingStrategy?: UserNamingStrategies | UserNamingStrategy;
       userTransformer?: OktaUserEntityTransformer;
+      schedule?: 'manual' | SchedulerServiceTaskRunner;
     },
   ) {
     const accountConfig = getAccountConfig(config);


### PR DESCRIPTION
Hey 👋 

I've proposed some changes to align the Okta catalog provider closer to the new backend system's standards for providers. I appreciate there are a few changes in this PR, but hopefully can be reviewed by looking at the individual commits.

## Reason for changes
These changes have been made to allow for the Okta provider backend module to work with backend feature detection, removing the need for a user to add backend changes to use the module. Users will still need to provide their own modules for extending the `entityProviderFactory` and `UserTransformation`.

There are also some fixes in this PR, to align the behaviour of the module with the config schema declaration, and to fix an issue where the provider is scheduled before the catalog has finished initialising and a connection can be established.

## Changes
- [fix: Issue where scheduled provider can run before catalog connection can be established](https://github.com/RoadieHQ/roadie-backstage-plugins/commit/69cf821ada471e0d80189d697d05ccad3f3c5b77) 
- [fix: Check for optional okta config as per config schema](https://github.com/RoadieHQ/roadie-backstage-plugins/commit/9460a03e79e31300b2799468a29bfb2ca25e9814)
- [feat: Export oktaCatalogBackendModule as default to allow for backend feature discovery](https://github.com/RoadieHQ/roadie-backstage-plugins/commit/8faf5093474019f2a7d72e6b871c40e02daa1781)
- [fix: Package metadata pluginId to be catalog](https://github.com/RoadieHQ/roadie-backstage-plugins/commit/282d8c86922e7540b185e6bc78bc4b9edcec978b)

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
