### PR TITLE
remove backend-common package from rag-ai-storage-pgvector

### DIFF
--- a/.changeset/brave-needles-provide.md
+++ b/.changeset/brave-needles-provide.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-storage-pgvector': major
+---
+
+Remove `@roadiehq/backend-common`. The interface of `createRoadiePgVectorStore` now expects `DatabaseService` in place of `PluginDatabaseManager`.

--- a/plugins/backend/rag-ai-storage-pgvector/package.json
+++ b/plugins/backend/rag-ai-storage-pgvector/package.json
@@ -40,7 +40,6 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "^1.0.2",
     "@backstage/config": "^1.3.0",
     "@langchain/core": "^0.2.27",

--- a/plugins/backend/rag-ai-storage-pgvector/src/database/migrations.ts
+++ b/plugins/backend/rag-ai-storage-pgvector/src/database/migrations.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { resolvePackagePath } from '@backstage/backend-common';
+import { resolvePackagePath } from '@backstage/backend-plugin-api';
 import { Knex } from 'knex';
 
 export async function applyDatabaseMigrations(knex: Knex): Promise<void> {

--- a/plugins/backend/rag-ai-storage-pgvector/src/service/index.ts
+++ b/plugins/backend/rag-ai-storage-pgvector/src/service/index.ts
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PluginDatabaseManager } from '@backstage/backend-common';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import { LoggerService, DatabaseService } from '@backstage/backend-plugin-api';
 import { applyDatabaseMigrations } from '../database/migrations';
 
 import { RoadieVectorStore } from '@roadiehq/rag-ai-node';
@@ -23,7 +22,7 @@ import { Config } from '@backstage/config';
 
 export interface PgVectorStoreInitConfig {
   logger: LoggerService;
-  database: PluginDatabaseManager;
+  database: DatabaseService;
   config: Config;
 }
 


### PR DESCRIPTION
remove backend-common package from rag-ai-storage-pgvector

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
