### PR TITLE
Enable proxy authentication in backstage-plugin-prometheus

### DIFF
--- a/.changeset/nasty-melons-change.md
+++ b/.changeset/nasty-melons-change.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-prometheus': minor
+---
+
+Enable proxy authentication using Backstage fetch API

--- a/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
@@ -18,6 +18,7 @@ import {
   ConfigApi,
   createApiRef,
   DiscoveryApi,
+  FetchApi,
 } from '@backstage/core-plugin-api';
 import { DateTime, Duration } from 'luxon';
 
@@ -31,15 +32,18 @@ export const prometheusApiRef = createApiRef<PrometheusApi>({
 type Options = {
   discoveryApi: DiscoveryApi;
   configApi: ConfigApi;
+  fetchApi: FetchApi;
 };
 
 export class PrometheusApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly configApi: ConfigApi;
+  private readonly fetchApi: FetchApi;
 
   constructor(options: Options) {
     this.discoveryApi = options.discoveryApi;
     this.configApi = options.configApi;
+    this.fetchApi = options.fetchApi;
   }
 
   private async getApiUrl({ serviceName }: { serviceName?: string }) {
@@ -103,7 +107,7 @@ export class PrometheusApi {
 
     const end = DateTime.now().toSeconds();
     const start = DateTime.now().minus(Duration.fromObject(range)).toSeconds();
-    const response = await fetch(
+    const response = await this.fetchApi.fetch(
       `${apiUrl}/query_range?query=${query}&start=${start}&end=${end}&step=${step}`,
       {
         headers: {
@@ -121,7 +125,7 @@ export class PrometheusApi {
 
   async getAlerts({ serviceName }: { serviceName?: string }) {
     const apiUrl = await this.getApiUrl({ serviceName });
-    const response = await fetch(`${apiUrl}/rules?type=alert`, {
+    const response = await this.fetchApi.fetch(`${apiUrl}/rules?type=alert`, {
       headers: {
         [SERVICE_NAME_HEADER]: serviceName || '',
       },

--- a/plugins/frontend/backstage-plugin-prometheus/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createRoutableExtension,
   createRouteRef,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { PrometheusApi, prometheusApiRef } from './api';
 
@@ -33,9 +34,13 @@ export const backstagePluginPrometheusPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: prometheusApiRef,
-      deps: { discoveryApi: discoveryApiRef, configApi: configApiRef },
-      factory: ({ discoveryApi, configApi }) =>
-        new PrometheusApi({ discoveryApi, configApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, configApi, fetchApi }) =>
+        new PrometheusApi({ discoveryApi, configApi, fetchApi }),
     }),
   ],
   routes: {


### PR DESCRIPTION
Enable proxy authentication in backstage-plugin-prometheus using the Backstage fetch API.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [X] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
