### PR TITLE
feat: Add Prometheus plugin customisation support

### DIFF
--- a/.changeset/sharp-fans-talk.md
+++ b/.changeset/sharp-fans-talk.md
@@ -1,0 +1,14 @@
+---
+'@roadiehq/backstage-plugin-prometheus': major
+---
+
+Customisation improvements:
+
+- Add `extraColumns` prop to `EntityPrometheusAlertCard` & `EntityPrometheusContent`
+- Add `showAnnotations` prop to `EntityPrometheusAlertCard` & `EntityPrometheusContent`
+- Add `showLabels` prop to `EntityPrometheusAlertCard` & `EntityPrometheusContent`
+
+Fixes:
+
+- Fix #1823 to support multiple instances of Prometheus.
+- Move import of `MissingAnnotationEmptyState` to `@backstage/plugin-catalog-react` to clear deprecation warning.

--- a/plugins/frontend/backstage-plugin-prometheus/README.md
+++ b/plugins/frontend/backstage-plugin-prometheus/README.md
@@ -189,7 +189,7 @@ const extraColumns: TableColumn<PrometheusDisplayableAlert>[] = [
   {
     title: 'Description',
     field: 'annotations.description',
-  }
+  },
 ];
 ```
 

--- a/plugins/frontend/backstage-plugin-prometheus/README.md
+++ b/plugins/frontend/backstage-plugin-prometheus/README.md
@@ -96,6 +96,8 @@ const overviewContent = (
 
 ```
 
+See table customisation steps below for extra context of available customisation.
+
 ## Entity annotations
 
 The plugin uses entity annotations to determine what data to display. There are two different annotations that can be used:
@@ -170,7 +172,25 @@ Type definition for `PrometheusAlertStatus' props is:
 ```typescript
 {
   alerts: string[] | 'all';
+  extraColumns: TableColumn<PrometheusDisplayableAlert>[];
+  showAnnotations: boolean;
+  showLabels: boolean;
 }
+```
+
+example for extra alerts table columns:
+
+```typescript
+const extraColumns: TableColumn<PrometheusDisplayableAlert>[] = [
+  {
+    title: 'Summary',
+    field: 'annotations.summary',
+  },
+  {
+    title: 'Description',
+    field: 'annotations.description',
+  }
+];
 ```
 
 ## Multiple Prometheus instances

--- a/plugins/frontend/backstage-plugin-prometheus/config.d.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/config.d.ts
@@ -38,26 +38,24 @@ export interface Config {
      * Should be used if you have multiple Prometheus instances you like to proxy to.
      * @visibility frontend
      */
-    instances?: [
-      {
-        /**
-         * The proxy service instance name.
-         * Should match the annotation prometheus.io/service-name.
-         * @visibility frontend
-         */
-        name: string;
-        /**
-         * The proxy path for the service instance.
-         * Should match a Backstage proxy.
-         * @visibility frontend
-         */
-        proxyPath: string;
-        /**
-         * The URL for the Prometheus UI.
-         * @visibility frontend
-         */
-        uiUrl?: string;
-      },
-    ];
+    instances?: Array<{
+      /**
+       * The proxy service instance name.
+       * Should match the annotation prometheus.io/service-name.
+       * @visibility frontend
+       */
+      name: string;
+      /**
+       * The proxy path for the service instance.
+       * Should match a Backstage proxy.
+       * @visibility frontend
+       */
+      proxyPath: string;
+      /**
+       * The URL for the Prometheus UI.
+       * @visibility frontend
+       */
+      uiUrl?: string;
+    }>;
   };
 }

--- a/plugins/frontend/backstage-plugin-prometheus/package.json
+++ b/plugins/frontend/backstage-plugin-prometheus/package.json
@@ -40,7 +40,7 @@
     "diff": "backstage-cli plugin:diff",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "clean": "backstage-cli clean"
+    "clean": "backstage-cli package clean"
   },
   "dependencies": {
     "@backstage/catalog-model": "^1.7.1",

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertEntityWrapper.tsx
@@ -15,20 +15,27 @@
  */
 
 import React from 'react';
-import { MissingAnnotationEmptyState } from '@backstage/core-components';
+import { MissingAnnotationEmptyState } from '@backstage/plugin-catalog-react';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { TableColumn } from '@backstage/core-components';
 import {
   isPrometheusAlertAvailable,
   PROMETHEUS_ALERT_ANNOTATION,
   PROMETHEUS_PLUGIN_DOCUMENTATION,
 } from '../util';
 import { PrometheusAlertStatus } from './PrometheusAlertStatus';
-import { OnRowClick } from '../../types';
+import { OnRowClick, PrometheusDisplayableAlert } from '../../types';
 
 export const PrometheusAlertEntityWrapper = ({
+  extraColumns,
   onRowClick,
+  showAnnotations = true,
+  showLabels = true,
 }: {
+  extraColumns?: TableColumn<PrometheusDisplayableAlert>[];
   onRowClick?: OnRowClick;
+  showAnnotations?: boolean;
+  showLabels?: boolean;
 }) => {
   const { entity } = useEntity();
   const alertContent = isPrometheusAlertAvailable(entity);
@@ -45,8 +52,20 @@ export const PrometheusAlertEntityWrapper = ({
     : [];
 
   return alerts.length > 0 && alerts[0] === 'all' ? (
-    <PrometheusAlertStatus alerts="all" onRowClick={onRowClick} />
+    <PrometheusAlertStatus
+      alerts="all"
+      onRowClick={onRowClick}
+      extraColumns={extraColumns}
+      showAnnotations={showAnnotations}
+      showLabels={showLabels}
+    />
   ) : (
-    <PrometheusAlertStatus alerts={alerts} onRowClick={onRowClick} />
+    <PrometheusAlertStatus
+      alerts={alerts}
+      onRowClick={onRowClick}
+      extraColumns={extraColumns}
+      showAnnotations={showAnnotations}
+      showLabels={showLabels}
+    />
   );
 };

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
@@ -64,79 +64,98 @@ const state = (str: string) => {
   }
 };
 
-const columns: TableColumn<PrometheusDisplayableAlert>[] = [
-  {
-    field: 'name',
-    title: 'Name',
-    render: row => (
-      <Tooltip title={`${row.query}`}>
-        <p>{row.name}</p>
-      </Tooltip>
-    ),
-  },
-  { field: 'state', title: 'State', render: row => state(row.state) },
-  {
-    field: 'lastEvaluation',
-    title: 'Last Evaluation',
-    render: row =>
-      DateTime.fromISO(row.lastEvaluation).toLocaleString(
-        DateTime.DATETIME_SHORT_WITH_SECONDS,
-      ),
-  },
-  {
-    field: 'value',
-    title: 'Value',
-    render: row => {
-      const formatter = new Intl.NumberFormat('en', {
-        notation: 'compact',
-      });
-      // @ts-ignore
-      const shortVal = formatter.format(row.value);
-      return (
-        <Tooltip title={row.value}>
-          <p>{shortVal}</p>
+const getColumns = (
+  showAnnotations: boolean,
+  showLabels: boolean,
+): TableColumn<PrometheusDisplayableAlert>[] => {
+  const columns: TableColumn<PrometheusDisplayableAlert>[] = [
+    {
+      field: 'name',
+      title: 'Name',
+      render: row => (
+        <Tooltip title={`${row.query}`}>
+          <p>{row.name}</p>
         </Tooltip>
-      );
+      ),
     },
-  },
-  {
-    field: 'labels',
-    title: 'Labels',
-    render: row => (
-      <>
-        {Object.entries(row.labels).map(([k, v]) => (
-          <Chip key={k + v} label={`${k}: ${v}`} size="small" />
-        ))}
-      </>
-    ),
-  },
-  {
-    field: 'annotations',
-    title: 'Annotations',
-    render: row => (
-      <>
-        {Object.entries(row.annotations).map(([k, v]) => (
-          <Chip
-            key={k + v}
-            label={`${k}: ${v}`}
-            size="small"
-            classes={{
-              root: useStyles().chipRoot,
-              label: useStyles().chipLabel,
-            }}
-          />
-        ))}
-      </>
-    ),
-  },
-];
+    { field: 'state', title: 'State', render: row => state(row.state) },
+    {
+      field: 'lastEvaluation',
+      title: 'Last Evaluation',
+      render: row =>
+        DateTime.fromISO(row.lastEvaluation).toLocaleString(
+          DateTime.DATETIME_SHORT_WITH_SECONDS,
+        ),
+    },
+    {
+      field: 'value',
+      title: 'Value',
+      render: row => {
+        const formatter = new Intl.NumberFormat('en', {
+          notation: 'compact',
+        });
+        // @ts-ignore
+        const shortVal = formatter.format(row.value);
+        return (
+          <Tooltip title={row.value}>
+            <p>{shortVal}</p>
+          </Tooltip>
+        );
+      },
+    },
+  ];
+
+  if (showLabels) {
+    columns.push({
+      field: 'labels',
+      title: 'Labels',
+      render: row => (
+        <>
+          {Object.entries(row.labels).map(([k, v]) => (
+            <Chip key={k + v} label={`${k}: ${v}`} size="small" />
+          ))}
+        </>
+      ),
+    });
+  }
+
+  if (showAnnotations) {
+    columns.push({
+      field: 'annotations',
+      title: 'Annotations',
+      render: row => (
+        <>
+          {Object.entries(row.annotations).map(([k, v]) => (
+            <Chip
+              key={k + v}
+              label={`${k}: ${v}`}
+              size="small"
+              classes={{
+                root: useStyles().chipRoot,
+                label: useStyles().chipLabel,
+              }}
+            />
+          ))}
+        </>
+      ),
+    });
+  }
+
+  return columns;
+};
 
 export const PrometheusAlertStatus = ({
   alerts,
+  extraColumns,
   onRowClick,
+  showAnnotations = true,
+  showLabels = false,
 }: {
   alerts: string[] | 'all';
+  extraColumns?: TableColumn<PrometheusDisplayableAlert>[];
   onRowClick?: OnRowClick;
+  showAnnotations?: boolean;
+  showLabels?: boolean;
 }) => {
   const { error, loading, displayableAlerts, uiUrl } = useAlerts(alerts);
   if (loading) {
@@ -158,6 +177,8 @@ export const PrometheusAlertStatus = ({
     </Grid>
   );
 
+  const columns = getColumns(showAnnotations, showLabels);
+
   return (
     <div>
       <InfoCard title={title} noPadding>
@@ -171,7 +192,7 @@ export const PrometheusAlertStatus = ({
             onRowClick ? (_, rowData) => onRowClick(rowData!) : undefined
           }
           data={displayableAlerts}
-          columns={columns}
+          columns={extraColumns ? columns.concat(extraColumns) : columns}
         />
       </InfoCard>
     </div>

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusAlertStatus/PrometheusAlertStatus.tsx
@@ -149,7 +149,7 @@ export const PrometheusAlertStatus = ({
   extraColumns,
   onRowClick,
   showAnnotations = true,
-  showLabels = false,
+  showLabels = true,
 }: {
   alerts: string[] | 'all';
   extraColumns?: TableColumn<PrometheusDisplayableAlert>[];

--- a/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusContentWrapper.tsx
+++ b/plugins/frontend/backstage-plugin-prometheus/src/components/PrometheusContentWrapper.tsx
@@ -19,9 +19,10 @@ import { Grid } from '@material-ui/core';
 import {
   Content,
   ContentHeader,
-  MissingAnnotationEmptyState,
   SupportButton,
+  TableColumn,
 } from '@backstage/core-components';
+import { MissingAnnotationEmptyState } from '@backstage/plugin-catalog-react';
 import { PrometheusGraph } from './PrometheusGraph';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import {
@@ -32,15 +33,22 @@ import {
   PROMETHEUS_PLUGIN_DOCUMENTATION,
 } from './util';
 import { PrometheusAlertStatus } from './PrometheusAlertStatus';
+import { PrometheusDisplayableAlert } from '../types';
 
 const PrometheusContentWrapper = ({
   step = 14,
   range = { hours: 1 },
   graphType,
+  extraColumns,
+  showAlertsAnnotations,
+  showAlertsLabels,
 }: {
   step?: number;
   range?: { hours?: number; minutes?: number };
   graphType?: 'line' | 'area';
+  extraColumns?: TableColumn<PrometheusDisplayableAlert>[];
+  showAlertsAnnotations?: boolean;
+  showAlertsLabels?: boolean;
 }) => {
   const { entity } = useEntity();
   const graphContent = isPrometheusGraphAvailable(entity);
@@ -74,7 +82,12 @@ const PrometheusContentWrapper = ({
       {alertContent && (
         <Grid container spacing={3} direction="column">
           <Grid item>
-            <PrometheusAlertStatus alerts={alertProp} />
+            <PrometheusAlertStatus
+              alerts={alertProp}
+              extraColumns={extraColumns}
+              showAnnotations={showAlertsAnnotations}
+              showLabels={showAlertsLabels}
+            />
           </Grid>
         </Grid>
       )}

--- a/plugins/frontend/backstage-plugin-prometheus/src/index.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/index.ts
@@ -23,3 +23,4 @@ export {
 export { PrometheusGraph } from './components/PrometheusGraph';
 export { PrometheusAlertStatus } from './components/PrometheusAlertStatus';
 export { isPrometheusAvailable } from './conditions';
+export type { PrometheusDisplayableAlert } from './types';

--- a/plugins/frontend/backstage-plugin-prometheus/src/types.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/types.ts
@@ -56,9 +56,13 @@ type PrometheusRule = {
   alerts: PrometheusAlert[];
 };
 
+interface PrometheusAnnotations {
+  [key: string]: string;
+}
+
 type PrometheusAlert = {
   activeAt: string;
-  annotations: {};
+  annotations: PrometheusAnnotations;
   labels: {
     alertname: string;
   };


### PR DESCRIPTION
<!-- Please describe what these changes achieve -->

Add support for customisation in the `backstage-plugin-prometheus` plugin by allowing the possibility of specifying additional table columns to be rendered as well as to optionally hide the `annotations` & `labels` columns.

Fix issue reported in #1823 to allow multiple instances of Prometheus to be defined.

Example of customisations in effect:
```typescript
import {
  EntityPrometheusContent,
  PrometheusDisplayableAlert,
} from '@roadiehq/backstage-plugin-prometheus';

const extraColumns: TableColumn<PrometheusDisplayableAlert>[] = [
  {
    title: 'Summary',
    field: 'annotations.summary',
  },
  {
    title: 'Description',
    field: 'annotations.description',
  }
];

...
    <EntityLayout.Route path="/prometheus" title="Prometheus">
      <EntityPrometheusContent
        showAlertsAnnotations={false}
        showAlertsLabels={false}
        extraColumns={extraColumns}
      />
    </EntityLayout.Route>
...
```


#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
