### PR TITLE
fix(github-pull-requests): allow to use GHE instance

### DIFF
--- a/.changeset/nasty-turkeys-destroy.md
+++ b/.changeset/nasty-turkeys-destroy.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Allow to pass the `hostname` props on `HomePageRequestedReviewsCard` and `HomePageYourOpenPullRequestsCard` when using GitHub Enterprise instances.

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/GroupPullRequestsCard/Content.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/GroupPullRequestsCard/Content.test.tsx
@@ -42,7 +42,12 @@ const mockScmAuth = {
 
 const config = {
   getOptionalConfigArray(_: string) {
-    return [{ getOptionalString: (_s: string) => undefined }];
+    return [
+      {
+        getOptionalString: (_s: string) => undefined,
+        getOptionalConfigArray: (_s: string) => undefined,
+      },
+    ];
   },
 } as ConfigApi;
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.test.tsx
@@ -39,7 +39,12 @@ const mockScmAuth = {
 
 const config = {
   getOptionalConfigArray(_: string) {
-    return [{ getOptionalString: (_s: string) => undefined }];
+    return [
+      {
+        getOptionalString: (_s: string) => undefined,
+        getOptionalConfigArray: (_s: string) => undefined,
+      },
+    ];
   },
 } as ConfigApi;
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/RequestedReviewsCard/Content.tsx
@@ -25,13 +25,14 @@ import { GitHubAuthorizationWrapper } from '@roadiehq/github-auth-utils-react';
 
 type RequestedReviewsCardProps = {
   query?: string;
+  hostname?: string;
 };
 
 const defaultReviewsQuery = 'is:open is:pr review-requested:@me archived:false';
 
 const RequestedReviewsContent = (props: RequestedReviewsCardProps) => {
-  const { query = defaultReviewsQuery } = props;
-  const { loading, error, value } = useGithubSearchPullRequest(query);
+  const { query = defaultReviewsQuery, hostname } = props;
+  const { loading, error, value } = useGithubSearchPullRequest(query, hostname);
 
   if (loading) return <SkeletonPullRequestsListView />;
   if (error) return <Alert severity="error">{error.message}</Alert>;
@@ -42,7 +43,10 @@ const RequestedReviewsContent = (props: RequestedReviewsCardProps) => {
 };
 export const Content = (props: RequestedReviewsCardProps) => {
   return (
-    <GitHubAuthorizationWrapper title="Pull Requests List">
+    <GitHubAuthorizationWrapper
+      title="Pull Requests List"
+      hostname={props.hostname}
+    >
       <RequestedReviewsContent {...props} />
     </GitHubAuthorizationWrapper>
   );

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.test.tsx
@@ -39,7 +39,12 @@ const mockScmAuth = {
 
 const config = {
   getOptionalConfigArray(_: string) {
-    return [{ getOptionalString: (_s: string) => undefined }];
+    return [
+      {
+        getOptionalString: (_s: string) => undefined,
+        getOptionalConfigArray: (_s: string) => undefined,
+      },
+    ];
   },
 } as ConfigApi;
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/Home/YourOpenPullRequestsCard/Content.tsx
@@ -25,13 +25,14 @@ import { GitHubAuthorizationWrapper } from '@roadiehq/github-auth-utils-react';
 
 type OpenPullRequestsCardProps = {
   query?: string;
+  hostname?: string;
 };
 
 const defaultPullRequestsQuery = 'is:open is:pr author:@me archived:false';
 
 const OpenPullRequestsContent = (props: OpenPullRequestsCardProps) => {
-  const { query = defaultPullRequestsQuery } = props;
-  const { loading, error, value } = useGithubSearchPullRequest(query);
+  const { query = defaultPullRequestsQuery, hostname } = props;
+  const { loading, error, value } = useGithubSearchPullRequest(query, hostname);
 
   if (loading) return <SkeletonPullRequestsListView />;
   if (error) return <Alert severity="error">{error.message}</Alert>;
@@ -46,7 +47,10 @@ const OpenPullRequestsContent = (props: OpenPullRequestsCardProps) => {
 
 export const Content = (props: OpenPullRequestsCardProps) => {
   return (
-    <GitHubAuthorizationWrapper title="Your Pull Requests">
+    <GitHubAuthorizationWrapper
+      title="Your Pull Requests"
+      hostname={props.hostname}
+    >
       <OpenPullRequestsContent {...props} />
     </GitHubAuthorizationWrapper>
   );

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsListView/PullRequestListView.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsListView/PullRequestListView.test.tsx
@@ -36,7 +36,12 @@ const mockScmAuth = {
 
 const config = {
   getOptionalConfigArray(_: string) {
-    return [{ getOptionalString: (_s: string) => undefined }];
+    return [
+      {
+        getOptionalString: (_s: string) => undefined,
+        getOptionalConfigArray: (_s: string) => undefined,
+      },
+    ];
   },
 } as ConfigApi;
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
@@ -38,7 +38,12 @@ const mockScmAuth = {
 
 const config = {
   getOptionalConfigArray(_: string) {
-    return [{ getOptionalString: (_s: string) => undefined }];
+    return [
+      {
+        getOptionalString: (_s: string) => undefined,
+        getOptionalConfigArray: (_s: string) => undefined,
+      },
+    ];
   },
 } as ConfigApi;
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsTable/PullRequestsTable.test.tsx
@@ -38,7 +38,12 @@ const mockScmAuth = {
 
 const config = {
   getOptionalConfigArray(_: string) {
-    return [{ getOptionalString: (_s: string) => undefined }];
+    return [
+      {
+        getOptionalString: (_s: string) => undefined,
+        getOptionalConfigArray: (_s: string) => undefined,
+      },
+    ];
   },
 } as ConfigApi;
 

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/plugin.ts
@@ -79,7 +79,7 @@ export const EntityGithubPullRequestsTable = githubPullRequestsPlugin.provide(
 );
 
 export const HomePageRequestedReviewsCard = githubPullRequestsPlugin.provide(
-  createCardExtension<{ query?: string }>({
+  createCardExtension<{ query?: string; hostname?: string }>({
     name: 'HomePageRequestedReviewsCard',
     title: 'Review requests',
     components: () => import('./components/Home/RequestedReviewsCard'),
@@ -88,7 +88,7 @@ export const HomePageRequestedReviewsCard = githubPullRequestsPlugin.provide(
 
 export const HomePageYourOpenPullRequestsCard =
   githubPullRequestsPlugin.provide(
-    createCardExtension<{ query?: string }>({
+    createCardExtension<{ query?: string; hostname?: string }>({
       name: 'YourOpenPullRequestsCard',
       title: 'Your open pull requests',
       components: () => import('./components/Home/YourOpenPullRequestsCard'),


### PR DESCRIPTION
Fixes #1810 (partially, this focuses on the PR plugin, not sure about the Insights plugin) which is currently blocking upgrades.

The `hostname` prop can now be passed on `HomePageRequestedReviewsCard` and `HomePageYourOpenPullRequestsCard` to support GHE instances.

In `useGithubRepositoryData` hook, the logic didn't work for GHE. The repository URL passed to the hook starts with the API base URL:
- In GHE, the API base URL looks like `https://github.company.com/api/v3/`
- In github.com the API base URL is `https://api.github.com/...`

I changed the logic to try to find a GHE URL. If nothing is found, it will be undefined, which will use github.com anyway.

Note: I had some trouble setting up the GHE auth alongside github.com to test my changes, so feel free to test it 👍 

#### :heavy_check_mark: Checklist

- [X] ~Added tests for new functionality and regression tests for bug fixes~
- [X] Added changeset (run `yarn changeset` in the root)
- [X] ~Screenshots of before and after attached (for UI changes)~
- [X] ~Added or updated documentation (if applicable)~
