### PR TITLE
fix(catalog-backend-module-okta): chunk membership resolution queries to avoid socket overloading

### DIFF
--- a/.changeset/giant-maps-camp.md
+++ b/.changeset/giant-maps-camp.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Apply chunking of membership resolution to OktaGroupEntityProvider

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -344,6 +344,20 @@ const factory: EntityProviderFactory = (oktaConfig: Config) =>
   });
 ```
 
+#### Membership Resolution Parallelism
+
+By default, Group membership will attempt to be resolved 250 groups at a time. If you would like to increase or decrease this parallelism, provide a new value for `chunkSize`:
+
+```typescript
+const factory: EntityProviderFactory = (oktaConfig: Config) =>
+  OktaOrgEntityProvider.fromConfig(oktaConfig, {
+    logger: logger,
+    userNamingStrategy: 'strip-domain-email',
+    groupNamingStrategy: 'kebab-case-name',
+    chunkSize: 100,
+  });
+```
+
 #### Legacy backend
 
 <details>

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -39,6 +39,8 @@ import { OktaGroupEntityTransformer, OktaUserEntityTransformer } from './types';
 import chunk from 'lodash/chunk';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
+const DEFAULT_CHUNK_SIZE = 250;
+
 /**
  * Provides entities from Okta Org service.
  */
@@ -117,7 +119,7 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
     this.hierarchyConfig = options.hierarchyConfig;
     this.customAttributesToAnnotationAllowlist =
       options.customAttributesToAnnotationAllowlist || [];
-    this.chunkSize = options.chunkSize || 250;
+    this.chunkSize = options.chunkSize || DEFAULT_CHUNK_SIZE;
   }
 
   getProviderName(): string {


### PR DESCRIPTION
Recently, we expanded our usage of the `OktaGroupEntityProvider` to pull in more Groups than we typically had in the past (>1000).

We started noticing that every run of the provider would produce different results and that Groups were disappearing on subsequent runs. After some local investigation and debugging, we found that many of the `listUsers()` queries were silently failing and thus skipping that group entirely for ingestion.

For us, the underlying root cause was `ERR_SOCKET_TIMEOUT` since we were kicking off >1000 async requests to Okta to resolve membership. This is resolved by adding chunking to membership resolution to limit how many async processes we have in flight at once.

Implementing this change and testing it locally showed minimum to no difference in timing to resolve all membership for 1000+ groups, likely due to lack of socket contention meaning things were resolving faster and/or automated rate limit handling happening internally to the Okta package not needing to take effect.

This is an extension of https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1280 which was only applied to `OktaOrgEntityProvider`

We separately schedule the User and Group providers to avoid hammering Okta and to reduce risk.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes): **N/A**
- [x] Added or updated documentation (if applicable)
