### PR TITLE
chore: allow using WizClient outside the plugin

### DIFF
--- a/.changeset/silver-walls-itch.md
+++ b/.changeset/silver-walls-itch.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/plugin-wiz-backend': minor
+---
+
+Allow using WizClient outside the plugin.

--- a/plugins/backend/wiz-backend/src/service/index.ts
+++ b/plugins/backend/wiz-backend/src/service/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './service';
-export { wizBackendPlugin as default } from './plugin';
+export * from './WizClient';
+export * from './router';


### PR DESCRIPTION
In our company, we want to create a processor that will automatically populate the `wiz.io/project-id` annotation based on the project name. We have a name mapping consistency between Backstage and Wiz, so we can retrieve the correct ID using WizClient. 

Instead of duplicating the authentication logic for the API, we prefer to leverage the existing implementation already available in this plugin. The only change needed is exporting the `WizClient` class so it can be used externally.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
