### PR TITLE
#1892: @backstage/plugin-jira: using new jira rest search api (search jql)

### DIFF
--- a/.changeset/swift-files-remember.md
+++ b/.changeset/swift-files-remember.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-jira': minor
+---
+
+#1892 switch to search jql api

--- a/packages/app/cypress/integration/jira.ts
+++ b/packages/app/cypress/integration/jira.ts
@@ -27,7 +27,7 @@ describe('Jira plugin', () => {
     ).as('getProject');
     cy.intercept(
       'POST',
-      'http://localhost:7007/api/proxy/jira/api/rest/api/latest/search',
+      'http://localhost:7007/api/proxy/jira/api/rest/api/latest/search/jql',
       { fixture: 'jira/searchresult.json' },
     ).as('postSearchResult');
 
@@ -64,7 +64,7 @@ describe('Jira plugin', () => {
       cy.visit('/catalog/default/component/sample-service/jira');
       cy.intercept(
         'POST',
-        'http://localhost:7007/api/proxy/jira/api/rest/api/latest/search',
+        'http://localhost:7007/api/proxy/jira/api/rest/api/latest/search/jql',
         { fixture: 'jira/jqlQueryResult.json' },
       ).as('queryResult');
       cy.wait('@queryResult');

--- a/plugins/frontend/backstage-plugin-jira/src/components/Home/MyJiraTicketsCard/Content.test.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/Home/MyJiraTicketsCard/Content.test.tsx
@@ -34,7 +34,7 @@ describe('MyJiraTicketsCard', () => {
   it('should display error in displaying tickets', async () => {
     worker.use(
       rest.post(
-        'http://exampleapi.com/jira/api/rest/api/latest/search',
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
         (_, res, ctx) => res(ctx.json(searchResponseStub)),
       ),
       rest.get(
@@ -70,11 +70,10 @@ describe('MyJiraTicketsCard', () => {
   it('should display no tickets found', async () => {
     worker.use(
       rest.post(
-        'http://exampleapi.com/jira/api/rest/api/latest/search',
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
         (_, res, ctx) =>
           res(
             ctx.json({
-              startAt: 0,
               maxResults: 50,
               total: 0,
               issues: [],
@@ -112,7 +111,7 @@ describe('MyJiraTicketsCard', () => {
   it('should display found tickets', async () => {
     worker.use(
       rest.post(
-        'http://exampleapi.com/jira/api/rest/api/latest/search',
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
         (_, res, ctx) => res(ctx.json(searchResponseStub)),
       ),
       rest.get(

--- a/plugins/frontend/backstage-plugin-jira/src/components/JiraOverviewCard/JiraCard.test.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/JiraOverviewCard/JiraCard.test.tsx
@@ -60,7 +60,7 @@ describe('JiraCard', () => {
         (_, res, ctx) => res(ctx.json(projectResponseStub)),
       ),
       rest.post(
-        'http://exampleapi.com/jira/api/rest/api/latest/search',
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
         (_, res, ctx) => res(ctx.json(searchResponseStub)),
       ),
       rest.get(
@@ -106,7 +106,7 @@ describe('JiraCard', () => {
         (_, res, ctx) => res(ctx.json(projectResponseStub)),
       ),
       rest.post(
-        'http://exampleapi.com/jira/api/rest/api/latest/search',
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
         (_, res, ctx) => res(ctx.json(searchResponseStub)),
       ),
       rest.get(
@@ -152,7 +152,7 @@ describe('JiraCard', () => {
         (_, res, ctx) => res(ctx.status(403)),
       ),
       rest.post(
-        'http://exampleapi.com/jira/api/rest/api/latest/search',
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
         (_, res, ctx) => res(ctx.status(403)),
       ),
       rest.get(

--- a/plugins/frontend/backstage-plugin-jira/src/responseStubs.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/responseStubs.ts
@@ -149,7 +149,6 @@ export const projectResponseStub = {
 };
 
 export const searchResponseStub = {
-  startAt: 0,
   maxResults: 50,
   total: 1,
   issues: [

--- a/plugins/frontend/backstage-plugin-jira/src/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/types.ts
@@ -119,7 +119,7 @@ export type Status = {
 };
 
 export type IssuesResponse = {
-  startAt: number;
+  nextPageToken: string;
   maxResults: number;
   total: number;
   issues: Ticket[];
@@ -193,7 +193,7 @@ export type User = {
 };
 
 export type IssuesResult = {
-  next: number | undefined;
+  nextPageToken: string | undefined;
   issues: Ticket[];
 };
 


### PR DESCRIPTION
Switch to [search jql](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post) api, since May 1st,2025 old one gets shut off ... 

#### :heavy_check_mark: Checklist

- [x] **Updated** tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] ~Screenshots of before and after attached (for UI changes)~ - Not applicable
- [ ] ~Added or updated documentation (if applicable)~ - Not applicable
