### PR TITLE
feat: add writeMulti option for yaml

### DIFF
--- a/.changeset/plenty-games-exist.md
+++ b/.changeset/plenty-games-exist.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-utils': minor
+---
+
+add writeMulti option for yaml

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/jsonata/yaml.test.ts
@@ -171,4 +171,28 @@ describe('roadiehq:utils:jsonata:yaml:transform', () => {
       hello: ['world'],
     });
   });
+
+  it('should be able to write back multi yaml', async () => {
+    mock({
+      'fake-tmp-dir': {
+        'fake-file.yaml': '---\nhello: [world]\n---\nfoo: [bar]',
+      },
+    });
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        path: 'fake-file.yaml',
+        expression: '$',
+        loadAll: true,
+        writeMulti: true,
+        as: 'string',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'result',
+      `hello:\n  - world\n---\nfoo:\n  - bar\n`,
+    );
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/src/actions/serialize/yaml.test.ts
@@ -69,6 +69,37 @@ describe('roadiehq:utils:serialize:yaml', () => {
     );
   });
 
+  it('should write file to the workspacePath with multidoc content', async () => {
+    await action.handler({
+      ...mockContext,
+      workspacePath: 'fake-tmp-dir',
+      input: {
+        data: [{ hello: 'world' }, { are: 'you there?' }],
+        writeMulti: true,
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'serialized',
+      `hello: world\n---\nare: you there?\n`,
+    );
+  });
+
+  it('should error when input is not suitable for multidoc', async () => {
+    await expect(
+      action.handler({
+        ...mockContext,
+        workspacePath: 'fake-tmp-dir',
+        input: {
+          data: { hello: 'world' },
+          writeMulti: true,
+        },
+      }),
+    ).rejects.toThrow(
+      'input is not an array, cannot be stringified as multidoc yaml',
+    );
+  });
+
   it('should pass options to YAML.stringify', async () => {
     const opts = {
       indent: 3,


### PR DESCRIPTION
YAML util actions could [load multidoc YAML](https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1225#issuecomment-2775456965) (with `loadAll`) but not write it yet. Added an option `writeMulti` to write an array as multidoc (`---`) YAML.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
