### PR TITLE
Validate trailing slash for `source-location`

### DIFF
--- a/utils/roadie-backstage-entity-validator/package.json
+++ b/utils/roadie-backstage-entity-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/roadie-backstage-entity-validator",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "author": "RoadieHQ",
   "description": "Backstage entity validator library",
   "main": "src/index.js",

--- a/utils/roadie-backstage-entity-validator/src/schemas/annotations.schema.json
+++ b/utils/roadie-backstage-entity-validator/src/schemas/annotations.schema.json
@@ -47,7 +47,7 @@
               "properties": {
                 "backstage.io/source-location": {
                   "type": "string",
-                  "pattern": "((url|gitlab|github|azure/api):.*|(dir):.*/)$"
+                  "pattern": "((url|gitlab|github|azure/api):.*/|(dir):.*/)$"
                 }
               }
             },


### PR DESCRIPTION
This can break techdocs builds if not present with a 404. Mentioned in the spec here https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
