### PR TITLE
Fix ArgoCD plugin throwing errors in NFS

### DIFF
--- a/.changeset/nine-doors-repeat.md
+++ b/.changeset/nine-doors-repeat.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': patch
+---
+
+Fixing crashing when using the `argocd` plugin with the new frontend system. The wrong Blueprint type was used, as this should be a tab used within context of an Entity.

--- a/plugins/frontend/backstage-plugin-argo-cd/src/alpha/pages.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/alpha/pages.tsx
@@ -1,6 +1,6 @@
 import React from 'react'; // Add this line to import React
 
-import { PageBlueprint } from '@backstage/frontend-plugin-api';
+import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
 import {
   compatWrapper,
   convertLegacyRouteRef,
@@ -10,10 +10,11 @@ import { entityContentRouteRef } from '../plugin';
 /**
  * @alpha
  */
-export const argoCdPage = PageBlueprint.make({
+export const argoCdPage = EntityContentBlueprint.make({
   name: 'ArgoCdPage',
   params: {
-    defaultPath: '/',
+    defaultPath: '/argocd',
+    defaultTitle: 'ArgoCD',
     // you can reuse the existing routeRef
     // by wrapping into the convertLegacyRouteRef.
     routeRef: convertLegacyRouteRef(entityContentRouteRef),


### PR DESCRIPTION
The `argocd` plugin uses the wrong Blueprint in the new frontend system throwing errors because the `argoCdPage` is actually an `EntityContent` tab instead and expects an `EntityContext` to be available.

This fixes that by moving this to be an `EntityContentBlueprint` instead.