### PR TITLE
fix(wiz): corrected url in frontend plugin to the correct backend plugin

### DIFF
--- a/.changeset/old-teachers-sniff.md
+++ b/.changeset/old-teachers-sniff.md
@@ -1,0 +1,35 @@
+---
+'@roadiehq/plugin-wiz-backend': major
+---
+
+**BREAKING** Fixed an issue with backend plugin initialisation approach which required additional configuration for the end user.
+
+This fix allows plugin consumers to add the backend plugin using the new backend system, unfortunately, this breaks existing approaches as plugin consumers will have customised the backend plugin to respond on the incorrect URL.
+
+These changes are **required** to `packages/backend/src/index.ts`
+
+```diff
++ // Install wiz backend plugin
++ backend.add(import('@roadiehq/plugin-wiz-backend'));
+- import wiz from './plugins/wiz';
+- // ...
+- async function main() {
+-   // ...
+-   const wizEnv = useHotMemoize(module, () => createEnv('wiz'));
+-
+-   const wizConfig = {
+-   clientId: config.getOptionalString('wiz.clientId'),
+-   clientSecret: config.getOptionalString('wiz.clientSecret'),
+-   tokenUrl: config.getOptionalString('wiz.tokenUrl'),
+-   apiUrl: config.getOptionalString('wiz.wizAPIUrl'),
+- };
+-
+-   const apiRouter = Router();
+-     if (wizConfig.enabled && wizConfig.clientId && wizConfig.clientSecret && wizConfig.tokenUrl && wizConfig.apiUrl) {
+-     router.use('/wiz-backend', await wiz(wizEnv));
+-   } await wiz(wizEnv));
+-   // ...
+- }
+```
+
+And you can remove the previous plugin customisation file `packages/backend/src/plugins/wiz.ts`

--- a/plugins/backend/wiz-backend/README.md
+++ b/plugins/backend/wiz-backend/README.md
@@ -30,6 +30,23 @@ wiz:
   dashboardLink: <your-wiz-url>
 ```
 
+### Using the new backend plugin system
+
+**_Note: This approach requires v2 of the wiz-backend plugin_**
+
+Edit your `backend/src/index.ts` file, and add the following lines alongside the rest of your plugins
+
+```typescript
+// Install wiz backend plugin
+backend.add(import('@roadiehq/plugin-wiz-backend'));
+```
+
+If you have previously used v1 of this plugin, you can remove the files / code mentioned below as it's no longer needed.
+
+### Using the legacy plugin system
+
+This approach is compatible with the v1 versions of the wiz-backend plugin.
+
 Create a file in `packages/backend/src/plugins/wiz.ts`
 
 ```typescript

--- a/plugins/backend/wiz-backend/package.json
+++ b/plugins/backend/wiz-backend/package.json
@@ -11,7 +11,7 @@
   },
   "backstage": {
     "role": "backend-plugin",
-    "pluginId": "plugin-wiz-backend",
+    "pluginId": "wiz-backend",
     "pluginPackages": [
       "@roadiehq/plugin-wiz-backend"
     ]

--- a/plugins/backend/wiz-backend/src/plugin.ts
+++ b/plugins/backend/wiz-backend/src/plugin.ts
@@ -25,7 +25,7 @@ import { createRouter } from './service/router';
  * @public
  */
 export const wizBackendPlugin = createBackendPlugin({
-  pluginId: 'plugin-wiz-backend',
+  pluginId: 'wiz-backend',
   register(env) {
     env.registerInit({
       deps: {


### PR DESCRIPTION
This change allows wiz plugin consumers to add the backend plugin using the new Backstage plugin system, and removes the need for additional customisation or additional development effort.

It could be achieved by changing the backend component's plugin ID but I wasn't sure if there were other instances referencing this plugin, hence the simpler change to the frontend plugin to change the URL being called by the API client.

Existing tests pass, mainly a documentation change.

Marked the change as breaking because if people have customised the backend plugin, their integration won't work with the new frontend plugin anymore.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
