### PR TITLE
Add validator overrides

### DIFF
--- a/.changeset/orange-kids-train.md
+++ b/.changeset/orange-kids-train.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/roadie-backstage-entity-validator': minor
+---
+
+Loosen validation restrictions on tags, label values and name fields

--- a/utils/roadie-backstage-entity-validator/src/validator.js
+++ b/utils/roadie-backstage-entity-validator/src/validator.js
@@ -15,6 +15,7 @@ import {
   domainEntityV1alpha1Validator,
   resourceEntityV1alpha1Validator,
   entityKindSchemaValidator,
+  makeValidator,
 } from '@backstage/catalog-model';
 import { templateEntityV1beta3Validator } from '@backstage/plugin-scaffolder-common';
 import annotationSchema from './schemas/annotations.schema.json';
@@ -73,6 +74,26 @@ export const validate = async (
   customAnnotationSchemaLocation = '',
 ) => {
   let validator;
+
+  const overrides = {
+    isValidEntityName(value) {
+      return (
+        typeof value === 'string' &&
+        value.length >= 1 &&
+        value.length <= 120 &&
+        /^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/.test(value)
+      );
+    },
+    isValidLabelValue(value) {
+      return typeof value === 'string';
+    },
+    isValidTag(value) {
+      return (
+        typeof value === 'string' && value.length >= 1 && value.length <= 63
+      );
+    },
+  };
+
   const validateAnnotations = (entity, idx) => {
     if (!validator) {
       if (customAnnotationSchemaLocation) {
@@ -118,7 +139,7 @@ export const validate = async (
     });
     const entityPolicies = EntityPolicies.allOf([
       new DefaultNamespaceEntityPolicy(),
-      new FieldFormatEntityPolicy(),
+      new FieldFormatEntityPolicy(makeValidator(overrides)),
       new NoForeignRootFieldsEntityPolicy(),
       new SchemaValidEntityPolicy(),
     ]);


### PR DESCRIPTION
Make entity validation rules consistent with Roadie rules by loosening some restrictions. 

- Tags can be any string less that 64 chars
- Label values can be any string
- names can be up to 120 chars 

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
