### PR TITLE
add ability to template aws entities

### DIFF
--- a/.changeset/quick-elephants-know.md
+++ b/.changeset/quick-elephants-know.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-aws': minor
+---
+
+Adds ability to template entity from eks entity provider.

--- a/.changeset/quick-elephants-know.md
+++ b/.changeset/quick-elephants-know.md
@@ -2,4 +2,4 @@
 '@roadiehq/catalog-backend-module-aws': minor
 ---
 
-Adds ability to template entity from eks entity provider.
+Adds ability to template entity from AWS entity providers.

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,5 @@ dist-types
 
 # reduce the barrier for adopters to add themselves
 ADOPTERS.md
+
+*.njs

--- a/plugins/backend/catalog-backend-module-aws/package.json
+++ b/plugins/backend/catalog-backend-module-aws/package.json
@@ -65,9 +65,9 @@
     "@backstage/plugin-catalog-node": "backstage:^",
     "@backstage/plugin-kubernetes-common": "backstage:^",
     "js-yaml": "^4.1.0",
-    "nunjucks": "^3.2.4",
     "link2aws": "^1.0.18",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "nunjucks": "^3.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",

--- a/plugins/backend/catalog-backend-module-aws/package.json
+++ b/plugins/backend/catalog-backend-module-aws/package.json
@@ -64,6 +64,8 @@
     "@backstage/plugin-catalog-backend": "backstage:^",
     "@backstage/plugin-catalog-node": "backstage:^",
     "@backstage/plugin-kubernetes-common": "backstage:^",
+    "js-yaml": "^4.1.0",
+    "nunjucks": "^3.2.4",
     "link2aws": "^1.0.18",
     "lodash": "^4.17.21"
   },

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.example.yaml.njs
@@ -1,0 +1,13 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ table.TableArn | to_entity_name }}
+  annotations:
+    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
+  title: {{ table.TableName }}
+  labels:
+    {% for tag in tags %}
+    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
+    {% endfor %}
+spec:
+  type: dynamo-db-table

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.example.yaml.njs
@@ -1,10 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ table.TableArn | to_entity_name }}
+  name: {{ data.TableArn | to_entity_name }}
   annotations:
-    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
-  title: {{ table.TableName }}
+    amazon.com/dynamo-db-table-arn: {{ data.TableArn }}
+  title: {{ data.TableName }}
   labels:
     {% for tag in tags %}
     {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableDataProvider.test.ts
@@ -17,6 +17,8 @@
 import { AWSDynamoDbTableDataProvider } from './AWSDynamoDbTableDataProvider';
 import { ConfigReader } from '@backstage/config';
 import { createLogger } from 'winston';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const validConfig = {
   accountId: '123456789012',
@@ -65,6 +67,28 @@ describe('AWSDynamoDbTableDataProvider', () => {
     const testWrapper = () => {
       AWSDynamoDbTableDataProvider.fromConfig(config, {
         logger: createLogger(),
+      });
+    };
+    expect(testWrapper).not.toThrow();
+  });
+
+  it('should not blow up on correct configs using template', () => {
+    const config = ConfigReader.fromConfigs([
+      {
+        context: 'unit-test',
+        data: validConfig,
+      },
+    ]);
+    const template = readFileSync(
+      join(
+        dirname(__filename),
+        './AWSDynamoDbTableDataProvider.example.yaml.njs',
+      ),
+    ).toString();
+    const testWrapper = () => {
+      AWSDynamoDbTableDataProvider.fromConfig(config, {
+        logger: createLogger(),
+        template,
       });
     };
     expect(testWrapper).not.toThrow();

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.example.yaml.njs
@@ -1,0 +1,13 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ table.TableArn | to_entity_name }}
+  annotations:
+    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
+  title: {{ table.TableName }}
+  labels:
+    {% for tag in tags %}
+    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
+    {% endfor %}
+spec:
+  type: dynamo-db-table

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.example.yaml.njs
@@ -1,10 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ table.TableArn | to_entity_name }}
+  name: {{ data.TableArn | to_entity_name }}
   annotations:
-    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
-  title: {{ table.TableName }}
+    amazon.com/dynamo-db-table-arn: {{ data.TableArn }}
+  title: {{ data.TableName }}
   labels:
     {% for tag in tags %}
     {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.example.yaml.njs
@@ -6,8 +6,6 @@ metadata:
     amazon.com/dynamo-db-table-arn: {{ data.TableArn }}
   title: {{ data.TableName }}
   labels:
-    {% for tag in tags %}
-    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
-    {% endfor %}
+    something: {{ tags['something'] | replace("/", "-") | replace("/", "-") | replace(":", "-") }}
 spec:
   type: dynamo-db-table

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.test.ts
@@ -27,6 +27,8 @@ import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSDynamoDbTableProvider } from './AWSDynamoDbTableProvider';
 import { ANNOTATION_AWS_DDB_TABLE_ARN } from '../annotations';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const eks = mockClient(DynamoDB);
 const sts = mockClient(STS);
@@ -95,6 +97,46 @@ describe('AWSDynamoDbTableProvider', () => {
         refresh: jest.fn(),
       };
       const provider = AWSDynamoDbTableProvider.fromConfig(config, { logger });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              metadata: expect.objectContaining({
+                name: '789400bd545150a5e718539098e053ad2242a887ffe74c390197aed9dceb621',
+                title: 'table1',
+                annotations: expect.objectContaining({
+                  [ANNOTATION_AWS_DDB_TABLE_ARN]:
+                    'arn:aws:dynamodb::123456789012:table/table1',
+                }),
+                labels: {
+                  something: 'something--something',
+                },
+              }),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('creates table with template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(
+          dirname(__filename),
+          './AWSDynamoDbTableProvider.example.yaml.njs',
+        ),
+      ).toString();
+      const provider = AWSDynamoDbTableProvider.fromConfig(config, {
+        logger,
+        template,
+      });
       await provider.connect(entityProviderConnection);
       await provider.run();
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
@@ -113,11 +113,13 @@ export class AWSDynamoDbTableProvider extends AWSEntityProvider {
             const table = tableDescriptionResult.Table;
 
             if (table && table.TableName && table.TableArn) {
-              let entity: Entity | undefined = this.renderEntity({
-                tags,
-                table,
-                defaultAnnotations,
-              });
+              let entity: Entity | undefined = this.renderEntity(
+                {
+                  tags,
+                  data: table,
+                },
+                { defaultAnnotations },
+              );
 
               if (!entity) {
                 entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSDynamoDbTableProvider.ts
@@ -111,11 +111,17 @@ export class AWSDynamoDbTableProvider extends AWSEntityProvider {
             });
             const tags = tagsResponse.Tags ?? [];
             const table = tableDescriptionResult.Table;
+            const tagMap = tags.reduce((acc, tag) => {
+              if (tag.Key && tag.Value) {
+                acc[tag.Key] = tag.Value;
+              }
+              return acc;
+            }, {} as Record<string, string>);
 
             if (table && table.TableName && table.TableArn) {
               let entity: Entity | undefined = this.renderEntity(
                 {
-                  tags,
+                  tags: tagMap,
                   data: table,
                 },
                 { defaultAnnotations },

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.example.yaml.njs
@@ -1,0 +1,17 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ volume.VolumeId | to_entity_name }}
+  annotations:
+    amazonaws.com/ebs-volume-id: {{ volume.VolumeId }}
+    backstage.io/managed-by-location: aws-ebs-volume-provider-0:arn:aws:iam::123456789012:role/role1
+    backstage.io/managed-by-origin-location: aws-ebs-volume-provider-0:arn:aws:iam::123456789012:role/role1
+    backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/home?region=eu-west-1#VolumeDetails:volumeId=undefined
+  title: {{ volume.VolumeId }}
+  labels:
+    {% for tag in volume.Tags %}
+    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
+    {% endfor %}
+spec:
+  owner: unknown
+  type: ebs-volume

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.example.yaml.njs
@@ -1,15 +1,15 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ volume.VolumeId | to_entity_name }}
+  name: {{ data.VolumeId | to_entity_name }}
   annotations:
-    amazonaws.com/ebs-volume-id: {{ volume.VolumeId }}
+    amazonaws.com/ebs-volume-id: {{ data.VolumeId }}
     backstage.io/managed-by-location: aws-ebs-volume-provider-0:arn:aws:iam::123456789012:role/role1
     backstage.io/managed-by-origin-location: aws-ebs-volume-provider-0:arn:aws:iam::123456789012:role/role1
     backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/home?region=eu-west-1#VolumeDetails:volumeId=undefined
-  title: {{ volume.VolumeId }}
+  title: {{ data.VolumeId }}
   labels:
-    {% for tag in volume.Tags %}
+    {% for tag in data.Tags %}
     {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
     {% endfor %}
 spec:

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.ts
@@ -109,10 +109,12 @@ export class AWSEBSVolumeProvider extends AWSEntityProvider {
         const ebsVolumeId = resourceParts[3];
 
         const consoleLink = createEbsVolumeConsoleLink(region, ebsVolumeId);
-        let entity: Entity | undefined = this.renderEntity({
-          volume,
-          defaultAnnotations,
-        });
+        let entity: Entity | undefined = this.renderEntity(
+          {
+            data: volume,
+          },
+          { defaultAnnotations },
+        );
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEBSVolumeProvider.ts
@@ -16,7 +16,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import type { Logger } from 'winston';
 import { EC2 } from '@aws-sdk/client-ec2';
@@ -43,6 +43,7 @@ export class AWSEBSVolumeProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -86,7 +87,7 @@ export class AWSEBSVolumeProvider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing EBS volume resources from aws: ${accountId}`);
-    const ebsResources: ResourceEntity[] = [];
+    const ebsResources: Entity[] = [];
 
     const ec2 = await this.getEc2(dynamicAccountConfig);
     const defaultAnnotations = await this.buildDefaultAnnotations(
@@ -108,38 +109,43 @@ export class AWSEBSVolumeProvider extends AWSEntityProvider {
         const ebsVolumeId = resourceParts[3];
 
         const consoleLink = createEbsVolumeConsoleLink(region, ebsVolumeId);
-
-        const resource: ResourceEntity = {
-          kind: 'Resource',
-          apiVersion: 'backstage.io/v1beta1',
-          metadata: {
-            annotations: {
-              ...defaultAnnotations,
-              [ANNOTATION_VIEW_URL]: consoleLink,
-              [ANNOTATION_EBS_VOLUME_ID]: volumeId,
+        let entity: Entity | undefined = this.renderEntity({
+          volume,
+          defaultAnnotations,
+        });
+        if (!entity) {
+          entity = {
+            kind: 'Resource',
+            apiVersion: 'backstage.io/v1beta1',
+            metadata: {
+              annotations: {
+                ...defaultAnnotations,
+                [ANNOTATION_VIEW_URL]: consoleLink,
+                [ANNOTATION_EBS_VOLUME_ID]: volumeId,
+              },
+              labels: this.labelsFromTags(volume.Tags),
+              name: volumeId,
+              title:
+                volume.Tags?.find(tag => tag.Key === 'Name')?.Value || volumeId,
+              size: volume.Size,
+              volumeType: volume.VolumeType,
+              availabilityZone: volume.AvailabilityZone,
+              state: volume.State,
+              encrypted: volume.Encrypted ? 'Yes' : 'No',
+              attachedInstanceIds: volume.Attachments?.map(
+                a => a.InstanceId,
+              ).join(', '),
+              createTime: volume.CreateTime?.toISOString(),
             },
-            labels: this.labelsFromTags(volume.Tags),
-            name: volumeId,
-            title:
-              volume.Tags?.find(tag => tag.Key === 'Name')?.Value || volumeId,
-            size: volume.Size,
-            volumeType: volume.VolumeType,
-            availabilityZone: volume.AvailabilityZone,
-            state: volume.State,
-            encrypted: volume.Encrypted ? 'Yes' : 'No',
-            attachedInstanceIds: volume.Attachments?.map(
-              a => a.InstanceId,
-            ).join(', '),
-            createTime: volume.CreateTime?.toISOString(),
-          },
-          spec: {
-            owner: ownerFromTags(volume.Tags, this.getOwnerTag(), groups),
-            ...relationshipsFromTags(volume.Tags),
-            type: 'ebs-volume',
-          },
-        };
+            spec: {
+              owner: ownerFromTags(volume.Tags, this.getOwnerTag(), groups),
+              ...relationshipsFromTags(volume.Tags),
+              type: 'ebs-volume',
+            },
+          };
+        }
 
-        ebsResources.push(resource);
+        ebsResources.push(entity);
       }
 
       nextToken = volumes.NextToken;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.example.yaml.njs
@@ -1,10 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ instance.InstanceId }}
-  title: {{ instance.InstanceId }}
+  name: {{ data.InstanceId }}
+  title: {{ data.InstanceId }}
   annotations:
-    amazon.com/ec2-instance-id: {{ instance.InstanceId }}
+    amazon.com/ec2-instance-id: {{ data.InstanceId }}
     backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/v2/home
 spec:
   type: ec2-instance

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.example.yaml.njs
@@ -1,0 +1,13 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ table.TableArn | to_entity_name }}
+  annotations:
+    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
+  title: {{ table.TableName }}
+  labels:
+    {% for tag in tags %}
+    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
+    {% endfor %}
+spec:
+  type: dynamo-db-table

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.example.yaml.njs
@@ -1,13 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ table.TableArn | to_entity_name }}
+  name: {{ instance.InstanceId }}
+  title: {{ instance.InstanceId }}
   annotations:
-    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
-  title: {{ table.TableName }}
-  labels:
-    {% for tag in tags %}
-    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
-    {% endfor %}
+    amazon.com/ec2-instance-id: {{ instance.InstanceId }}
+    backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/v2/home
 spec:
-  type: dynamo-db-table
+  type: ec2-instance

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.test.ts
@@ -148,13 +148,9 @@ describe('AWSEC2Provider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'ec2-instance',
               },
               metadata: expect.objectContaining({
-                labels: {
-                  something: 'something--something',
-                },
                 annotations: expect.objectContaining({
                   [ANNOTATION_AWS_EC2_INSTANCE_ID]: 'asdf',
                   'backstage.io/managed-by-location':

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { EC2 } from '@aws-sdk/client-ec2';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -39,6 +39,7 @@ export class AWSEC2Provider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -82,7 +83,7 @@ export class AWSEC2Provider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing ec2 resources from aws: ${accountId}`);
-    const ec2Resources: ResourceEntity[] = [];
+    const ec2Resources: Entity[] = [];
 
     const ec2 = await this.getEc2(dynamicAccountConfig);
 
@@ -99,40 +100,48 @@ export class AWSEC2Provider extends AWSEntityProvider {
           const instanceId = instance.InstanceId;
           const arn = `arn:aws:ec2:${region}:${accountId}:instance/${instanceId}`;
           const consoleLink = new ARN(arn).consoleLink;
-          const resource: ResourceEntity = {
-            kind: 'Resource',
-            apiVersion: 'backstage.io/v1beta1',
-            metadata: {
-              annotations: {
-                ...(await defaultAnnotations),
-                [ANNOTATION_VIEW_URL]: consoleLink,
-                [ANNOTATION_AWS_EC2_INSTANCE_ID]: instanceId ?? 'unknown',
-              },
-              labels: this.labelsFromTags(instance.Tags),
-              name:
-                instanceId ??
-                `${reservation.ReservationId}-instance-${instance.InstanceId}`,
-              title:
-                instance?.Tags?.find(
-                  tag => tag.Key === 'Name' || tag.Key === 'name',
-                )?.Value ?? undefined,
-              instancePlatform: instance.Platform,
-              instanceType: instance.InstanceType,
-              monitoringState: instance.Monitoring?.State,
-              instancePlacement: instance.Placement?.AvailabilityZone,
-              amountOfBlockDevices: instance.BlockDeviceMappings?.length ?? 0,
-              instanceCpuCores: instance.CpuOptions?.CoreCount,
-              instanceCpuThreadsPerCode: instance.CpuOptions?.ThreadsPerCore,
-              reservationId: reservation.ReservationId,
-            },
-            spec: {
-              owner: ownerFromTags(instance.Tags, this.getOwnerTag(), groups),
-              ...relationshipsFromTags(instance.Tags),
-              type: 'ec2-instance',
-            },
-          };
 
-          ec2Resources.push(resource);
+          let entity: Entity | undefined = this.renderEntity({
+            instance,
+            defaultAnnotations,
+          });
+
+          if (!entity) {
+            entity = {
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              metadata: {
+                annotations: {
+                  ...(await defaultAnnotations),
+                  [ANNOTATION_VIEW_URL]: consoleLink,
+                  [ANNOTATION_AWS_EC2_INSTANCE_ID]: instanceId ?? 'unknown',
+                },
+                labels: this.labelsFromTags(instance.Tags),
+                name:
+                  instanceId ??
+                  `${reservation.ReservationId}-instance-${instance.InstanceId}`,
+                title:
+                  instance?.Tags?.find(
+                    tag => tag.Key === 'Name' || tag.Key === 'name',
+                  )?.Value ?? undefined,
+                instancePlatform: instance.Platform,
+                instanceType: instance.InstanceType,
+                monitoringState: instance.Monitoring?.State,
+                instancePlacement: instance.Placement?.AvailabilityZone,
+                amountOfBlockDevices: instance.BlockDeviceMappings?.length ?? 0,
+                instanceCpuCores: instance.CpuOptions?.CoreCount,
+                instanceCpuThreadsPerCode: instance.CpuOptions?.ThreadsPerCore,
+                reservationId: reservation.ReservationId,
+              },
+              spec: {
+                owner: ownerFromTags(instance.Tags, this.getOwnerTag(), groups),
+                ...relationshipsFromTags(instance.Tags),
+                type: 'ec2-instance',
+              },
+            };
+          }
+
+          ec2Resources.push(entity);
         }
       }
     }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
@@ -101,9 +101,12 @@ export class AWSEC2Provider extends AWSEntityProvider {
           const arn = `arn:aws:ec2:${region}:${accountId}:instance/${instanceId}`;
           const consoleLink = new ARN(arn).consoleLink;
 
-          let entity: Entity | undefined = this.renderEntity({
-            instance,
-          }, { defaultAnnotations: await defaultAnnotations });
+          let entity: Entity | undefined = this.renderEntity(
+            {
+              instance,
+            },
+            { defaultAnnotations: await defaultAnnotations },
+          );
 
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
@@ -103,7 +103,7 @@ export class AWSEC2Provider extends AWSEntityProvider {
 
           let entity: Entity | undefined = this.renderEntity(
             {
-              instance,
+              data: instance,
             },
             { defaultAnnotations: await defaultAnnotations },
           );

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEC2Provider.ts
@@ -103,8 +103,7 @@ export class AWSEC2Provider extends AWSEntityProvider {
 
           let entity: Entity | undefined = this.renderEntity({
             instance,
-            defaultAnnotations,
-          });
+          }, { defaultAnnotations: await defaultAnnotations });
 
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.example.yaml.njs
@@ -1,0 +1,13 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ table.TableArn | to_entity_name }}
+  annotations:
+    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
+  title: {{ table.TableName }}
+  labels:
+    {% for tag in tags %}
+    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
+    {% endfor %}
+spec:
+  type: dynamo-db-table

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.example.yaml.njs
@@ -1,13 +1,13 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ repository.repositoryName }}
-  tagImmutability: {{ repository.imageTagMutability }}
-  encryption: {{ repository.encryptionConfiguration.encryptionType }}
-  createdAt: {{ repository.createdAt }}
-  uri: {{ repository.repositoryUri }}
+  name: {{ data.repositoryName }}
+  tagImmutability: {{ data.imageTagMutability }}
+  encryption: {{ data.encryptionConfiguration.encryptionType }}
+  createdAt: {{ data.createdAt }}
+  uri: {{ data.repositoryUri }}
   annotations:
-    amazonaws.com/ecr-repository-arn: {{ repository.repositoryArn }}
-  title: {{ repository.repositoryName }}
+    amazonaws.com/ecr-repository-arn: {{ data.repositoryArn }}
+  title: {{ data.repositoryName }}
 spec:
   type: ecr-repository

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.example.yaml.njs
@@ -1,13 +1,13 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ table.TableArn | to_entity_name }}
+  name: {{ repository.repositoryName }}
+  tagImmutability: {{ repository.imageTagMutability }}
+  encryption: {{ repository.encryptionConfiguration.encryptionType }}
+  createdAt: {{ repository.createdAt }}
+  uri: {{ repository.repositoryUri }}
   annotations:
-    amazon.com/dynamo-db-table-arn: {{ table.TableArn }}
-  title: {{ table.TableName }}
-  labels:
-    {% for tag in tags %}
-    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
-    {% endfor %}
+    amazonaws.com/ecr-repository-arn: {{ repository.repositoryArn }}
+  title: {{ repository.repositoryName }}
 spec:
-  type: dynamo-db-table
+  type: ecr-repository

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.test.ts
@@ -130,16 +130,11 @@ describe('AWSECRRepositoryEntityProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'ecr-repository',
               },
               metadata: expect.objectContaining({
                 name: 'my-app-repo',
                 title: 'my-app-repo',
-                labels: {
-                  'aws-ecr-region': 'eu-west-1',
-                  Environment: 'production//staging',
-                },
                 annotations: expect.objectContaining({
                   'amazonaws.com/ecr-repository-arn':
                     'arn:aws:ecr:eu-west-1:123456789012:repository/my-app-repo',
@@ -150,7 +145,7 @@ describe('AWSECRRepositoryEntityProvider', () => {
                 }),
                 uri: '123456789012.dkr.ecr.eu-west-1.amazonaws.com/my-app-repo',
                 tagImmutability: 'MUTABLE',
-                createdAt: 'Sun Jan 01 2023',
+                createdAt: expect.stringContaining('Sun Jan 01 2023'),
                 encryption: 'AES256',
               }),
             }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.test.ts
@@ -27,6 +27,8 @@ import { createLogger, transports } from 'winston';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSECRRepositoryEntityProvider } from './AWSECRRepositoryEntityProvider';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 // @ts-ignore
 const ecr = mockClient(ECRClient);
@@ -100,6 +102,61 @@ describe('AWSECRRepositoryEntityProvider', () => {
           },
         ],
       } as ListTagsForResourceCommandOutput);
+    });
+
+    it('creates repository with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(
+          dirname(__filename),
+          './AWSECRRepositoryEntityProvider.example.yaml.njs',
+        ),
+      ).toString();
+      const provider = AWSECRRepositoryEntityProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            locationKey: 'aws-ecr-repo-0',
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              spec: {
+                owner: 'unknown',
+                type: 'ecr-repository',
+              },
+              metadata: expect.objectContaining({
+                name: 'my-app-repo',
+                title: 'my-app-repo',
+                labels: {
+                  'aws-ecr-region': 'eu-west-1',
+                  Environment: 'production//staging',
+                },
+                annotations: expect.objectContaining({
+                  'amazonaws.com/ecr-repository-arn':
+                    'arn:aws:ecr:eu-west-1:123456789012:repository/my-app-repo',
+                  'backstage.io/managed-by-location':
+                    'aws-ecr-repo-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-ecr-repo-0:arn:aws:iam::123456789012:role/role1',
+                }),
+                uri: '123456789012.dkr.ecr.eu-west-1.amazonaws.com/my-app-repo',
+                tagImmutability: 'MUTABLE',
+                createdAt: 'Sun Jan 01 2023',
+                encryption: 'AES256',
+              }),
+            }),
+          }),
+        ],
+      });
     });
 
     it('creates repository', async () => {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.ts
@@ -130,7 +130,7 @@ export class AWSECRRepositoryEntityProvider extends AWSEntityProvider {
 
         let entity: Entity | undefined = this.renderEntity(
           {
-            repository: repo,
+            data: repo,
             tags,
           },
           { defaultAnnotations },

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.ts
@@ -130,7 +130,8 @@ export class AWSECRRepositoryEntityProvider extends AWSEntityProvider {
 
         let entity: Entity | undefined = this.renderEntity({
           repository: repo,
-        });
+          tags,
+        }, { defaultAnnotations });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSECRRepositoryEntityProvider.ts
@@ -128,10 +128,13 @@ export class AWSECRRepositoryEntityProvider extends AWSEntityProvider {
           return acc;
         }, {} as Record<string, string>);
 
-        let entity: Entity | undefined = this.renderEntity({
-          repository: repo,
-          tags,
-        }, { defaultAnnotations });
+        let entity: Entity | undefined = this.renderEntity(
+          {
+            repository: repo,
+            tags,
+          },
+          { defaultAnnotations },
+        );
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.example.yaml.njs
@@ -1,12 +1,12 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ data.name | to_entity_name }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    amazon.com/eks-cluster-arn: {{ data.arn }}
+    amazon.com/iam-role-arn: {{ data.roleArn }}
     kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+    kubernetes.io/x-k8s-aws-id: {{ data.name }}
+  title: {{ accountId }}:{{ region }}:{{ data.name }}
   labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    some_url: {{ data.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEKSClusterProvider.ts
@@ -171,7 +171,7 @@ export class AWSEKSClusterProvider extends AWSEntityProvider {
 
           const labels = this.labelsFromTags(cluster.cluster?.tags);
           let entity: Entity | undefined = this.renderEntity({
-            cluster: cluster.cluster,
+            data: cluster.cluster,
           });
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.example.yaml.njs
@@ -1,12 +1,11 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ cluster.CacheClusterId }}
+  title: {{ cluster.CacheClusterId }}
+  engineVersion: {{ cluster.EngineVersion }}
+  engine: {{ cluster.Engine }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    "amazon.com/elasticache-cluster-arn": {{ cluster.ARN }}
+spec:
+  type: elasticache-cluster

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.example.yaml.njs
@@ -1,11 +1,11 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.CacheClusterId }}
-  title: {{ cluster.CacheClusterId }}
-  engineVersion: {{ cluster.EngineVersion }}
-  engine: {{ cluster.Engine }}
+  name: {{ data.CacheClusterId }}
+  title: {{ data.CacheClusterId }}
+  engineVersion: {{ data.EngineVersion }}
+  engine: {{ data.Engine }}
   annotations:
-    "amazon.com/elasticache-cluster-arn": {{ cluster.ARN }}
+    "amazon.com/elasticache-cluster-arn": {{ data.ARN }}
 spec:
   type: elasticache-cluster

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.test.ts
@@ -135,15 +135,11 @@ describe('AWSElastiCacheEntityProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'elasticache-cluster',
               },
               metadata: expect.objectContaining({
                 name: 'my-redis-cluster',
                 title: 'my-redis-cluster',
-                labels: {
-                  'aws-elasticache-region': 'eu-west-1',
-                },
                 annotations: expect.objectContaining({
                   [ANNOTATION_AWS_ELASTICACHE_CLUSTER_ARN]:
                     'arn:aws:elasticache:eu-west-1:123456789012:cluster:my-redis-cluster',
@@ -152,11 +148,8 @@ describe('AWSElastiCacheEntityProvider', () => {
                   'backstage.io/managed-by-origin-location':
                     'aws-elasticache-cluster-0:arn:aws:iam::123456789012:role/role1',
                 }),
-                status: 'available',
                 engine: 'redis',
                 engineVersion: '7.0.7',
-                nodeType: 'cache.t3.micro',
-                endpoint: 'my-redis-cluster.abc123.cache.amazonaws.com:6379',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
@@ -119,6 +119,12 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
         const tags = clusterArn
           ? await elastiCache.listTagsForResource({ ResourceName: clusterArn })
           : undefined;
+        const tagMap = tags?.TagList?.reduce((acc, tag) => {
+          if (tag.Key && tag.Value) {
+            acc[tag.Key] = tag.Value;
+          }
+          return acc;
+        }, {} as Record<string, string>);
 
         // Additional metadata properties
         const clusterStatus = cluster.CacheClusterStatus || '';
@@ -130,7 +136,7 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
             ? `${cluster.CacheNodes[0].Endpoint.Address}:${cluster.CacheNodes[0].Endpoint.Port}`
             : '';
         let entity: Entity | undefined = this.renderEntity(
-          { data: cluster, tags },
+          { data: cluster, tags: tagMap },
           { defaultAnnotations },
         );
         if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
@@ -129,7 +129,7 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
           cluster.CacheNodes && cluster.CacheNodes[0]?.Endpoint
             ? `${cluster.CacheNodes[0].Endpoint.Address}:${cluster.CacheNodes[0].Endpoint.Port}`
             : '';
-        let entity: Entity | undefined = this.renderEntity({ cluster, tags });
+        let entity: Entity | undefined = this.renderEntity({ cluster, tags }, { defaultAnnotations });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
@@ -129,7 +129,10 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
           cluster.CacheNodes && cluster.CacheNodes[0]?.Endpoint
             ? `${cluster.CacheNodes[0].Endpoint.Address}:${cluster.CacheNodes[0].Endpoint.Port}`
             : '';
-        let entity: Entity | undefined = this.renderEntity({ cluster, tags }, { defaultAnnotations });
+        let entity: Entity | undefined = this.renderEntity(
+          { cluster, tags },
+          { defaultAnnotations },
+        );
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
@@ -130,7 +130,7 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
             ? `${cluster.CacheNodes[0].Endpoint.Address}:${cluster.CacheNodes[0].Endpoint.Port}`
             : '';
         let entity: Entity | undefined = this.renderEntity(
-          { cluster, tags },
+          { data: cluster, tags },
           { defaultAnnotations },
         );
         if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSElastiCacheEntityProvider.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ResourceEntity } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { ElastiCache } from '@aws-sdk/client-elasticache';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -39,6 +39,7 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -99,7 +100,7 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
     this.logger.info(
       `Providing ElastiCache cluster resources from AWS: ${accountId}`,
     );
-    const elasticacheResources: ResourceEntity[] = [];
+    const elasticacheResources: Entity[] = [];
 
     const elastiCache = await this.getElastiCacheClient(dynamicAccountConfig);
 
@@ -128,34 +129,36 @@ export class AWSElastiCacheEntityProvider extends AWSEntityProvider {
           cluster.CacheNodes && cluster.CacheNodes[0]?.Endpoint
             ? `${cluster.CacheNodes[0].Endpoint.Address}:${cluster.CacheNodes[0].Endpoint.Port}`
             : '';
-
-        const resource: ResourceEntity = {
-          kind: 'Resource',
-          apiVersion: 'backstage.io/v1beta1',
-          metadata: {
-            name: clusterName.toLowerCase().replace(/[^a-zA-Z0-9\-]/g, '-'),
-            title: clusterName,
-            labels: {
-              'aws-elasticache-region': this.region,
+        let entity: Entity | undefined = this.renderEntity({ cluster, tags });
+        if (!entity) {
+          entity = {
+            kind: 'Resource',
+            apiVersion: 'backstage.io/v1beta1',
+            metadata: {
+              name: clusterName.toLowerCase().replace(/[^a-zA-Z0-9\-]/g, '-'),
+              title: clusterName,
+              labels: {
+                'aws-elasticache-region': this.region,
+              },
+              annotations: {
+                ...defaultAnnotations,
+                [ANNOTATION_AWS_ELASTICACHE_CLUSTER_ARN]: clusterArn ?? '',
+              },
+              status: clusterStatus,
+              engine,
+              engineVersion,
+              nodeType,
+              endpoint,
             },
-            annotations: {
-              ...defaultAnnotations,
-              [ANNOTATION_AWS_ELASTICACHE_CLUSTER_ARN]: clusterArn ?? '',
+            spec: {
+              owner: ownerFromTags(tags?.TagList || [], this.getOwnerTag()),
+              ...relationshipsFromTags(tags?.TagList || []),
+              type: this.elasticacheTypeValue,
             },
-            status: clusterStatus,
-            engine,
-            engineVersion,
-            nodeType,
-            endpoint,
-          },
-          spec: {
-            owner: ownerFromTags(tags?.TagList || [], this.getOwnerTag()),
-            ...relationshipsFromTags(tags?.TagList || []),
-            type: this.elasticacheTypeValue,
-          },
-        };
+          };
+        }
 
-        elasticacheResources.push(resource);
+        elasticacheResources.push(entity);
       }
     }
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
@@ -86,14 +86,17 @@ export abstract class AWSEntityProvider implements EntityProvider {
           .digest('hex')
           .slice(0, 63);
       });
-      env.addFilter('split', function(str, delimiter) {
+      env.addFilter('split', function (str, delimiter) {
         return str.split(delimiter);
       });
       this.template = compile(options.template, env);
     }
   }
 
-  protected renderEntity(context: any, options?: { defaultAnnotations: Record<string, string>}): Entity | undefined {
+  protected renderEntity(
+    context: any,
+    options?: { defaultAnnotations: Record<string, string> },
+  ): Entity | undefined {
     if (this.template) {
       const entity = yaml.load(
         this.template.render({
@@ -103,9 +106,9 @@ export abstract class AWSEntityProvider implements EntityProvider {
         }),
       ) as Entity;
       entity.metadata.annotations = {
-        ...options?.defaultAnnotations || {},
+        ...(options?.defaultAnnotations || {}),
         ...entity.metadata.annotations,
-      }
+      };
       return entity;
     }
     return undefined;

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
@@ -86,19 +86,27 @@ export abstract class AWSEntityProvider implements EntityProvider {
           .digest('hex')
           .slice(0, 63);
       });
+      env.addFilter('split', function(str, delimiter) {
+        return str.split(delimiter);
+      });
       this.template = compile(options.template, env);
     }
   }
 
-  protected renderEntity(options: any): Entity | undefined {
+  protected renderEntity(context: any, options?: { defaultAnnotations: Record<string, string>}): Entity | undefined {
     if (this.template) {
-      return yaml.load(
+      const entity = yaml.load(
         this.template.render({
-          ...options,
+          ...context,
           accountId: this.accountId,
           region: this.region,
         }),
       ) as Entity;
+      entity.metadata.annotations = {
+        ...options?.defaultAnnotations || {},
+        ...entity.metadata.annotations,
+      }
+      return entity;
     }
     return undefined;
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
@@ -25,6 +25,7 @@ import { STS } from '@aws-sdk/client-sts';
 import {
   ANNOTATION_ORIGIN_LOCATION,
   ANNOTATION_LOCATION,
+  Entity,
 } from '@backstage/catalog-model';
 import { ANNOTATION_ACCOUNT_ID } from '../annotations';
 import { CatalogApi } from '@backstage/catalog-client';
@@ -33,6 +34,9 @@ import { ConfigReader } from '@backstage/config';
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { parse as parseArn } from '@aws-sdk/util-arn-parser';
 import { LabelValueMapper, labelsFromTags, Tag } from '../utils/tags';
+import { compile, Environment, Template } from 'nunjucks';
+import crypto from 'crypto';
+import yaml from 'js-yaml';
 
 export abstract class AWSEntityProvider implements EntityProvider {
   protected readonly useTemporaryCredentials: boolean;
@@ -44,6 +48,7 @@ export abstract class AWSEntityProvider implements EntityProvider {
   private credentialsManager: DefaultAwsCredentialsManager;
   private account: AccountConfig;
   protected readonly labelValueMapper: LabelValueMapper | undefined;
+  private template: Template | undefined;
 
   public abstract getProviderName(): string;
   public abstract run(
@@ -54,6 +59,7 @@ export abstract class AWSEntityProvider implements EntityProvider {
     account: AccountConfig,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -71,6 +77,30 @@ export abstract class AWSEntityProvider implements EntityProvider {
       new ConfigReader({ aws: { accounts: [account] } }),
     );
     this.labelValueMapper = options.labelValueMapper;
+    if (options.template) {
+      const env = new Environment();
+      env.addFilter('to_entity_name', input => {
+        return crypto
+          .createHash('sha256')
+          .update(input)
+          .digest('hex')
+          .slice(0, 63);
+      });
+      this.template = compile(options.template, env);
+    }
+  }
+
+  protected renderEntity(options: any): Entity | undefined {
+    if (this.template) {
+      return yaml.load(
+        this.template.render({
+          ...options,
+          accountId: this.accountId,
+          region: this.region,
+        }),
+      ) as Entity;
+    }
+    return undefined;
   }
 
   get accountId() {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSEntityProvider.ts
@@ -94,7 +94,10 @@ export abstract class AWSEntityProvider implements EntityProvider {
   }
 
   protected renderEntity(
-    context: any,
+    context: {
+      data: any;
+      tags?: Record<string, string>;
+    },
     options?: { defaultAnnotations: Record<string, string> },
   ): Entity | undefined {
     if (this.template) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.example.yaml.njs
@@ -1,13 +1,13 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ role.RoleName | to_entity_name }}
+  name: {{ data.RoleName | to_entity_name }}
   annotations:
-    amazon.com/iam-role-arn: {{ role.Arn }}
-  title: {{ role.RoleName }}
+    amazon.com/iam-role-arn: {{ data.Arn }}
+  title: {{ data.RoleName }}
   labels:
-    {% if role.Tags %}
-    {% for tag in role.Tags %}
+    {% if data.Tags %}
+    {% for tag in data.Tags %}
     {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
     {% endfor %}
     {% endif %}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.example.yaml.njs
@@ -1,0 +1,16 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ role.RoleName | to_entity_name }}
+  annotations:
+    amazon.com/iam-role-arn: {{ role.Arn }}
+  title: {{ role.RoleName }}
+  labels:
+    {% if role.Tags %}
+    {% for tag in role.Tags %}
+    {{ tag.Key }}: {{ tag.Value | replace(":", "-") | replace("/", "-") }}
+    {% endfor %}
+    {% endif %}
+spec:
+  type: aws-role
+  owner: {{ accountId }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
@@ -104,7 +104,7 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
           const consoleLink = new ARN(role.Arn).consoleLink;
           let entity: Entity | undefined = this.renderEntity(
             { data: role },
-            { defaultAnnotations },
+            { defaultAnnotations: await defaultAnnotations },
           );
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
@@ -102,7 +102,10 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
       for (const role of rolePage.Roles || []) {
         if (role.RoleName && role.Arn && role.RoleId) {
           const consoleLink = new ARN(role.Arn).consoleLink;
-          let entity: Entity | undefined = this.renderEntity({ role });
+          let entity: Entity | undefined = this.renderEntity(
+            { data: role },
+            { defaultAnnotations },
+          );
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMRoleProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { IAM, paginateListRoles } from '@aws-sdk/client-iam';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -40,6 +40,7 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -83,7 +84,7 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing IAM role resources from AWS: ${accountId}`);
-    const roleResources: ResourceEntity[] = [];
+    const roleResources: Entity[] = [];
 
     const defaultAnnotations =
       this.buildDefaultAnnotations(dynamicAccountConfig);
@@ -101,27 +102,30 @@ export class AWSIAMRoleProvider extends AWSEntityProvider {
       for (const role of rolePage.Roles || []) {
         if (role.RoleName && role.Arn && role.RoleId) {
           const consoleLink = new ARN(role.Arn).consoleLink;
-          const roleEntity: ResourceEntity = {
-            kind: 'Resource',
-            apiVersion: 'backstage.io/v1alpha1',
-            metadata: {
-              annotations: {
-                ...(await defaultAnnotations),
-                [ANNOTATION_AWS_IAM_ROLE_ARN]: role.Arn,
-                [ANNOTATION_VIEW_URL]: consoleLink.toString(),
+          let entity: Entity | undefined = this.renderEntity({ role });
+          if (!entity) {
+            entity = {
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1alpha1',
+              metadata: {
+                annotations: {
+                  ...(await defaultAnnotations),
+                  [ANNOTATION_AWS_IAM_ROLE_ARN]: role.Arn,
+                  [ANNOTATION_VIEW_URL]: consoleLink.toString(),
+                },
+                name: arnToName(role.Arn),
+                title: role.RoleName,
+                labels: this.labelsFromTags(role.Tags),
               },
-              name: arnToName(role.Arn),
-              title: role.RoleName,
-              labels: this.labelsFromTags(role.Tags),
-            },
-            spec: {
-              type: 'aws-role',
-              owner: ownerFromTags(role.Tags, this.getOwnerTag(), groups),
-              ...relationshipsFromTags(role.Tags),
-            },
-          };
+              spec: {
+                type: 'aws-role',
+                owner: ownerFromTags(role.Tags, this.getOwnerTag(), groups),
+                ...relationshipsFromTags(role.Tags),
+              },
+            };
+          }
 
-          roleResources.push(roleEntity);
+          roleResources.push(entity);
         }
       }
     }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.example.yaml.njs
@@ -1,9 +1,9 @@
 kind: User
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ user.UserId | to_entity_name }}
+  name: {{ data.UserId | to_entity_name }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ user.Arn }}
+    amazon.com/eks-cluster-arn: {{ data.Arn }}
     kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ user.UserName }}
-  title: {{ user.UserName }}
+    kubernetes.io/x-k8s-aws-id: {{ data.UserName }}
+  title: {{ data.UserName }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.example.yaml.njs
@@ -1,12 +1,9 @@
-kind: Resource
+kind: User
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ user.UserId | to_entity_name }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    amazon.com/eks-cluster-arn: {{ user.Arn }}
     kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    kubernetes.io/x-k8s-aws-id: {{ user.UserName }}
+  title: {{ user.UserName }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.test.ts
@@ -22,7 +22,6 @@ import { createLogger, transports } from 'winston';
 import { AWSIAMUserProvider } from './AWSIAMUserProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.test.ts
@@ -22,6 +22,9 @@ import { createLogger, transports } from 'winston';
 import { AWSIAMUserProvider } from './AWSIAMUserProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const iam = mockClient(IAM);
 const sts = mockClient(STS);
@@ -76,11 +79,41 @@ describe('AWSIAMUserProvider', () => {
       });
     });
 
+    it('creates aws users with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(dirname(__filename), './AWSIAMUserProvider.example.yaml.njs'),
+      ).toString();
+      const provider = AWSIAMUserProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'User',
+              metadata: expect.objectContaining({
+                title: 'adsf',
+              }),
+            }),
+          }),
+        ],
+      });
+    });
+
     it('creates aws users', async () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
         refresh: jest.fn(),
       };
+
       const provider = AWSIAMUserProvider.fromConfig(config, { logger });
       provider.connect(entityProviderConnection);
       await provider.run();

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
@@ -98,7 +98,7 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
           const consoleLink = new ARN(user.Arn).consoleLink;
           let entity: Entity | undefined = this.renderEntity(
             { data: user },
-            { defaultAnnotations },
+            { defaultAnnotations: await defaultAnnotations },
           );
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, UserEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { IAM, paginateListUsers } from '@aws-sdk/client-iam';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -36,6 +36,7 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -77,7 +78,7 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
 
     const { accountId } = this.getParsedConfig(dynamicAccountConfig);
     this.logger.info(`Providing IAM user resources from AWS: ${accountId}`);
-    const userResources: UserEntity[] = [];
+    const userResources: Entity[] = [];
 
     const defaultAnnotations =
       this.buildDefaultAnnotations(dynamicAccountConfig);
@@ -95,29 +96,32 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
       for (const user of userPage.Users || []) {
         if (user.UserName && user.Arn && user.UserId) {
           const consoleLink = new ARN(user.Arn).consoleLink;
-          const userEntity: UserEntity = {
-            kind: 'User',
-            apiVersion: 'backstage.io/v1alpha1',
-            metadata: {
-              annotations: {
-                ...(await defaultAnnotations),
-                [ANNOTATION_AWS_IAM_USER_ARN]: user.Arn,
-                [ANNOTATION_VIEW_URL]: consoleLink.toString(),
+          let entity: Entity | undefined = this.renderEntity({ user });
+          if (!entity) {
+            entity = {
+              kind: 'User',
+              apiVersion: 'backstage.io/v1alpha1',
+              metadata: {
+                annotations: {
+                  ...(await defaultAnnotations),
+                  [ANNOTATION_AWS_IAM_USER_ARN]: user.Arn,
+                  [ANNOTATION_VIEW_URL]: consoleLink.toString(),
+                },
+                name: arnToName(user.Arn),
+                title: user.UserName,
+                labels: this.labelsFromTags(user.Tags),
               },
-              name: arnToName(user.Arn),
-              title: user.UserName,
-              labels: this.labelsFromTags(user.Tags),
-            },
-            spec: {
-              profile: {
-                displayName: user.Arn,
-                email: user.UserName,
+              spec: {
+                profile: {
+                  displayName: user.Arn,
+                  email: user.UserName,
+                },
+                memberOf: [],
               },
-              memberOf: [],
-            },
-          };
+            };
+          }
 
-          userResources.push(userEntity);
+          userResources.push(entity);
         }
       }
     }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSIAMUserProvider.ts
@@ -96,7 +96,10 @@ export class AWSIAMUserProvider extends AWSEntityProvider {
       for (const user of userPage.Users || []) {
         if (user.UserName && user.Arn && user.UserId) {
           const consoleLink = new ARN(user.Arn).consoleLink;
-          let entity: Entity | undefined = this.renderEntity({ user });
+          let entity: Entity | undefined = this.renderEntity(
+            { data: user },
+            { defaultAnnotations },
+          );
           if (!entity) {
             entity = {
               kind: 'User',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.example.yaml.njs
@@ -1,8 +1,8 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ lambdaFunction.FunctionArn | to_entity_name }}
+  name: {{ data.FunctionArn | to_entity_name }}
   annotations:
-    amazon.com/lambda-function-arn: {{ lambdaFunction.FunctionArn }}
-    backstage.io/view-url: "https://{{ region }}.console.aws.amazon.com/lambda/home?region={{ region }}#/functions/{{ lambdaFunction.FunctionName }}"
-  title: {{ lambdaFunction.FunctionName }}
+    amazon.com/lambda-function-arn: {{ data.FunctionArn }}
+    backstage.io/view-url: "https://{{ region }}.console.aws.amazon.com/lambda/home?region={{ region }}#/functions/{{ data.FunctionName }}"
+  title: {{ data.FunctionName }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.example.yaml.njs
@@ -1,12 +1,8 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ lambdaFunction.FunctionArn | to_entity_name }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    amazon.com/lambda-function-arn: {{ lambdaFunction.FunctionArn }}
+    backstage.io/view-url: "https://{{ region }}.console.aws.amazon.com/lambda/home?region={{ region }}#/functions/{{ lambdaFunction.FunctionName }}"
+  title: {{ lambdaFunction.FunctionName }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.test.ts
@@ -127,8 +127,6 @@ describe('AWSLambdaFunctionProvider', () => {
               kind: 'Resource',
               metadata: expect.objectContaining({
                 annotations: {
-                  'amazon.com/iam-role-arn':
-                    'arn:aws:iam::123456789012:role/lambdaRole',
                   'amazon.com/lambda-function-arn':
                     'arn:aws:lambda:eu-west-1:123456789012:function:my-function',
                   'backstage.io/managed-by-location':
@@ -139,13 +137,7 @@ describe('AWSLambdaFunctionProvider', () => {
                     'https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/my-function',
                 },
                 title: 'my-function',
-                architectures: ['x86_64'],
-                description: '',
-                ephemeralStorage: 512,
-                memorySize: 1024,
                 name: 'bc6fa48d05a0a464c5e2a5214985bd957578cd50314fc6076cef1845fadb3c8',
-                runtime: 'nodejs14.x',
-                timeout: 30,
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.test.ts
@@ -26,6 +26,8 @@ import { createLogger, transports } from 'winston';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSLambdaFunctionProvider } from './AWSLambdaFunctionProvider';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const lambda = mockClient(Lambda);
 const sts = mockClient(STS);
@@ -100,11 +102,63 @@ describe('AWSLambdaFunctionProvider', () => {
       });
     });
 
+    it('creates aws functions with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(
+          dirname(__filename),
+          './AWSLambdaFunctionProvider.example.yaml.njs',
+        ),
+      ).toString();
+      const provider = AWSLambdaFunctionProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              metadata: expect.objectContaining({
+                annotations: {
+                  'amazon.com/iam-role-arn':
+                    'arn:aws:iam::123456789012:role/lambdaRole',
+                  'amazon.com/lambda-function-arn':
+                    'arn:aws:lambda:eu-west-1:123456789012:function:my-function',
+                  'backstage.io/managed-by-location':
+                    'aws-lambda-function-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-lambda-function-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/view-url':
+                    'https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/my-function',
+                },
+                title: 'my-function',
+                architectures: ['x86_64'],
+                description: '',
+                ephemeralStorage: 512,
+                memorySize: 1024,
+                name: 'bc6fa48d05a0a464c5e2a5214985bd957578cd50314fc6076cef1845fadb3c8',
+                runtime: 'nodejs14.x',
+                timeout: 30,
+              }),
+            }),
+          }),
+        ],
+      });
+    });
+
     it('creates aws functions', async () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
         refresh: jest.fn(),
       };
+
       const provider = AWSLambdaFunctionProvider.fromConfig(config, { logger });
       provider.connect(entityProviderConnection);
       await provider.run();

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
@@ -139,7 +139,7 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
 
           const entity: Entity | undefined = this.renderEntity(
             {
-              lambdaFunction,
+              data: lambdaFunction,
             },
             { defaultAnnotations: await defaultAnnotations },
           );

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
@@ -139,7 +139,7 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
 
           const entity: Entity | undefined = this.renderEntity({
             lambdaFunction,
-          });
+          }, { defaultAnnotations: await defaultAnnotations });
           if (entity) {
             lambdaComponents.push(entity);
           } else {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
@@ -137,9 +137,12 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
             )}`,
           );
 
-          const entity: Entity | undefined = this.renderEntity({
-            lambdaFunction,
-          }, { defaultAnnotations: await defaultAnnotations });
+          const entity: Entity | undefined = this.renderEntity(
+            {
+              lambdaFunction,
+            },
+            { defaultAnnotations: await defaultAnnotations },
+          );
           if (entity) {
             lambdaComponents.push(entity);
           } else {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLambdaFunctionProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { Lambda, paginateListFunctions } from '@aws-sdk/client-lambda';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -43,6 +43,7 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -89,7 +90,7 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
       `Providing lambda function resources from AWS: ${accountId}`,
     );
 
-    const lambdaComponents: ResourceEntity[] = [];
+    const lambdaComponents: Entity[] = [];
 
     const lambda = await this.getLambda(dynamicAccountConfig);
 
@@ -136,27 +137,34 @@ export class AWSLambdaFunctionProvider extends AWSEntityProvider {
             )}`,
           );
 
-          lambdaComponents.push({
-            kind: 'Resource',
-            apiVersion: 'backstage.io/v1beta1',
-            metadata: {
-              annotations,
-              name: arnToName(lambdaFunction.FunctionArn),
-              title: lambdaFunction.FunctionName,
-              description: lambdaFunction.Description,
-              runtime: lambdaFunction.Runtime,
-              memorySize: lambdaFunction.MemorySize,
-              ephemeralStorage: lambdaFunction.EphemeralStorage?.Size,
-              timeout: lambdaFunction.Timeout,
-              architectures: lambdaFunction.Architectures,
-              labels: this.labelsFromTags(tags),
-            },
-            spec: {
-              owner: owner,
-              ...relationships,
-              type: 'lambda-function',
-            },
+          const entity: Entity | undefined = this.renderEntity({
+            lambdaFunction,
           });
+          if (entity) {
+            lambdaComponents.push(entity);
+          } else {
+            lambdaComponents.push({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              metadata: {
+                annotations,
+                name: arnToName(lambdaFunction.FunctionArn),
+                title: lambdaFunction.FunctionName,
+                description: lambdaFunction.Description,
+                runtime: lambdaFunction.Runtime,
+                memorySize: lambdaFunction.MemorySize,
+                ephemeralStorage: lambdaFunction.EphemeralStorage?.Size,
+                timeout: lambdaFunction.Timeout,
+                architectures: lambdaFunction.Architectures,
+                labels: this.labelsFromTags(tags),
+              },
+              spec: {
+                owner: owner,
+                ...relationships,
+                type: 'lambda-function',
+              },
+            });
+          }
         }
       }
     }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.example.yaml.njs
@@ -1,12 +1,16 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    amazonaws.com/load-balancer-arn: {{ loadBalancer.LoadBalancerArn }}
+    amazonaws.com/load-balancer-dns-name: {{ loadBalancer.DNSName }}
+    backstage.io/view-url: https://{{ region }}.console.aws.amazon.com/ec2/home?region={{ region }}#LoadBalancers:loadBalancerId={{ loadBalancer.LoadBalancerId }};sort=loadBalancerName
+  title: {{ loadBalancer.LoadBalancerName }}
+  name: {{ loadBalancer.LoadBalancerName }}
+  dnsName: {{ loadBalancer.DNSName }}
+  scheme: {{ loadBalancer.Scheme }}
+  type: {{ loadBalancer.Type }}
+  state: {{ loadBalancer.State.Code }}
+  vpcId: {{ loadBalancer.VpcId }}
+spec:
+  type: load-balancer

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.example.yaml.njs
@@ -2,15 +2,15 @@ kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
   annotations:
-    amazonaws.com/load-balancer-arn: {{ loadBalancer.LoadBalancerArn }}
-    amazonaws.com/load-balancer-dns-name: {{ loadBalancer.DNSName }}
-    backstage.io/view-url: https://{{ region }}.console.aws.amazon.com/ec2/home?region={{ region }}#LoadBalancers:loadBalancerId={{ loadBalancer.LoadBalancerId }};sort=loadBalancerName
-  title: {{ loadBalancer.LoadBalancerName }}
-  name: {{ loadBalancer.LoadBalancerName }}
-  dnsName: {{ loadBalancer.DNSName }}
-  scheme: {{ loadBalancer.Scheme }}
-  type: {{ loadBalancer.Type }}
-  state: {{ loadBalancer.State.Code }}
-  vpcId: {{ loadBalancer.VpcId }}
+    amazonaws.com/load-balancer-arn: {{ data.LoadBalancerArn }}
+    amazonaws.com/load-balancer-dns-name: {{ data.DNSName }}
+    backstage.io/view-url: https://{{ region }}.console.aws.amazon.com/ec2/home?region={{ region }}#LoadBalancers:loadBalancerId={{ data.LoadBalancerId }};sort=loadBalancerName
+  title: {{ data.LoadBalancerName }}
+  name: {{ data.LoadBalancerName }}
+  dnsName: {{ data.DNSName }}
+  scheme: {{ data.Scheme }}
+  type: {{ data.Type }}
+  state: {{ data.State.Code }}
+  vpcId: {{ data.VpcId }}
 spec:
   type: load-balancer

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.test.ts
@@ -139,7 +139,6 @@ describe('AWSLoadBalancerProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'load-balancer',
               },
               metadata: expect.objectContaining({
@@ -151,10 +150,6 @@ describe('AWSLoadBalancerProvider', () => {
                 vpcId: 'vpc-12345678',
                 type: 'application',
                 state: 'active',
-                availabilityZones: 'eu-west-1a, eu-west-1b',
-                labels: {
-                  Environment: 'production--staging',
-                },
                 annotations: expect.objectContaining({
                   'amazonaws.com/load-balancer-arn':
                     'arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188',
@@ -164,8 +159,6 @@ describe('AWSLoadBalancerProvider', () => {
                     'aws-load-balancer-provider-0:arn:aws:iam::123456789012:role/role1',
                   'backstage.io/managed-by-origin-location':
                     'aws-load-balancer-provider-0:arn:aws:iam::123456789012:role/role1',
-                  'backstage.io/view-url':
-                    'https://eu-west-1.console.aws.amazon.com/ec2/home?region=eu-west-1#LoadBalancers:loadBalancerId=50dc6c495c0c9188;sort=loadBalancerName',
                 }),
               }),
             }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.test.ts
@@ -27,6 +27,8 @@ import { createLogger, transports } from 'winston';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSLoadBalancerProvider } from './AWSLoadBalancerProvider';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const elbv2 = mockClient(ElasticLoadBalancingV2Client as any);
 const sts = mockClient(STS as any);
@@ -112,6 +114,64 @@ describe('AWSLoadBalancerProvider', () => {
         ],
         $metadata: {},
       } as DescribeTagsCommandOutput);
+    });
+
+    it('creates load balancer with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(dirname(__filename), './AWSLoadBalancerProvider.example.yaml.njs'),
+      ).toString();
+      const provider = AWSLoadBalancerProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            locationKey: 'aws-load-balancer-provider-0',
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              spec: {
+                owner: 'unknown',
+                type: 'load-balancer',
+              },
+              metadata: expect.objectContaining({
+                name: 'my-load-balancer',
+                title: 'my-load-balancer',
+                dnsName:
+                  'my-load-balancer-1234567890.eu-west-1.elb.amazonaws.com',
+                scheme: 'internet-facing',
+                vpcId: 'vpc-12345678',
+                type: 'application',
+                state: 'active',
+                availabilityZones: 'eu-west-1a, eu-west-1b',
+                labels: {
+                  Environment: 'production--staging',
+                },
+                annotations: expect.objectContaining({
+                  'amazonaws.com/load-balancer-arn':
+                    'arn:aws:elasticloadbalancing:eu-west-1:123456789012:loadbalancer/app/my-load-balancer/50dc6c495c0c9188',
+                  'amazonaws.com/load-balancer-dns-name':
+                    'my-load-balancer-1234567890.eu-west-1.elb.amazonaws.com',
+                  'backstage.io/managed-by-location':
+                    'aws-load-balancer-provider-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-load-balancer-provider-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/view-url':
+                    'https://eu-west-1.console.aws.amazon.com/ec2/home?region=eu-west-1#LoadBalancers:loadBalancerId=50dc6c495c0c9188;sort=loadBalancerName',
+                }),
+              }),
+            }),
+          }),
+        ],
+      });
     });
 
     it('creates load balancer', async () => {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
@@ -132,7 +132,7 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
 
       const consoleLink = createElbLink(region, loadBalancerId);
       let entity: Entity | undefined = this.renderEntity(
-        { data: lb, tags },
+        { data: lb, tags: tagMap },
         { defaultAnnotations },
       );
       if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
@@ -16,7 +16,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   ElasticLoadBalancingV2Client,
@@ -48,6 +48,7 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -93,7 +94,7 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
     this.logger.info(
       `Providing load balancer resources from aws: ${accountId}`,
     );
-    const lbResources: ResourceEntity[] = [];
+    const lbResources: Entity[] = [];
 
     const elbv2 = await this.getElbv2Client(dynamicAccountConfig);
     const defaultAnnotations = await this.buildDefaultAnnotations(
@@ -130,40 +131,42 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
       const loadBalancerId = resourceParts[3];
 
       const consoleLink = createElbLink(region, loadBalancerId);
-
-      const resource: ResourceEntity = {
-        kind: 'Resource',
-        apiVersion: 'backstage.io/v1beta1',
-        metadata: {
-          annotations: {
-            ...defaultAnnotations,
-            [ANNOTATION_VIEW_URL]: consoleLink,
-            [ANNOTATION_LOAD_BALANCER_ARN]: loadBalancerArn,
-            [ANNOTATION_LOAD_BALANCER_DNS_NAME]: lb.DNSName || 'unknown',
+      let entity: Entity | undefined = this.renderEntity({ loadBalancer: lb });
+      if (!entity) {
+        entity = {
+          kind: 'Resource',
+          apiVersion: 'backstage.io/v1beta1',
+          metadata: {
+            annotations: {
+              ...defaultAnnotations,
+              [ANNOTATION_VIEW_URL]: consoleLink,
+              [ANNOTATION_LOAD_BALANCER_ARN]: loadBalancerArn,
+              [ANNOTATION_LOAD_BALANCER_DNS_NAME]: lb.DNSName || 'unknown',
+            },
+            labels: this.labelsFromTags(tags),
+            name:
+              lb.LoadBalancerName ||
+              loadBalancerArn.split('/').pop() ||
+              'unknown',
+            title: tagMap.Name || lb.LoadBalancerName,
+            dnsName: lb.DNSName,
+            scheme: lb.Scheme,
+            vpcId: lb.VpcId,
+            type: lb.Type,
+            state: lb.State?.Code,
+            availabilityZones: lb.AvailabilityZones?.map(
+              az => az.ZoneName,
+            ).join(', '),
           },
-          labels: this.labelsFromTags(tags),
-          name:
-            lb.LoadBalancerName ||
-            loadBalancerArn.split('/').pop() ||
-            'unknown',
-          title: tagMap.Name || lb.LoadBalancerName,
-          dnsName: lb.DNSName,
-          scheme: lb.Scheme,
-          vpcId: lb.VpcId,
-          type: lb.Type,
-          state: lb.State?.Code,
-          availabilityZones: lb.AvailabilityZones?.map(az => az.ZoneName).join(
-            ', ',
-          ),
-        },
-        spec: {
-          owner: ownerFromTags(tags, this.getOwnerTag(), groups),
-          ...relationshipsFromTags(tags),
-          type: 'load-balancer',
-        },
-      };
+          spec: {
+            owner: ownerFromTags(tags, this.getOwnerTag(), groups),
+            ...relationshipsFromTags(tags),
+            type: 'load-balancer',
+          },
+        };
+      }
 
-      lbResources.push(resource);
+      lbResources.push(entity);
     }
 
     await this.connection.applyMutation({

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
@@ -131,7 +131,10 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
       const loadBalancerId = resourceParts[3];
 
       const consoleLink = createElbLink(region, loadBalancerId);
-      let entity: Entity | undefined = this.renderEntity({ loadBalancer: lb, tags }, { defaultAnnotations });
+      let entity: Entity | undefined = this.renderEntity(
+        { loadBalancer: lb, tags },
+        { defaultAnnotations },
+      );
       if (!entity) {
         entity = {
           kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
@@ -131,7 +131,7 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
       const loadBalancerId = resourceParts[3];
 
       const consoleLink = createElbLink(region, loadBalancerId);
-      let entity: Entity | undefined = this.renderEntity({ loadBalancer: lb });
+      let entity: Entity | undefined = this.renderEntity({ loadBalancer: lb, tags }, { defaultAnnotations });
       if (!entity) {
         entity = {
           kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSLoadBalancerProvider.ts
@@ -132,7 +132,7 @@ export class AWSLoadBalancerProvider extends AWSEntityProvider {
 
       const consoleLink = createElbLink(region, loadBalancerId);
       let entity: Entity | undefined = this.renderEntity(
-        { loadBalancer: lb, tags },
+        { data: lb, tags },
         { defaultAnnotations },
       );
       if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.example.yaml.njs
@@ -1,12 +1,12 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ domain.DomainStatus.DomainName }}
+  name: {{ data.DomainStatus.DomainName }}
   annotations:
-    amazon.com/open-search-domain-arn: {{ domain.DomainStatus.ARN }}
-  title: {{ domain.DomainStatus.DomainName }}
-  storageType: EBS-{{ domain.DomainStatus.EBSOptions.VolumeType }}
-  endpoint: {{ domain.DomainStatus.Endpoint }}
-  engineVersion: {{ domain.DomainStatus.EngineVersion }}
+    amazon.com/open-search-domain-arn: {{ data.DomainStatus.ARN }}
+  title: {{ data.DomainStatus.DomainName }}
+  storageType: EBS-{{ data.DomainStatus.EBSOptions.VolumeType }}
+  endpoint: {{ data.DomainStatus.Endpoint }}
+  engineVersion: {{ data.DomainStatus.EngineVersion }}
 spec:
   type: opensearch-domain

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.example.yaml.njs
@@ -1,12 +1,12 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ domain.DomainStatus.DomainName }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    amazon.com/open-search-domain-arn: {{ domain.DomainStatus.ARN }}
+  title: {{ domain.DomainStatus.DomainName }}
+  storageType: EBS-{{ domain.DomainStatus.EBSOptions.VolumeType }}
+  endpoint: {{ domain.DomainStatus.Endpoint }}
+  engineVersion: {{ domain.DomainStatus.EngineVersion }}
+spec:
+  type: opensearch-domain

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.test.ts
@@ -144,15 +144,11 @@ describe('AWSOpenSearchEntityProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'opensearch-domain',
               },
               metadata: expect.objectContaining({
                 name: 'my-search-domain',
                 title: 'my-search-domain',
-                labels: {
-                  'aws-opensearch-region': 'eu-west-1',
-                },
                 annotations: expect.objectContaining({
                   [ANNOTATION_AWS_OPEN_SEARCH_ARN]:
                     'arn:aws:es:eu-west-1:123456789012:domain/my-search-domain',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.test.ts
@@ -30,6 +30,8 @@ import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSOpenSearchEntityProvider } from './AWSOpenSearchEntityProvider';
 import { ANNOTATION_AWS_OPEN_SEARCH_ARN } from '../annotations';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 // @ts-ignore
 const opensearch = mockClient(OpenSearch);
@@ -116,6 +118,59 @@ describe('AWSOpenSearchEntityProvider', () => {
       } as ListTagsCommandOutput);
     });
 
+    it('creates domain with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(
+          dirname(__filename),
+          './AWSOpenSearchEntityProvider.example.yaml.njs',
+        ),
+      ).toString();
+      const provider = AWSOpenSearchEntityProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            locationKey: 'aws-opensearch-domain-0',
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              spec: {
+                owner: 'unknown',
+                type: 'opensearch-domain',
+              },
+              metadata: expect.objectContaining({
+                name: 'my-search-domain',
+                title: 'my-search-domain',
+                labels: {
+                  'aws-opensearch-region': 'eu-west-1',
+                },
+                annotations: expect.objectContaining({
+                  [ANNOTATION_AWS_OPEN_SEARCH_ARN]:
+                    'arn:aws:es:eu-west-1:123456789012:domain/my-search-domain',
+                  'backstage.io/managed-by-location':
+                    'aws-opensearch-domain-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-opensearch-domain-0:arn:aws:iam::123456789012:role/role1',
+                }),
+                endpoint:
+                  'search-my-search-domain-abc123.eu-west-1.es.amazonaws.com',
+                engineVersion: 'OpenSearch_2.3',
+                storageType: 'EBS-gp3',
+              }),
+            }),
+          }),
+        ],
+      });
+    });
     it('creates domain', async () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.ts
@@ -134,7 +134,7 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
           ? `EBS-${domainStatus.EBSOptions.VolumeType}`
           : 'Instance Storage';
 
-        let entity = this.renderEntity({ domain });
+        let entity = this.renderEntity({ domain }, { defaultAnnotations });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.ts
@@ -134,7 +134,10 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
           ? `EBS-${domainStatus.EBSOptions.VolumeType}`
           : 'Instance Storage';
 
-        let entity = this.renderEntity({ domain }, { defaultAnnotations });
+        let entity = this.renderEntity(
+          { data: domain },
+          { defaultAnnotations },
+        );
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOpenSearchEntityProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ResourceEntity } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { OpenSearch } from '@aws-sdk/client-opensearch';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -40,6 +40,7 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -63,6 +64,7 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
     account: AccountConfig,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -100,7 +102,7 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
     this.logger.info(
       `Providing OpenSearch domain resources from AWS: ${accountId}`,
     );
-    const opensearchResources: ResourceEntity[] = [];
+    const opensearchEntities: Entity[] = [];
 
     const openSearchClient = await this.getOpenSearchClient(
       dynamicAccountConfig,
@@ -114,14 +116,13 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
     const domainList = await openSearchClient.listDomainNames();
 
     if (domainList.DomainNames) {
-      for (const domain of domainList.DomainNames) {
-        const domainName = domain.DomainName || 'unknown';
-
-        const domainDetails = await openSearchClient.describeDomain({
+      for (const {
+        DomainName: domainName = 'unknown',
+      } of domainList.DomainNames) {
+        const domain = await openSearchClient.describeDomain({
           DomainName: domainName,
         });
-
-        const domainStatus = domainDetails.DomainStatus;
+        const domainStatus = domain.DomainStatus;
         const domainArn = domainStatus?.ARN;
         const tags = domainArn
           ? await openSearchClient.listTags({ ARN: domainArn })
@@ -133,44 +134,47 @@ export class AWSOpenSearchEntityProvider extends AWSEntityProvider {
           ? `EBS-${domainStatus.EBSOptions.VolumeType}`
           : 'Instance Storage';
 
-        const resource: ResourceEntity = {
-          kind: 'Resource',
-          apiVersion: 'backstage.io/v1beta1',
-          metadata: {
-            name: domainName.toLowerCase().replace(/[^a-zA-Z0-9\-]/g, '-'),
-            title: domainName,
-            annotations: {
-              ...defaultAnnotations,
-              [ANNOTATION_AWS_OPEN_SEARCH_ARN]: domainArn ?? '',
+        let entity = this.renderEntity({ domain });
+        if (!entity) {
+          entity = {
+            kind: 'Resource',
+            apiVersion: 'backstage.io/v1beta1',
+            metadata: {
+              name: domainName.toLowerCase().replace(/[^a-zA-Z0-9\-]/g, '-'),
+              title: domainName,
+              annotations: {
+                ...defaultAnnotations,
+                [ANNOTATION_AWS_OPEN_SEARCH_ARN]: domainArn ?? '',
+              },
+              labels: {
+                'aws-opensearch-region': this.region,
+              },
+              endpoint,
+              engineVersion,
+              storageType,
             },
-            labels: {
-              'aws-opensearch-region': this.region,
+            spec: {
+              owner: ownerFromTags(tags?.TagList || [], this.getOwnerTag()),
+              ...relationshipsFromTags(tags?.TagList || []),
+              type: this.opensearchTypeValue,
             },
-            endpoint,
-            engineVersion,
-            storageType,
-          },
-          spec: {
-            owner: ownerFromTags(tags?.TagList || [], this.getOwnerTag()),
-            ...relationshipsFromTags(tags?.TagList || []),
-            type: this.opensearchTypeValue,
-          },
-        };
+          };
+        }
 
-        opensearchResources.push(resource);
+        opensearchEntities.push(entity);
       }
     }
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: opensearchResources.map(entity => ({
+      entities: opensearchEntities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),
     });
 
     this.logger.info(
-      `Finished providing ${opensearchResources.length} OpenSearch domain resources from AWS: ${accountId}`,
+      `Finished providing ${opensearchEntities.length} OpenSearch domain resources from AWS: ${accountId}`,
       { run_duration: duration(startTimestamp) },
     );
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.example.yaml.njs
@@ -1,10 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ account.Arn | to_entity_name }}
+  name: {{ data.Arn | to_entity_name }}
   annotations: {}
-  title: {{ account.Name }}
-  joinedMethod: {{ account.JoinedMethod}}
-  status: {{ account.Status}}
+  title: {{ data.Name }}
+  joinedMethod: {{ data.JoinedMethod}}
+  status: {{ data.Status}}
 spec:
   type: "aws-account"

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.example.yaml.njs
@@ -1,12 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
-  annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+  name: {{ account.Arn | to_entity_name }}
+  annotations: {}
+  title: {{ account.Name }}
+  joinedMethod: {{ account.JoinedMethod}}
+  status: {{ account.Status}}
+spec:
+  type: "aws-account"

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.test.ts
@@ -31,6 +31,8 @@ import {
   ANNOTATION_ACCOUNT_ID,
   ANNOTATION_AWS_ACCOUNT_ARN,
 } from '../annotations';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const organizations = mockClient(OrganizationsClient);
 const sts = mockClient(STS);
@@ -101,6 +103,60 @@ describe('AWSOrganizationAccountsProvider', () => {
         ],
         $metadata: {},
       } as ListTagsForResourceCommandOutput);
+    });
+
+    it('creates account with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(
+          dirname(__filename),
+          './AWSOrganizationAccountsProvider.example.yaml.njs',
+        ),
+      ).toString();
+      const provider = AWSOrganizationAccountsProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            locationKey: 'aws-organization-accounts-0',
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              spec: {
+                owner: 'unknown',
+                type: 'aws-account',
+              },
+              metadata: expect.objectContaining({
+                name: expect.any(String),
+                title: 'Test Account',
+                joinedTimestamp: '2023-01-01T00:00:00.000Z',
+                joinedMethod: 'INVITED',
+                status: 'ACTIVE',
+                labels: {
+                  Environment: 'production--staging',
+                },
+                annotations: expect.objectContaining({
+                  [ANNOTATION_AWS_ACCOUNT_ARN]:
+                    'arn:aws:organizations::123456789012:account/o-example123456/123456789012',
+                  [ANNOTATION_ACCOUNT_ID]: '123456789012',
+                  'backstage.io/managed-by-location':
+                    'aws-organization-accounts-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-organization-accounts-0:arn:aws:iam::123456789012:role/role1',
+                }),
+              }),
+            }),
+          }),
+        ],
+      });
     });
 
     it('creates account', async () => {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.test.ts
@@ -131,18 +131,13 @@ describe('AWSOrganizationAccountsProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'aws-account',
               },
               metadata: expect.objectContaining({
                 name: expect.any(String),
                 title: 'Test Account',
-                joinedTimestamp: '2023-01-01T00:00:00.000Z',
                 joinedMethod: 'INVITED',
                 status: 'ACTIVE',
-                labels: {
-                  Environment: 'production--staging',
-                },
                 annotations: expect.objectContaining({
                   [ANNOTATION_AWS_ACCOUNT_ARN]:
                     'arn:aws:organizations::123456789012:account/o-example123456/123456789012',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
@@ -131,7 +131,7 @@ export class AWSOrganizationAccountsProvider extends AWSEntityProvider {
           annotations[ANNOTATION_AWS_ACCOUNT_ARN] = account.Arn ?? '';
           annotations[ANNOTATION_ACCOUNT_ID] = account.Id ?? '';
 
-          let entity = this.renderEntity({ account });
+          let entity = this.renderEntity({ account, tags }, { defaultAnnotations: annotations });
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
@@ -132,7 +132,7 @@ export class AWSOrganizationAccountsProvider extends AWSEntityProvider {
           annotations[ANNOTATION_ACCOUNT_ID] = account.Id ?? '';
 
           let entity = this.renderEntity(
-            { account, tags },
+            { data: account, tags },
             { defaultAnnotations: annotations },
           );
           if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
@@ -131,7 +131,10 @@ export class AWSOrganizationAccountsProvider extends AWSEntityProvider {
           annotations[ANNOTATION_AWS_ACCOUNT_ARN] = account.Arn ?? '';
           annotations[ANNOTATION_ACCOUNT_ID] = account.Id ?? '';
 
-          let entity = this.renderEntity({ account, tags }, { defaultAnnotations: annotations });
+          let entity = this.renderEntity(
+            { account, tags },
+            { defaultAnnotations: annotations },
+          );
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSOrganizationAccountsProvider.ts
@@ -128,11 +128,18 @@ export class AWSOrganizationAccountsProvider extends AWSEntityProvider {
           for await (const listTagsForResourceCommandOutput of tagsResponse) {
             tags = tags.concat(listTagsForResourceCommandOutput.Tags ?? []);
           }
+
+          const tagMap = tags?.reduce((acc, tag) => {
+            if (tag.Key && tag.Value) {
+              acc[tag.Key] = tag.Value;
+            }
+            return acc;
+          }, {} as Record<string, string>);
           annotations[ANNOTATION_AWS_ACCOUNT_ARN] = account.Arn ?? '';
           annotations[ANNOTATION_ACCOUNT_ID] = account.Id ?? '';
 
           let entity = this.renderEntity(
-            { data: account, tags },
+            { data: account, tags: tagMap },
             { defaultAnnotations: annotations },
           );
           if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.example.yaml.njs
@@ -1,12 +1,11 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ dbInstance.DBInstanceIdentifier }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    amazon.com/rds-instance-arn: {{ dbInstance.DBInstanceArn }}
+    backstage.io/view-url: https://console.aws.amazon.com/rds/home?region={{ region }}#database:id={{ dbInstance.DBInstanceIdentifier }}
+  title: {{ dbInstance.DBInstanceIdentifier }}
+  dbInstanceClass: {{ dbInstance.DBInstanceClass }}
+spec:
+  type: rds-instance

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.example.yaml.njs
@@ -1,11 +1,11 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ dbInstance.DBInstanceIdentifier }}
+  name: {{ data.DBInstanceIdentifier }}
   annotations:
-    amazon.com/rds-instance-arn: {{ dbInstance.DBInstanceArn }}
-    backstage.io/view-url: https://console.aws.amazon.com/rds/home?region={{ region }}#database:id={{ dbInstance.DBInstanceIdentifier }}
-  title: {{ dbInstance.DBInstanceIdentifier }}
-  dbInstanceClass: {{ dbInstance.DBInstanceClass }}
+    amazon.com/rds-instance-arn: {{ data.DBInstanceArn }}
+    backstage.io/view-url: https://console.aws.amazon.com/rds/home?region={{ region }}#database:id={{ data.DBInstanceIdentifier }}
+  title: {{ data.DBInstanceIdentifier }}
+  dbInstanceClass: {{ data.DBInstanceClass }}
 spec:
   type: rds-instance

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.test.ts
@@ -22,6 +22,8 @@ import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSRDSProvider } from './AWSRDSProvider';
 import { ANNOTATION_AWS_RDS_INSTANCE_ARN } from '../annotations';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const rds = mockClient(RDS);
 const sts = mockClient(STS);
@@ -90,6 +92,64 @@ describe('AWSRDSProvider', () => {
               },
             ],
           },
+        ],
+      });
+    });
+
+    it('creates DB instance with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(dirname(__filename), './AWSRDSProvider.example.yaml.njs'),
+      ).toString();
+      const provider = AWSRDSProvider.fromConfig(config, { logger, template });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            locationKey: 'aws-rds-provider-0',
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              spec: {
+                owner: 'unknown',
+                type: 'rds-instance',
+              },
+              metadata: expect.objectContaining({
+                name: 'my-database-instance',
+                title: 'my-database-instance',
+                dbInstanceClass: 'db.t3.micro',
+                dbEngine: 'mysql',
+                dbEngineVersion: '8.0.35',
+                allocatedStorage: 20,
+                preferredMaintenanceWindow: 'sun:03:00-sun:04:00',
+                preferredBackupWindow: '02:00-03:00',
+                backupRetentionPeriod: 7,
+                isMultiAz: false,
+                automaticMinorVersionUpgrade: true,
+                isPubliclyAccessible: false,
+                storageType: 'gp2',
+                isPerformanceInsightsEnabled: false,
+                labels: {
+                  Environment: 'production--staging',
+                },
+                annotations: expect.objectContaining({
+                  [ANNOTATION_AWS_RDS_INSTANCE_ARN]:
+                    'arn:aws:rds:eu-west-1:123456789012:db:my-database-instance',
+                  'backstage.io/managed-by-location':
+                    'aws-rds-provider-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-rds-provider-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/view-url':
+                    'https://console.aws.amazon.com/rds/home?region=eu-west-1#database:id=my-database-instance',
+                }),
+              }),
+            }),
+          }),
         ],
       });
     });

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.test.ts
@@ -116,27 +116,12 @@ describe('AWSRDSProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'rds-instance',
               },
               metadata: expect.objectContaining({
                 name: 'my-database-instance',
                 title: 'my-database-instance',
                 dbInstanceClass: 'db.t3.micro',
-                dbEngine: 'mysql',
-                dbEngineVersion: '8.0.35',
-                allocatedStorage: 20,
-                preferredMaintenanceWindow: 'sun:03:00-sun:04:00',
-                preferredBackupWindow: '02:00-03:00',
-                backupRetentionPeriod: 7,
-                isMultiAz: false,
-                automaticMinorVersionUpgrade: true,
-                isPubliclyAccessible: false,
-                storageType: 'gp2',
-                isPerformanceInsightsEnabled: false,
-                labels: {
-                  Environment: 'production--staging',
-                },
                 annotations: expect.objectContaining({
                   [ANNOTATION_AWS_RDS_INSTANCE_ARN]:
                     'arn:aws:rds:eu-west-1:123456789012:db:my-database-instance',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
@@ -102,7 +102,7 @@ export class AWSRDSProvider extends AWSEntityProvider {
           const instanceId = dbInstance.DBInstanceIdentifier;
           const instanceArn = dbInstance.DBInstanceArn;
           const consoleLink = new ARN(dbInstance.DBInstanceArn).consoleLink;
-          let entity = this.renderEntity({ dbInstance });
+          let entity = this.renderEntity({ dbInstance }, { defaultAnnotations: await defaultAnnotations });
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { RDS, paginateDescribeDBInstances } from '@aws-sdk/client-rds';
 import type { Logger } from 'winston';
 import { Config } from '@backstage/config';
@@ -39,6 +39,7 @@ export class AWSRDSProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       useTemporaryCredentials?: boolean;
@@ -81,7 +82,7 @@ export class AWSRDSProvider extends AWSEntityProvider {
 
     const groups = await this.getGroups();
     this.logger.info(`Providing RDS resources from AWS: ${accountId}`);
-    const rdsResources: ResourceEntity[] = [];
+    const rdsEntities: Entity[] = [];
 
     const rdsClient = await this.getRdsClient(dynamicAccountConfig);
 
@@ -101,51 +102,56 @@ export class AWSRDSProvider extends AWSEntityProvider {
           const instanceId = dbInstance.DBInstanceIdentifier;
           const instanceArn = dbInstance.DBInstanceArn;
           const consoleLink = new ARN(dbInstance.DBInstanceArn).consoleLink;
-          const resource: ResourceEntity = {
-            kind: 'Resource',
-            apiVersion: 'backstage.io/v1beta1',
-            metadata: {
-              annotations: {
-                ...(await defaultAnnotations),
-                [ANNOTATION_VIEW_URL]: consoleLink,
-                [ANNOTATION_AWS_RDS_INSTANCE_ARN]: instanceArn,
+          let entity = this.renderEntity({ dbInstance });
+          if (!entity) {
+            entity = {
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              metadata: {
+                annotations: {
+                  ...(await defaultAnnotations),
+                  [ANNOTATION_VIEW_URL]: consoleLink,
+                  [ANNOTATION_AWS_RDS_INSTANCE_ARN]: instanceArn,
+                },
+                labels: this.labelsFromTags(dbInstance.TagList),
+                name: instanceId.substring(0, 62),
+                title: instanceId,
+                dbInstanceClass: dbInstance.DBInstanceClass,
+                dbEngine: dbInstance.Engine,
+                dbEngineVersion: dbInstance.EngineVersion,
+                allocatedStorage: dbInstance.AllocatedStorage,
+                preferredMaintenanceWindow:
+                  dbInstance.PreferredMaintenanceWindow,
+                preferredBackupWindow: dbInstance.PreferredBackupWindow,
+                backupRetentionPeriod: dbInstance.BackupRetentionPeriod,
+                isMultiAz: dbInstance.MultiAZ,
+                automaticMinorVersionUpgrade:
+                  dbInstance.AutoMinorVersionUpgrade,
+                isPubliclyAccessible: dbInstance.PubliclyAccessible,
+                storageType: dbInstance.StorageType,
+                isPerformanceInsightsEnabled:
+                  dbInstance.PerformanceInsightsEnabled,
               },
-              labels: this.labelsFromTags(dbInstance.TagList),
-              name: instanceId.substring(0, 62),
-              title: instanceId,
-              dbInstanceClass: dbInstance.DBInstanceClass,
-              dbEngine: dbInstance.Engine,
-              dbEngineVersion: dbInstance.EngineVersion,
-              allocatedStorage: dbInstance.AllocatedStorage,
-              preferredMaintenanceWindow: dbInstance.PreferredMaintenanceWindow,
-              preferredBackupWindow: dbInstance.PreferredBackupWindow,
-              backupRetentionPeriod: dbInstance.BackupRetentionPeriod,
-              isMultiAz: dbInstance.MultiAZ,
-              automaticMinorVersionUpgrade: dbInstance.AutoMinorVersionUpgrade,
-              isPubliclyAccessible: dbInstance.PubliclyAccessible,
-              storageType: dbInstance.StorageType,
-              isPerformanceInsightsEnabled:
-                dbInstance.PerformanceInsightsEnabled,
-            },
-            spec: {
-              owner: ownerFromTags(
-                dbInstance.TagList,
-                this.getOwnerTag(),
-                groups,
-              ),
-              ...relationshipsFromTags(dbInstance.TagList),
-              type: 'rds-instance',
-            },
-          };
+              spec: {
+                owner: ownerFromTags(
+                  dbInstance.TagList,
+                  this.getOwnerTag(),
+                  groups,
+                ),
+                ...relationshipsFromTags(dbInstance.TagList),
+                type: 'rds-instance',
+              },
+            };
+          }
 
-          rdsResources.push(resource);
+          rdsEntities.push(entity);
         }
       }
     }
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: rdsResources.map(entity => ({
+      entities: rdsEntities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
@@ -103,7 +103,7 @@ export class AWSRDSProvider extends AWSEntityProvider {
           const instanceArn = dbInstance.DBInstanceArn;
           const consoleLink = new ARN(dbInstance.DBInstanceArn).consoleLink;
           let entity = this.renderEntity(
-            { dbInstance },
+            { data: dbInstance },
             { defaultAnnotations: await defaultAnnotations },
           );
           if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSRDSProvider.ts
@@ -102,7 +102,10 @@ export class AWSRDSProvider extends AWSEntityProvider {
           const instanceId = dbInstance.DBInstanceIdentifier;
           const instanceArn = dbInstance.DBInstanceArn;
           const consoleLink = new ARN(dbInstance.DBInstanceArn).consoleLink;
-          let entity = this.renderEntity({ dbInstance }, { defaultAnnotations: await defaultAnnotations });
+          let entity = this.renderEntity(
+            { dbInstance },
+            { defaultAnnotations: await defaultAnnotations },
+          );
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.example.yaml.njs
@@ -1,10 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ bucket.Name | to_entity_name }}
+  name: {{ data.Name | to_entity_name }}
   annotations:
-    amazonaws.com/s3-bucket-arn: arn:aws:s3:::{{ bucket.Name }}
-  title: {{ bucket.Name }}
+    amazonaws.com/s3-bucket-arn: arn:aws:s3:::{{ data.Name }}
+  title: {{ data.Name }}
   labels:
     region: {{ region }}
     accountId: {{ accountId }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.example.yaml.njs
@@ -1,0 +1,13 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ bucket.Name | to_entity_name }}
+  annotations:
+    amazonaws.com/s3-bucket-arn: arn:aws:s3:::{{ bucket.Name }}
+  title: {{ bucket.Name }}
+  labels:
+    region: {{ region }}
+    accountId: {{ accountId }}
+spec:
+  type: s3-bucket
+  owner: unknown

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
@@ -107,7 +107,7 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
             bucket: bucket.Name,
           });
         }
-        let entity = this.renderEntity({ bucket });
+        let entity = this.renderEntity({ data: bucket });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSS3BucketProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { S3, Tag } from '@aws-sdk/client-s3';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -40,6 +40,7 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -82,7 +83,7 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing S3 bucket resources from AWS: ${accountId}`);
-    const s3Resources: ResourceEntity[] = [];
+    const s3Entities: Entity[] = [];
 
     const s3 = await this.getS3(dynamicAccountConfig);
 
@@ -106,40 +107,43 @@ export class AWSS3BucketProvider extends AWSEntityProvider {
             bucket: bucket.Name,
           });
         }
-        const resource: ResourceEntity = {
-          kind: 'Resource',
-          apiVersion: 'backstage.io/v1beta1',
-          metadata: {
-            annotations: {
-              ...(await defaultAnnotations),
-              [ANNOTATION_AWS_S3_BUCKET_ARN]: bucketArn,
-              [ANNOTATION_VIEW_URL]: consoleLink,
+        let entity = this.renderEntity({ bucket });
+        if (!entity) {
+          entity = {
+            kind: 'Resource',
+            apiVersion: 'backstage.io/v1beta1',
+            metadata: {
+              annotations: {
+                ...(await defaultAnnotations),
+                [ANNOTATION_AWS_S3_BUCKET_ARN]: bucketArn,
+                [ANNOTATION_VIEW_URL]: consoleLink,
+              },
+              name: arnToName(bucketArn),
+              title: bucket.Name,
+              labels: this.labelsFromTags(tags),
             },
-            name: arnToName(bucketArn),
-            title: bucket.Name,
-            labels: this.labelsFromTags(tags),
-          },
-          spec: {
-            owner: ownerFromTags(tags, this.getOwnerTag(), groups),
-            ...relationshipsFromTags(tags),
-            type: 's3-bucket',
-          },
-        };
+            spec: {
+              owner: ownerFromTags(tags, this.getOwnerTag(), groups),
+              ...relationshipsFromTags(tags),
+              type: 's3-bucket',
+            },
+          };
+        }
 
-        s3Resources.push(resource);
+        s3Entities.push(entity);
       }
     }
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: s3Resources.map(entity => ({
+      entities: s3Entities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),
     });
 
     this.logger.info(
-      `Finished providing ${s3Resources.length} S3 bucket resources from AWS: ${accountId}`,
+      `Finished providing ${s3Entities.length} S3 bucket resources from AWS: ${accountId}`,
       { run_duration: duration(startTimestamp) },
     );
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.example.yaml.njs
@@ -1,7 +1,7 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ topic.TopicArn | split(":") | last }}
+  name: {{ data.TopicArn | split(":") | last }}
   annotations:
-    backstage.io/view-url: "https://console.aws.amazon.com/sns/v3/home?region={{ region }}#/topic/{{ topic.TopicArn }}"
-  title: {{ topic.TopicArn | split(":") | last }}
+    backstage.io/view-url: "https://console.aws.amazon.com/sns/v3/home?region={{ region }}#/topic/{{ data.TopicArn }}"
+  title: {{ data.TopicArn | split(":") | last }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ topic.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ topic.arn }}
+    amazon.com/iam-role-arn: {{ topic.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ topic.name }}
+  title: {{ accountId }}:{{ region }}:{{ topic.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.example.yaml.njs
@@ -1,12 +1,7 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ topic.name | to_entity_name }}
+  name: {{ topic.TopicArn | split(":") | last }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ topic.arn }}
-    amazon.com/iam-role-arn: {{ topic.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ topic.name }}
-  title: {{ accountId }}:{{ region }}:{{ topic.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    backstage.io/view-url: "https://console.aws.amazon.com/sns/v3/home?region={{ region }}#/topic/{{ topic.TopicArn }}"
+  title: {{ topic.TopicArn | split(":") | last }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.test.ts
@@ -27,6 +27,9 @@ import { createLogger, transports } from 'winston';
 import { AWSSNSTopicProvider } from './AWSSNSTopicProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
+import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const sns = mockClient(SNS);
 const sts = mockClient(STS);
@@ -83,6 +86,40 @@ describe('AWSSNSTopicProvider', () => {
       });
       sns.on(ListTagsForResourceCommand).resolves({
         Tags: [],
+      });
+    });
+
+    it('creates SNS topic entities with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(dirname(__filename), './AWSSNSTopicProvider.example.yaml.njs'),
+      ).toString();
+      const provider = AWSSNSTopicProvider.fromConfig(config, {
+        logger,
+        template,
+      });
+      provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              metadata: expect.objectContaining({
+                name: 'example-topic',
+                title: 'example-topic',
+                annotations: expect.objectContaining({
+                  'backstage.io/view-url':
+                    'https://console.aws.amazon.com/sns/v3/home?region=eu-west-1#/topic/arn:aws:sns:eu-west-1:123456789012:example-topic',
+                }),
+              }),
+            }),
+          }),
+        ],
       });
     });
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.test.ts
@@ -27,7 +27,6 @@ import { createLogger, transports } from 'winston';
 import { AWSSNSTopicProvider } from './AWSSNSTopicProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { EntityProviderConnection } from '@backstage/plugin-catalog-backend';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
@@ -104,7 +104,10 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
           const tags = tagsResponse.Tags ?? [];
           const topicName = topic.TopicArn.split(':').pop() || 'unknown-topic';
           const consoleLink = new ARN(topic.TopicArn).consoleLink;
-          let entity = this.renderEntity({ topic }, { defaultAnnotations: await defaultAnnotations });
+          let entity = this.renderEntity(
+            { topic },
+            { defaultAnnotations: await defaultAnnotations },
+          );
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
@@ -105,7 +105,7 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
           const topicName = topic.TopicArn.split(':').pop() || 'unknown-topic';
           const consoleLink = new ARN(topic.TopicArn).consoleLink;
           let entity = this.renderEntity(
-            { topic },
+            { data: topic },
             { defaultAnnotations: await defaultAnnotations },
           );
           if (!entity) {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { SNS, paginateListTopics } from '@aws-sdk/client-sns';
 import type { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
@@ -39,6 +39,7 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -80,7 +81,7 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing SNS topic resources from AWS: ${accountId}`);
-    const topicResources: ResourceEntity[] = [];
+    const entities: Entity[] = [];
 
     const defaultAnnotations =
       this.buildDefaultAnnotations(dynamicAccountConfig);
@@ -103,41 +104,44 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
           const tags = tagsResponse.Tags ?? [];
           const topicName = topic.TopicArn.split(':').pop() || 'unknown-topic';
           const consoleLink = new ARN(topic.TopicArn).consoleLink;
-          const topicEntity: ResourceEntity = {
-            kind: 'Resource',
-            apiVersion: 'backstage.io/v1alpha1',
-            metadata: {
-              annotations: {
-                ...(await defaultAnnotations),
-                [ANNOTATION_AWS_SNS_TOPIC_ARN]: topic.TopicArn,
-                [ANNOTATION_VIEW_URL]: consoleLink.toString(),
+          let entity = this.renderEntity({ topic });
+          if (!entity) {
+            entity = {
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1alpha1',
+              metadata: {
+                annotations: {
+                  ...(await defaultAnnotations),
+                  [ANNOTATION_AWS_SNS_TOPIC_ARN]: topic.TopicArn,
+                  [ANNOTATION_VIEW_URL]: consoleLink.toString(),
+                },
+                name: topicName,
+                title: topicName,
+                labels: this.labelsFromTags(tags),
               },
-              name: topicName,
-              title: topicName,
-              labels: this.labelsFromTags(tags),
-            },
-            spec: {
-              type: 'aws-sns-topic',
-              owner: ownerFromTags(tags, this.getOwnerTag(), groups),
-              ...relationshipsFromTags(tags),
-            },
-          };
+              spec: {
+                type: 'aws-sns-topic',
+                owner: ownerFromTags(tags, this.getOwnerTag(), groups),
+                ...relationshipsFromTags(tags),
+              },
+            };
+          }
 
-          topicResources.push(topicEntity);
+          entities.push(entity);
         }
       }
     }
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: topicResources.map(entity => ({
+      entities: entities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),
     });
 
     this.logger.info(
-      `Finished providing ${topicResources.length} SNS topic resources from AWS: ${accountId}`,
+      `Finished providing ${entities.length} SNS topic resources from AWS: ${accountId}`,
       { run_duration: duration(startTimestamp) },
     );
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSNSTopicProvider.ts
@@ -104,7 +104,7 @@ export class AWSSNSTopicProvider extends AWSEntityProvider {
           const tags = tagsResponse.Tags ?? [];
           const topicName = topic.TopicArn.split(':').pop() || 'unknown-topic';
           const consoleLink = new ARN(topic.TopicArn).consoleLink;
-          let entity = this.renderEntity({ topic });
+          let entity = this.renderEntity({ topic }, { defaultAnnotations: await defaultAnnotations });
           if (!entity) {
             entity = {
               kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.example.yaml.njs
@@ -1,12 +1,12 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ queueAttributes.Attributes.QueueArn | split(":") | last }}
+  title: {{ queueAttributes.Attributes.QueueArn | split(":") | last }}
+  queueArn: {{ queueAttributes.Attributes.QueueArn }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+    amazon.com/sqs-queue-arn: {{ queueAttributes.Attributes.QueueArn }}
   labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    aws-sqs-region: {{ region }}
+spec:
+  type: 'sqs-queue'

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.example.yaml.njs
@@ -1,11 +1,11 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ queueAttributes.Attributes.QueueArn | split(":") | last }}
-  title: {{ queueAttributes.Attributes.QueueArn | split(":") | last }}
-  queueArn: {{ queueAttributes.Attributes.QueueArn }}
+  name: {{ data.Attributes.QueueArn | split(":") | last }}
+  title: {{ data.Attributes.QueueArn | split(":") | last }}
+  queueArn: {{ data.Attributes.QueueArn }}
   annotations:
-    amazon.com/sqs-queue-arn: {{ queueAttributes.Attributes.QueueArn }}
+    amazon.com/sqs-queue-arn: {{ data.Attributes.QueueArn }}
   labels:
     aws-sqs-region: {{ region }}
 spec:

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.test.ts
@@ -109,7 +109,7 @@ describe('AWSSQSEntityProvider', () => {
         refresh: jest.fn(),
       };
       const template = readFileSync(
-        join(dirname(__filename), './AWSSNSTopicProvider.example.yaml.njs'),
+        join(dirname(__filename), './AWSSQSEntityProvider.example.yaml.njs'),
       ).toString();
       const provider = AWSSQSEntityProvider.fromConfig(config, {
         logger,
@@ -126,7 +126,6 @@ describe('AWSSQSEntityProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'sqs-queue',
               },
               metadata: expect.objectContaining({
@@ -145,11 +144,6 @@ describe('AWSSQSEntityProvider', () => {
                 }),
                 queueArn:
                   'arn:aws:sqs:eu-west-1:123456789012:my-standard-queue',
-                visibilityTimeout: '30',
-                delaySeconds: '0',
-                maximumMessageSize: '262144',
-                retentionPeriod: '1209600',
-                approximateNumberOfMessages: '5',
               }),
             }),
           }),

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.ts
@@ -131,7 +131,7 @@ export class AWSSQSEntityProvider extends AWSEntityProvider {
           const approximateNumberOfMessages =
             attributes.Attributes?.ApproximateNumberOfMessages || '';
 
-          let entity = this.renderEntity({ queueAttributes: attributes });
+          let entity = this.renderEntity({ queueAttributes: attributes }, { defaultAnnotations });
 
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.ts
@@ -132,7 +132,7 @@ export class AWSSQSEntityProvider extends AWSEntityProvider {
             attributes.Attributes?.ApproximateNumberOfMessages || '';
 
           let entity = this.renderEntity(
-            { queueAttributes: attributes },
+            { data: attributes },
             { defaultAnnotations },
           );
 

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSQSEntityProvider.ts
@@ -131,7 +131,10 @@ export class AWSSQSEntityProvider extends AWSEntityProvider {
           const approximateNumberOfMessages =
             attributes.Attributes?.ApproximateNumberOfMessages || '';
 
-          let entity = this.renderEntity({ queueAttributes: attributes }, { defaultAnnotations });
+          let entity = this.renderEntity(
+            { queueAttributes: attributes },
+            { defaultAnnotations },
+          );
 
           if (!entity) {
             entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.example.yaml.njs
@@ -1,18 +1,18 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ securityGroup.GroupId }}
-  title: {{ securityGroup.GroupName }}
-  description: {{ securityGroup.Description }}
-  vpcId: {{ securityGroup.VpcId }}
-  groupName: {{ securityGroup.GroupName }}
+  name: {{ data.GroupId }}
+  title: {{ data.GroupName }}
+  description: {{ data.Description }}
+  vpcId: {{ data.VpcId }}
+  groupName: {{ data.GroupName }}
   ingressRules: tcp:80 from 0.0.0.0/0; tcp:443 from sg-87654321
   egressRules: All:All to 0.0.0.0/0
   labels:
     Environment: production--staging
   annotations:
-    amazonaws.com/security-group-id: {{ securityGroup.GroupId }}
-    backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#SecurityGroup:groupId={{ securityGroup.GroupId }}
+    amazonaws.com/security-group-id: {{ data.GroupId }}
+    backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#SecurityGroup:groupId={{ data.GroupId }}
 spec:
   owner: unknown
   type: security-group

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.example.yaml.njs
@@ -1,0 +1,18 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ securityGroup.GroupId }}
+  title: {{ securityGroup.GroupName }}
+  description: {{ securityGroup.Description }}
+  vpcId: {{ securityGroup.VpcId }}
+  groupName: {{ securityGroup.GroupName }}
+  ingressRules: tcp:80 from 0.0.0.0/0; tcp:443 from sg-87654321
+  egressRules: All:All to 0.0.0.0/0
+  labels:
+    Environment: production--staging
+  annotations:
+    amazonaws.com/security-group-id: {{ securityGroup.GroupId }}
+    backstage.io/view-url: https://eu-west-1.console.aws.amazon.com/ec2/v2/home?region=eu-west-1#SecurityGroup:groupId={{ securityGroup.GroupId }}
+spec:
+  owner: unknown
+  type: security-group

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
@@ -145,7 +145,10 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
             return `${protocol}:${portRange} to ${destinations || 'None'}`;
           }).join('; ') || 'None';
 
-        let entity = this.renderEntity({ securityGroup: sg }, { defaultAnnotations });
+        let entity = this.renderEntity(
+          { securityGroup: sg },
+          { defaultAnnotations },
+        );
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
@@ -145,7 +145,7 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
             return `${protocol}:${portRange} to ${destinations || 'None'}`;
           }).join('; ') || 'None';
 
-        let entity = this.renderEntity({ securityGroup: sg });
+        let entity = this.renderEntity({ securityGroup: sg }, { defaultAnnotations });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
@@ -145,10 +145,7 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
             return `${protocol}:${portRange} to ${destinations || 'None'}`;
           }).join('; ') || 'None';
 
-        let entity = this.renderEntity(
-          { securityGroup: sg },
-          { defaultAnnotations },
-        );
+        let entity = this.renderEntity({ data: sg }, { defaultAnnotations });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSecurityGroupProvider.ts
@@ -16,7 +16,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import type { Logger } from 'winston';
 import { EC2 } from '@aws-sdk/client-ec2';
@@ -41,6 +41,7 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -86,7 +87,7 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
     this.logger.info(
       `Providing security group resources from aws: ${accountId}`,
     );
-    const sgResources: ResourceEntity[] = [];
+    const entities: Entity[] = [];
 
     const ec2 = await this.getEc2(dynamicAccountConfig);
     const defaultAnnotations = await this.buildDefaultAnnotations(
@@ -144,35 +145,38 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
             return `${protocol}:${portRange} to ${destinations || 'None'}`;
           }).join('; ') || 'None';
 
-        const resource: ResourceEntity = {
-          kind: 'Resource',
-          apiVersion: 'backstage.io/v1beta1',
-          metadata: {
-            annotations: {
-              ...defaultAnnotations,
-              [ANNOTATION_VIEW_URL]: consoleLink,
-              [ANNOTATION_SECURITY_GROUP_ID]: securityGroupId,
+        let entity = this.renderEntity({ securityGroup: sg });
+        if (!entity) {
+          entity = {
+            kind: 'Resource',
+            apiVersion: 'backstage.io/v1beta1',
+            metadata: {
+              annotations: {
+                ...defaultAnnotations,
+                [ANNOTATION_VIEW_URL]: consoleLink,
+                [ANNOTATION_SECURITY_GROUP_ID]: securityGroupId,
+              },
+              labels: this.labelsFromTags(sg.Tags),
+              name: securityGroupId,
+              title:
+                sg.Tags?.find(tag => tag.Key === 'Name')?.Value ||
+                sg.GroupName ||
+                securityGroupId,
+              description: sg.Description,
+              vpcId: sg.VpcId,
+              groupName: sg.GroupName,
+              ingressRules: ingressRules,
+              egressRules: egressRules,
             },
-            labels: this.labelsFromTags(sg.Tags),
-            name: securityGroupId,
-            title:
-              sg.Tags?.find(tag => tag.Key === 'Name')?.Value ||
-              sg.GroupName ||
-              securityGroupId,
-            description: sg.Description,
-            vpcId: sg.VpcId,
-            groupName: sg.GroupName,
-            ingressRules: ingressRules,
-            egressRules: egressRules,
-          },
-          spec: {
-            owner: ownerFromTags(sg.Tags, this.getOwnerTag(), groups),
-            ...relationshipsFromTags(sg.Tags),
-            type: 'security-group',
-          },
-        };
+            spec: {
+              owner: ownerFromTags(sg.Tags, this.getOwnerTag(), groups),
+              ...relationshipsFromTags(sg.Tags),
+              type: 'security-group',
+            },
+          };
+        }
 
-        sgResources.push(resource);
+        entities.push(entity);
       }
 
       nextToken = securityGroups.NextToken;
@@ -180,14 +184,14 @@ export class AWSSecurityGroupProvider extends AWSEntityProvider {
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: sgResources.map(entity => ({
+      entities: entities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),
     });
 
     this.logger.info(
-      `Finished providing ${sgResources.length} Security Group resources from AWS: ${accountId} (processed ${pageCount} pages)`,
+      `Finished providing ${entities.length} Security Group resources from AWS: ${accountId} (processed ${pageCount} pages)`,
       { run_duration: duration(startTimestamp) },
     );
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.example.yaml.njs
@@ -1,16 +1,16 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ subnet.SubnetId }}
+  name: {{ data.SubnetId }}
   annotations:
-    amazonaws.com/subnet-id: {{ subnet.SubnetId }}
-    backstage.io/view-url: https://{{ region }}.console.aws.amazon.com/vpc/home?region={{ region }}#SubnetDetails:subnetId={{ subnet.SubnetId }}
-  vpcId: {{ subnet.VpcId }}
-  state: {{ subnet.State }}
-  defaultForAz: {{ subnet.DefaultForAz }}
-  cidrBlock: {{ subnet.CidrBlock }}
-  availableIpAddressCount: {{ subnet.AvailableIpAddressCount }}
-  availabilityZone: {{ subnet.AvailabilityZone }}
-  mapPublicIpOnLaunch: {{ subnet.MapPublicIpOnLaunch }}
+    amazonaws.com/subnet-id: {{ data.SubnetId }}
+    backstage.io/view-url: https://{{ region }}.console.aws.amazon.com/vpc/home?region={{ region }}#SubnetDetails:subnetId={{ data.SubnetId }}
+  vpcId: {{ data.VpcId }}
+  state: {{ data.State }}
+  defaultForAz: {{ data.DefaultForAz }}
+  cidrBlock: {{ data.CidrBlock }}
+  availableIpAddressCount: {{ data.AvailableIpAddressCount }}
+  availabilityZone: {{ data.AvailabilityZone }}
+  mapPublicIpOnLaunch: {{ data.MapPublicIpOnLaunch }}
   labels:
     Environment: production--staging

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.example.yaml.njs
@@ -1,12 +1,16 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ subnet.SubnetId }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+    amazonaws.com/subnet-id: {{ subnet.SubnetId }}
+    backstage.io/view-url: https://{{ region }}.console.aws.amazon.com/vpc/home?region={{ region }}#SubnetDetails:subnetId={{ subnet.SubnetId }}
+  vpcId: {{ subnet.VpcId }}
+  state: {{ subnet.State }}
+  defaultForAz: {{ subnet.DefaultForAz }}
+  cidrBlock: {{ subnet.CidrBlock }}
+  availableIpAddressCount: {{ subnet.AvailableIpAddressCount }}
+  availabilityZone: {{ subnet.AvailabilityZone }}
+  mapPublicIpOnLaunch: {{ subnet.MapPublicIpOnLaunch }}
   labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    Environment: production--staging

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.test.ts
@@ -117,18 +117,14 @@ describe('AWSSubnetProvider', () => {
             entity: expect.objectContaining({
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
-              spec: {
-                owner: 'unknown',
-                type: 'subnet',
-              },
               metadata: expect.objectContaining({
                 name: 'subnet-12345678',
                 cidrBlock: '10.0.1.0/24',
                 vpcId: 'vpc-12345678',
                 availabilityZone: 'eu-west-1a',
                 availableIpAddressCount: 251,
-                defaultForAz: 'No',
-                mapPublicIpOnLaunch: 'Yes',
+                defaultForAz: false,
+                mapPublicIpOnLaunch: true,
                 state: 'available',
                 labels: {
                   Environment: 'production--staging',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.ts
@@ -105,7 +105,10 @@ export class AWSSubnetProvider extends AWSEntityProvider {
         const arn = `arn:aws:ec2:${region}:${accountId}:subnet/${subnetId}`;
         const consoleLink = new ARN(arn).consoleLink;
 
-        let entity = this.renderEntity({ subnet }, { defaultAnnotations });
+        let entity = this.renderEntity(
+          { data: subnet },
+          { defaultAnnotations },
+        );
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.ts
@@ -16,7 +16,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import type { Logger } from 'winston';
 import { EC2 } from '@aws-sdk/client-ec2';
@@ -41,6 +41,7 @@ export class AWSSubnetProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -84,7 +85,7 @@ export class AWSSubnetProvider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing subnet resources from aws: ${accountId}`);
-    const subnetResources: ResourceEntity[] = [];
+    const entities: Entity[] = [];
 
     const ec2 = await this.getEc2(dynamicAccountConfig);
     const defaultAnnotations = await this.buildDefaultAnnotations(
@@ -104,33 +105,36 @@ export class AWSSubnetProvider extends AWSEntityProvider {
         const arn = `arn:aws:ec2:${region}:${accountId}:subnet/${subnetId}`;
         const consoleLink = new ARN(arn).consoleLink;
 
-        const resource: ResourceEntity = {
-          kind: 'Resource',
-          apiVersion: 'backstage.io/v1beta1',
-          metadata: {
-            annotations: {
-              ...defaultAnnotations,
-              [ANNOTATION_VIEW_URL]: consoleLink,
-              [ANNOTATION_SUBNET_ID]: subnetId,
+        let entity = this.renderEntity({ subnet });
+        if (!entity) {
+          entity = {
+            kind: 'Resource',
+            apiVersion: 'backstage.io/v1beta1',
+            metadata: {
+              annotations: {
+                ...defaultAnnotations,
+                [ANNOTATION_VIEW_URL]: consoleLink,
+                [ANNOTATION_SUBNET_ID]: subnetId,
+              },
+              labels: this.labelsFromTags(subnet.Tags),
+              name: subnetId,
+              cidrBlock: subnet.CidrBlock,
+              vpcId: subnet.VpcId,
+              availabilityZone: subnet.AvailabilityZone,
+              availableIpAddressCount: subnet.AvailableIpAddressCount,
+              defaultForAz: subnet.DefaultForAz ? 'Yes' : 'No',
+              mapPublicIpOnLaunch: subnet.MapPublicIpOnLaunch ? 'Yes' : 'No',
+              state: subnet.State,
             },
-            labels: this.labelsFromTags(subnet.Tags),
-            name: subnetId,
-            cidrBlock: subnet.CidrBlock,
-            vpcId: subnet.VpcId,
-            availabilityZone: subnet.AvailabilityZone,
-            availableIpAddressCount: subnet.AvailableIpAddressCount,
-            defaultForAz: subnet.DefaultForAz ? 'Yes' : 'No',
-            mapPublicIpOnLaunch: subnet.MapPublicIpOnLaunch ? 'Yes' : 'No',
-            state: subnet.State,
-          },
-          spec: {
-            owner: ownerFromTags(subnet.Tags, this.getOwnerTag(), groups),
-            ...relationshipsFromTags(subnet.Tags),
-            type: 'subnet',
-          },
-        };
+            spec: {
+              owner: ownerFromTags(subnet.Tags, this.getOwnerTag(), groups),
+              ...relationshipsFromTags(subnet.Tags),
+              type: 'subnet',
+            },
+          };
+        }
 
-        subnetResources.push(resource);
+        entities.push(entity);
       }
 
       nextToken = subnets.NextToken;
@@ -138,14 +142,14 @@ export class AWSSubnetProvider extends AWSEntityProvider {
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: subnetResources.map(entity => ({
+      entities: entities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),
     });
 
     this.logger.info(
-      `Finished providing ${subnetResources.length} Subnet resources from AWS: ${accountId}`,
+      `Finished providing ${entities.length} Subnet resources from AWS: ${accountId}`,
       { run_duration: duration(startTimestamp) },
     );
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSSubnetProvider.ts
@@ -105,7 +105,7 @@ export class AWSSubnetProvider extends AWSEntityProvider {
         const arn = `arn:aws:ec2:${region}:${accountId}:subnet/${subnetId}`;
         const consoleLink = new ARN(arn).consoleLink;
 
-        let entity = this.renderEntity({ subnet });
+        let entity = this.renderEntity({ subnet }, { defaultAnnotations });
         if (!entity) {
           entity = {
             kind: 'Resource',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.example.yaml.njs
@@ -1,12 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ cluster.name | to_entity_name }}
+  name: {{ vpc.VpcId }}
   annotations:
-    amazon.com/eks-cluster-arn: {{ cluster.arn }}
-    amazon.com/iam-role-arn: {{ cluster.roleArn }}
-    kubernetes.io/auth-provider: aws
-    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
-  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
-  labels:
-    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}
+    amazonaws.com/vpc-id: {{ vpc.VpcId }}
+  title: {{ vpc.VpcId }}
+  state: {{ vpc.State }}
+spec:
+  type: vpc

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.example.yaml.njs
@@ -1,10 +1,10 @@
 kind: Resource
 apiVersion: backstage.io/v1beta1
 metadata:
-  name: {{ vpc.VpcId }}
+  name: {{ data.VpcId }}
   annotations:
-    amazonaws.com/vpc-id: {{ vpc.VpcId }}
-  title: {{ vpc.VpcId }}
-  state: {{ vpc.State }}
+    amazonaws.com/vpc-id: {{ data.VpcId }}
+  title: {{ data.VpcId }}
+  state: {{ data.State }}
 spec:
   type: vpc

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.example.yaml.njs
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.example.yaml.njs
@@ -1,0 +1,12 @@
+kind: Resource
+apiVersion: backstage.io/v1beta1
+metadata:
+  name: {{ cluster.name | to_entity_name }}
+  annotations:
+    amazon.com/eks-cluster-arn: {{ cluster.arn }}
+    amazon.com/iam-role-arn: {{ cluster.roleArn }}
+    kubernetes.io/auth-provider: aws
+    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
+  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
+  labels:
+    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.test.ts
@@ -138,25 +138,13 @@ describe('AWSVPCProvider', () => {
               kind: 'Resource',
               apiVersion: 'backstage.io/v1beta1',
               spec: {
-                owner: 'unknown',
                 type: 'vpc',
               },
               metadata: expect.objectContaining({
                 name: 'vpc-12345678',
                 title: 'vpc-12345678',
-                cidrBlocks: '10.0.0.0/16',
-                dhcpOptions:
-                  'domain-name: eu-west-1.compute.internal; domain-name-servers: AmazonProvidedDNS',
-                isDefault: 'No',
                 state: 'available',
-                instanceTenancy: 'default',
-                labels: {
-                  Environment: 'production--staging',
-                },
                 annotations: expect.objectContaining({
-                  [ANNOTATION_VIEW_URL]: expect.stringContaining(
-                    'console.aws.amazon.com',
-                  ),
                   'amazonaws.com/vpc-id': 'vpc-12345678',
                   'backstage.io/managed-by-location':
                     'aws-vpc-provider-0:arn:aws:iam::123456789012:role/role1',

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.test.ts
@@ -28,6 +28,8 @@ import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AWSVPCProvider } from './AWSVPCProvider';
 import { ANNOTATION_VIEW_URL } from '@backstage/catalog-model';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 
 const ec2 = mockClient(EC2);
 const sts = mockClient(STS);
@@ -114,6 +116,58 @@ describe('AWSVPCProvider', () => {
         ],
         $metadata: {},
       } as DescribeDhcpOptionsCommandOutput);
+    });
+
+    it('creates VPC with a template', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+      const template = readFileSync(
+        join(dirname(__filename), './AWSVPCProvider.example.yaml.njs'),
+      ).toString();
+      const provider = AWSVPCProvider.fromConfig(config, { logger, template });
+      await provider.connect(entityProviderConnection);
+      await provider.run();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'full',
+        entities: [
+          expect.objectContaining({
+            locationKey: 'aws-vpc-provider-0',
+            entity: expect.objectContaining({
+              kind: 'Resource',
+              apiVersion: 'backstage.io/v1beta1',
+              spec: {
+                owner: 'unknown',
+                type: 'vpc',
+              },
+              metadata: expect.objectContaining({
+                name: 'vpc-12345678',
+                title: 'vpc-12345678',
+                cidrBlocks: '10.0.0.0/16',
+                dhcpOptions:
+                  'domain-name: eu-west-1.compute.internal; domain-name-servers: AmazonProvidedDNS',
+                isDefault: 'No',
+                state: 'available',
+                instanceTenancy: 'default',
+                labels: {
+                  Environment: 'production--staging',
+                },
+                annotations: expect.objectContaining({
+                  [ANNOTATION_VIEW_URL]: expect.stringContaining(
+                    'console.aws.amazon.com',
+                  ),
+                  'amazonaws.com/vpc-id': 'vpc-12345678',
+                  'backstage.io/managed-by-location':
+                    'aws-vpc-provider-0:arn:aws:iam::123456789012:role/role1',
+                  'backstage.io/managed-by-origin-location':
+                    'aws-vpc-provider-0:arn:aws:iam::123456789012:role/role1',
+                }),
+              }),
+            }),
+          }),
+        ],
+      });
     });
 
     it('creates VPC', async () => {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.ts
@@ -16,7 +16,7 @@
 
 import { CatalogApi } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
-import { ANNOTATION_VIEW_URL, ResourceEntity } from '@backstage/catalog-model';
+import { ANNOTATION_VIEW_URL, Entity } from '@backstage/catalog-model';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import type { Logger } from 'winston';
 import { EC2 } from '@aws-sdk/client-ec2';
@@ -40,6 +40,7 @@ export class AWSVPCProvider extends AWSEntityProvider {
     config: Config,
     options: {
       logger: Logger | LoggerService;
+      template?: string;
       catalogApi?: CatalogApi;
       providerId?: string;
       ownerTag?: string;
@@ -83,7 +84,7 @@ export class AWSVPCProvider extends AWSEntityProvider {
     const groups = await this.getGroups();
 
     this.logger.info(`Providing VPC resources from aws: ${accountId}`);
-    const vpcResources: ResourceEntity[] = [];
+    const entities: Entity[] = [];
 
     const ec2 = await this.getEc2(dynamicAccountConfig);
     const defaultAnnotations = await this.buildDefaultAnnotations(
@@ -126,44 +127,48 @@ export class AWSVPCProvider extends AWSEntityProvider {
         }
       }
 
-      const resource: ResourceEntity = {
-        kind: 'Resource',
-        apiVersion: 'backstage.io/v1beta1',
-        metadata: {
-          annotations: {
-            ...defaultAnnotations,
-            [ANNOTATION_VIEW_URL]: consoleLink,
-            [ANNOTATION_VPC_ID]: vpcId,
-          },
-          labels: this.labelsFromTags(vpc.Tags),
-          name: vpcId,
-          title: vpc.Tags?.find(tag => tag.Key === 'Name')?.Value || vpcId,
-          cidrBlocks: cidrBlocksResult,
-          dhcpOptions: dhcpOptionsDetails,
-          isDefault: vpc.IsDefault ? 'Yes' : 'No',
-          state: vpc.State,
-          instanceTenancy: vpc.InstanceTenancy,
-        },
-        spec: {
-          owner: ownerFromTags(vpc.Tags, this.getOwnerTag(), groups),
-          ...relationshipsFromTags(vpc.Tags),
-          type: 'vpc',
-        },
-      };
+      let entity = this.renderEntity({ vpc });
 
-      vpcResources.push(resource);
+      if (!entity) {
+        entity = {
+          kind: 'Resource',
+          apiVersion: 'backstage.io/v1beta1',
+          metadata: {
+            annotations: {
+              ...defaultAnnotations,
+              [ANNOTATION_VIEW_URL]: consoleLink,
+              [ANNOTATION_VPC_ID]: vpcId,
+            },
+            labels: this.labelsFromTags(vpc.Tags),
+            name: vpcId,
+            title: vpc.Tags?.find(tag => tag.Key === 'Name')?.Value || vpcId,
+            cidrBlocks: cidrBlocksResult,
+            dhcpOptions: dhcpOptionsDetails,
+            isDefault: vpc.IsDefault ? 'Yes' : 'No',
+            state: vpc.State,
+            instanceTenancy: vpc.InstanceTenancy,
+          },
+          spec: {
+            owner: ownerFromTags(vpc.Tags, this.getOwnerTag(), groups),
+            ...relationshipsFromTags(vpc.Tags),
+            type: 'vpc',
+          },
+        };
+      }
+
+      entities.push(entity);
     }
 
     await this.connection.applyMutation({
       type: 'full',
-      entities: vpcResources.map(entity => ({
+      entities: entities.map(entity => ({
         entity,
         locationKey: this.getProviderName(),
       })),
     });
 
     this.logger.info(
-      `Finished providing ${vpcResources.length} VPC resources from AWS: ${accountId}`,
+      `Finished providing ${entities.length} VPC resources from AWS: ${accountId}`,
       { run_duration: duration(startTimestamp) },
     );
   }

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.ts
@@ -127,7 +127,7 @@ export class AWSVPCProvider extends AWSEntityProvider {
         }
       }
 
-      let entity = this.renderEntity({ vpc }, { defaultAnnotations });
+      let entity = this.renderEntity({ data: vpc }, { defaultAnnotations });
 
       if (!entity) {
         entity = {

--- a/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.ts
+++ b/plugins/backend/catalog-backend-module-aws/src/providers/AWSVPCProvider.ts
@@ -127,7 +127,7 @@ export class AWSVPCProvider extends AWSEntityProvider {
         }
       }
 
-      let entity = this.renderEntity({ vpc });
+      let entity = this.renderEntity({ vpc }, { defaultAnnotations });
 
       if (!entity) {
         entity = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15262,8 +15262,10 @@ __metadata:
     "@types/link2aws": "npm:^1.0.0"
     "@types/lodash": "npm:^4.14.151"
     aws-sdk-client-mock: "npm:^4.1.0"
+    js-yaml: "npm:^4.1.0"
     link2aws: "npm:^1.0.18"
     lodash: "npm:^4.17.21"
+    nunjucks: "npm:^3.2.4"
     winston: "npm:^3.2.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Add ability to template AWS provided entities

The idea is that the entity provider can be configured with a template. The template would be rendered with the eks cluster returned from the aws apis. This allows more flexibility as to the resulting entity that is produced by the entity provider.

e.g. the provider could be configured like this:

```javascript
  const tempate = `kind: Resource
apiVersion: backstage.io/v1beta1
metadata:
  name: {{ cluster.name | to_entity_name }}
  annotations:
    amazon.com/eks-cluster-arn: {{ cluster.arn }}
    amazon.com/iam-role-arn: {{ cluster.roleArn }}
    kubernetes.io/auth-provider: aws
    kubernetes.io/x-k8s-aws-id: {{ cluster.name }}
  title: {{ accountId }}:{{ region }}:{{ cluster.name }}
  labels:
    some_url: {{ cluster.tags.some_url | replace(":", "-") | replace("/", "-") }}`;

  const eksClusterProvider = AWSEKSClusterProvider.fromConfig(
    config,
    {
      logger,
      template
    },
  );
```

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
