### PR TITLE
fix(jira): use separate search endpoint for data center

### DIFF
--- a/.changeset/tasty-readers-sneeze.md
+++ b/.changeset/tasty-readers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-jira': minor
+---
+
+Improved support for Data Center by introducing strategies per product

--- a/.changeset/tasty-readers-sneeze.md
+++ b/.changeset/tasty-readers-sneeze.md
@@ -2,4 +2,4 @@
 '@roadiehq/backstage-plugin-jira': minor
 ---
 
-Improved support for Data Center by introducing strategies per product
+Improved support for Data Center by using a separate search endpoint

--- a/plugins/frontend/backstage-plugin-jira/README.md
+++ b/plugins/frontend/backstage-plugin-jira/README.md
@@ -66,6 +66,8 @@ jira:
   confluenceActivityFilter: wiki@uuid
   # Defaults to latest and can be omitted if you want to use the latest version of the api
   apiVersion: latest
+  # Defaults to `cloud`, but also supports `datacenter`
+  product: cloud
 ```
 
 3. Set img-src in Content Security Policy

--- a/plugins/frontend/backstage-plugin-jira/config.d.ts
+++ b/plugins/frontend/backstage-plugin-jira/config.d.ts
@@ -33,10 +33,17 @@ export interface Config {
     confluenceActivityFilter?: string;
 
     /**
-     * The verison of the Jira API
+     * The version of the Jira API
      * Should be used if you do not want to use the latest Jira API.
      * @visibility frontend
      */
     apiVersion?: number;
+
+    /**
+     * The product type of the Jira instance.
+     * This is used to determine the correct API endpoints.
+     * @visibility frontend
+     */
+    product?: 'cloud' | 'datacenter';
   };
 }

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.test.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.test.ts
@@ -1,4 +1,9 @@
-import { mockApis, MockFetchApi, registerMswTestHooks } from '@backstage/test-utils';
+/* eslint-disable no-new */
+import {
+  mockApis,
+  MockFetchApi,
+  registerMswTestHooks,
+} from '@backstage/test-utils';
 import { JiraAPI } from './index';
 import { JiraProductStrategyFactory } from './strategies';
 import { JiraCloudStrategy } from './strategies/cloud';
@@ -13,7 +18,10 @@ describe('JiraAPI', () => {
   const discoveryApi = mockApis.discovery();
   const fetchApi = new MockFetchApi();
 
-  const strategyFactorySpy = jest.spyOn(JiraProductStrategyFactory, 'createStrategy');
+  const strategyFactorySpy = jest.spyOn(
+    JiraProductStrategyFactory,
+    'createStrategy',
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -46,7 +54,9 @@ describe('JiraAPI', () => {
   });
 
   it('should default to cloud strategy when product data center is configured', () => {
-    const configApi = mockApis.config({ data: { jira: { product: 'datacenter' } } });
+    const configApi = mockApis.config({
+      data: { jira: { product: 'datacenter' } },
+    });
 
     const options = {
       discoveryApi,
@@ -65,7 +75,10 @@ describe('JiraAPI', () => {
       fetchApi,
     });
 
-    const pagedIssuesRequestSpy = jest.spyOn(JiraCloudStrategy.prototype, 'pagedIssuesRequest');
+    const pagedIssuesRequestSpy = jest.spyOn(
+      JiraCloudStrategy.prototype,
+      'pagedIssuesRequest',
+    );
 
     it("should call the strategy's pagedIssuesRequest method", async () => {
       const query = 'foo';
@@ -74,7 +87,11 @@ describe('JiraAPI', () => {
       pagedIssuesRequestSpy.mockImplementation();
       await jiraApi.jqlQuery(query, maxResults);
 
-      expect(pagedIssuesRequestSpy).toHaveBeenCalledWith(expect.any(String), query, maxResults);
+      expect(pagedIssuesRequestSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        query,
+        maxResults,
+      );
     });
   });
 
@@ -85,18 +102,23 @@ describe('JiraAPI', () => {
       fetchApi,
     });
 
-    const pagedIssuesRequestSpy = jest.spyOn(JiraCloudStrategy.prototype, 'pagedIssuesRequest');
+    const pagedIssuesRequestSpy = jest.spyOn(
+      JiraCloudStrategy.prototype,
+      'pagedIssuesRequest',
+    );
 
     beforeEach(() => {
       worker.use(
-        rest.get('http://example.com/api/proxy/jira/api/rest/api/latest/user', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              avatarUrls: { '48x48': 'http://example.com' },
-              self: 'http://example.com',
-            }),
-          ),
+        rest.get(
+          'http://example.com/api/proxy/jira/api/rest/api/latest/user',
+          (_, res, ctx) =>
+            res(
+              ctx.status(200),
+              ctx.json({
+                avatarUrls: { '48x48': 'http://example.com' },
+                self: 'http://example.com',
+              }),
+            ),
         ),
       );
     });

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.test.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.test.ts
@@ -1,0 +1,116 @@
+import { mockApis, MockFetchApi, registerMswTestHooks } from '@backstage/test-utils';
+import { JiraAPI } from './index';
+import { JiraProductStrategyFactory } from './strategies';
+import { JiraCloudStrategy } from './strategies/cloud';
+import { setupServer } from 'msw/node';
+import { rest } from 'msw';
+
+const worker = setupServer();
+
+describe('JiraAPI', () => {
+  registerMswTestHooks(worker);
+
+  const discoveryApi = mockApis.discovery();
+  const fetchApi = new MockFetchApi();
+
+  const strategyFactorySpy = jest.spyOn(JiraProductStrategyFactory, 'createStrategy');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should default to cloud strategy when no product is configured', () => {
+    const configApi = mockApis.config();
+
+    const options = {
+      discoveryApi,
+      configApi,
+      fetchApi,
+    };
+    new JiraAPI(options);
+
+    expect(strategyFactorySpy).toHaveBeenCalledWith('cloud', options);
+  });
+
+  it('should default to cloud strategy when product cloud is configured', () => {
+    const configApi = mockApis.config({ data: { jira: { product: 'cloud' } } });
+
+    const options = {
+      discoveryApi,
+      configApi,
+      fetchApi,
+    };
+    new JiraAPI(options);
+
+    expect(strategyFactorySpy).toHaveBeenCalledWith('cloud', options);
+  });
+
+  it('should default to cloud strategy when product data center is configured', () => {
+    const configApi = mockApis.config({ data: { jira: { product: 'datacenter' } } });
+
+    const options = {
+      discoveryApi,
+      configApi,
+      fetchApi,
+    };
+    new JiraAPI(options);
+
+    expect(strategyFactorySpy).toHaveBeenCalledWith('datacenter', options);
+  });
+
+  describe('jqlQuery', () => {
+    const jiraApi = new JiraAPI({
+      discoveryApi,
+      configApi: mockApis.config(),
+      fetchApi,
+    });
+
+    const pagedIssuesRequestSpy = jest.spyOn(JiraCloudStrategy.prototype, 'pagedIssuesRequest');
+
+    it("should call the strategy's pagedIssuesRequest method", async () => {
+      const query = 'foo';
+      const maxResults = 50;
+
+      pagedIssuesRequestSpy.mockImplementation();
+      await jiraApi.jqlQuery(query, maxResults);
+
+      expect(pagedIssuesRequestSpy).toHaveBeenCalledWith(expect.any(String), query, maxResults);
+    });
+  });
+
+  describe('getUserDetails', () => {
+    const jiraApi = new JiraAPI({
+      discoveryApi,
+      configApi: mockApis.config(),
+      fetchApi,
+    });
+
+    const pagedIssuesRequestSpy = jest.spyOn(JiraCloudStrategy.prototype, 'pagedIssuesRequest');
+
+    beforeEach(() => {
+      worker.use(
+        rest.get('http://example.com/api/proxy/jira/api/rest/api/latest/user', (_, res, ctx) =>
+          res(
+            ctx.status(200),
+            ctx.json({
+              avatarUrls: { '48x48': 'http://example.com' },
+              self: 'http://example.com',
+            }),
+          ),
+        ),
+      );
+    });
+
+    it("should call the strategy's pagedIssuesRequest method", async () => {
+      const userId = 'foo';
+
+      pagedIssuesRequestSpy.mockResolvedValue([]);
+      await jiraApi.getUserDetails(userId);
+
+      expect(pagedIssuesRequestSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining(userId),
+      );
+    });
+  });
+});

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.ts
@@ -64,8 +64,9 @@ export class JiraAPI {
     this.apiVersion = apiVersion
       ? apiVersion.toString()
       : DEFAULT_REST_API_VERSION;
-      
-    const product = options.configApi.getOptionalString('jira.product') ?? 'cloud';
+
+    const product =
+      options.configApi.getOptionalString('jira.product') ?? 'cloud';
     this.strategy = JiraProductStrategyFactory.createStrategy(product, options);
 
     this.confluenceActivityFilter = options.configApi.getOptionalString(
@@ -120,10 +121,7 @@ export class JiraAPI {
       AND statuscategory not in ("Done") 
     `;
 
-    return this.strategy.pagedIssuesRequest(
-      apiUrl,
-      jql
-    );
+    return this.strategy.pagedIssuesRequest(apiUrl, jql);
   }
 
   async getProjectDetails(
@@ -285,10 +283,7 @@ export class JiraAPI {
 
     const jql = `assignee = "${userId}" AND statusCategory in ("To Do", "In Progress")`;
 
-    const foundIssues = await this.strategy.pagedIssuesRequest(
-      apiUrl,
-      jql,
-    );
+    const foundIssues = await this.strategy.pagedIssuesRequest(apiUrl, jql);
 
     tickets = foundIssues.map(index => {
       return {
@@ -320,10 +315,6 @@ export class JiraAPI {
   async jqlQuery(query: string, maxResults?: number) {
     const { apiUrl } = await this.getUrls();
 
-    return this.strategy.pagedIssuesRequest(
-      apiUrl,
-      query,
-      maxResults,
-    );
+    return this.strategy.pagedIssuesRequest(apiUrl, query, maxResults);
   }
 }

--- a/plugins/frontend/backstage-plugin-jira/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/index.ts
@@ -21,17 +21,16 @@ import {
   FetchApi,
 } from '@backstage/core-plugin-api';
 import {
-  IssuesResult,
-  IssuesResponse,
   IssuesCounter,
   IssueType,
   Project,
   Status,
-  Ticket,
   UserSummary,
   User,
   TicketSummary,
 } from '../types';
+import { JiraProductStrategy } from './strategies/base';
+import { JiraProductStrategyFactory } from './strategies';
 
 export const jiraApiRef = createApiRef<JiraAPI>({
   id: 'plugin.jira.service',
@@ -51,6 +50,7 @@ export class JiraAPI {
   private readonly discoveryApi: DiscoveryApi;
   private readonly proxyPath: string;
   private readonly apiVersion: string;
+  private readonly strategy: JiraProductStrategy;
   private readonly confluenceActivityFilter: string | undefined;
   private readonly fetchApi: FetchApi;
 
@@ -64,6 +64,9 @@ export class JiraAPI {
     this.apiVersion = apiVersion
       ? apiVersion.toString()
       : DEFAULT_REST_API_VERSION;
+      
+    const product = options.configApi.getOptionalString('jira.product') ?? 'cloud';
+    this.strategy = JiraProductStrategyFactory.createStrategy(product, options);
 
     this.confluenceActivityFilter = options.configApi.getOptionalString(
       'jira.confluenceActivityFilter',
@@ -95,49 +98,6 @@ export class JiraAPI {
       .map(i => `'${i}'`)
       .join(',');
 
-  private async pagedIssuesRequest(
-    apiUrl: string,
-    jql: string,
-    nextPageToken?: string,
-    maxResults?: number,
-  ): Promise<IssuesResult> {
-    const data = {
-      jql,
-      maxResults: maxResults ?? 5000,
-      fields: [
-        'key',
-        'issuetype',
-        'summary',
-        'status',
-        'assignee',
-        'priority',
-        'parent',
-        'created',
-        'updated',
-        'project',
-      ],
-      nextPageToken,
-    };
-    const request = await this.fetchApi.fetch(`${apiUrl}search/jql`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    });
-    if (!request.ok) {
-      throw new Error(
-        `failed to fetch data, status ${request.status}: ${request.statusText}`,
-      );
-    }
-    const response: IssuesResponse = await request.json();
-
-    return {
-      issues: response.issues,
-      nextPageToken: response.nextPageToken,
-    };
-  }
-
   private async getIssuesPaged({
     apiUrl,
     projectKey,
@@ -160,20 +120,10 @@ export class JiraAPI {
       AND statuscategory not in ("Done") 
     `;
 
-    let nextPageToken: string | undefined;
-    const issues: Ticket[] = [];
-
-    do {
-      const res: IssuesResult = await this.pagedIssuesRequest(
-        apiUrl,
-        jql,
-        nextPageToken,
-      );
-      nextPageToken = res.nextPageToken;
-      issues.push(...res.issues);
-    } while (nextPageToken !== undefined);
-
-    return issues;
+    return this.strategy.pagedIssuesRequest(
+      apiUrl,
+      jql
+    );
   }
 
   async getProjectDetails(
@@ -335,18 +285,10 @@ export class JiraAPI {
 
     const jql = `assignee = "${userId}" AND statusCategory in ("To Do", "In Progress")`;
 
-    let nextPageToken: string | undefined;
-    const foundIssues: Ticket[] = [];
-
-    do {
-      const res: IssuesResult = await this.pagedIssuesRequest(
-        apiUrl,
-        jql,
-        nextPageToken,
-      );
-      nextPageToken = res.nextPageToken;
-      foundIssues.push(...res.issues);
-    } while (nextPageToken !== undefined);
+    const foundIssues = await this.strategy.pagedIssuesRequest(
+      apiUrl,
+      jql,
+    );
 
     tickets = foundIssues.map(index => {
       return {
@@ -378,20 +320,10 @@ export class JiraAPI {
   async jqlQuery(query: string, maxResults?: number) {
     const { apiUrl } = await this.getUrls();
 
-    const issues = [];
-
-    let nextPageToken: string | undefined;
-    do {
-      const res: IssuesResult = await this.pagedIssuesRequest(
-        apiUrl,
-        query,
-        nextPageToken,
-        maxResults,
-      );
-      nextPageToken = res.nextPageToken;
-      issues.push(...res.issues);
-    } while (nextPageToken !== undefined);
-
-    return issues;
+    return this.strategy.pagedIssuesRequest(
+      apiUrl,
+      query,
+      maxResults,
+    );
   }
 }

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/base.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/base.ts
@@ -8,5 +8,9 @@ export type JiraProductStrategyOptions = {
 export abstract class JiraProductStrategy {
   constructor(protected options: JiraProductStrategyOptions) {}
 
-  abstract pagedIssuesRequest(apiUrl: string, jql: string, maxResults?: number): Promise<Ticket[]>;
+  abstract pagedIssuesRequest(
+    apiUrl: string,
+    jql: string,
+    maxResults?: number,
+  ): Promise<Ticket[]>;
 }

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/base.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/base.ts
@@ -1,0 +1,12 @@
+import { FetchApi } from '@backstage/core-plugin-api';
+import { Ticket } from '../../types';
+
+export type JiraProductStrategyOptions = {
+  fetchApi: FetchApi;
+};
+
+export abstract class JiraProductStrategy {
+  constructor(protected options: JiraProductStrategyOptions) {}
+
+  abstract pagedIssuesRequest(apiUrl: string, jql: string, maxResults?: number): Promise<Ticket[]>;
+}

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/index.ts
@@ -1,0 +1,44 @@
+import { JiraProductStrategy } from '../base';
+import { Ticket } from '../../../types';
+import { IssuesCloudResponse } from './types';
+
+export class JiraCloudStrategy extends JiraProductStrategy {
+  async pagedIssuesRequest(apiUrl: string, jql: string, maxResults?: number): Promise<Ticket[]> {
+    let issues: Ticket[] = [];
+    let nextPageToken: string | undefined;
+    do {
+      const data = {
+        jql,
+        maxResults: maxResults ?? 5000,
+        fields: [
+          'key',
+          'issuetype',
+          'summary',
+          'status',
+          'assignee',
+          'priority',
+          'parent',
+          'created',
+          'updated',
+          'project',
+        ],
+        nextPageToken,
+      };
+      const request = await this.options.fetchApi.fetch(`${apiUrl}search/jql`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+      if (!request.ok) {
+        throw new Error(`failed to fetch data, status ${request.status}: ${request.statusText}`);
+      }
+      const response: IssuesCloudResponse = await request.json();
+      nextPageToken = response.nextPageToken;
+      issues = issues.concat(response.issues);
+    } while (nextPageToken !== undefined);
+
+    return issues;
+  }
+}

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/index.ts
@@ -3,7 +3,11 @@ import { Ticket } from '../../../types';
 import { IssuesCloudResponse } from './types';
 
 export class JiraCloudStrategy extends JiraProductStrategy {
-  async pagedIssuesRequest(apiUrl: string, jql: string, maxResults?: number): Promise<Ticket[]> {
+  async pagedIssuesRequest(
+    apiUrl: string,
+    jql: string,
+    maxResults?: number,
+  ): Promise<Ticket[]> {
     let issues: Ticket[] = [];
     let nextPageToken: string | undefined;
     do {
@@ -32,7 +36,9 @@ export class JiraCloudStrategy extends JiraProductStrategy {
         body: JSON.stringify(data),
       });
       if (!request.ok) {
-        throw new Error(`failed to fetch data, status ${request.status}: ${request.statusText}`);
+        throw new Error(
+          `failed to fetch data, status ${request.status}: ${request.statusText}`,
+        );
       }
       const response: IssuesCloudResponse = await request.json();
       nextPageToken = response.nextPageToken;

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/index.ts
@@ -1,6 +1,6 @@
 import { JiraProductStrategy } from '../base';
 import { Ticket } from '../../../types';
-import { IssuesCloudResponse } from './types';
+import { SearchCloudResponse } from './types';
 
 export class JiraCloudStrategy extends JiraProductStrategy {
   async pagedIssuesRequest(
@@ -40,7 +40,7 @@ export class JiraCloudStrategy extends JiraProductStrategy {
           `failed to fetch data, status ${request.status}: ${request.statusText}`,
         );
       }
-      const response: IssuesCloudResponse = await request.json();
+      const response: SearchCloudResponse = await request.json();
       nextPageToken = response.nextPageToken;
       issues = issues.concat(response.issues);
     } while (nextPageToken !== undefined);

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/types.ts
@@ -1,6 +1,6 @@
 import { Ticket } from '../../../types';
 
-export type IssuesCloudResponse = {
+export type SearchCloudResponse = {
   nextPageToken: string;
   maxResults: number;
   total: number;

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/cloud/types.ts
@@ -1,0 +1,8 @@
+import { Ticket } from '../../../types';
+
+export type IssuesCloudResponse = {
+  nextPageToken: string;
+  maxResults: number;
+  total: number;
+  issues: Ticket[];
+};

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/index.ts
@@ -1,0 +1,45 @@
+import { JiraProductStrategy } from '../base';
+import { Ticket } from '../../../types';
+import { IssuesDataCenterResponse } from './types';
+
+export class JiraDataCenterStrategy extends JiraProductStrategy {
+  async pagedIssuesRequest(apiUrl: string, jql: string, maxResults?: number): Promise<Ticket[]> {
+    let issues: Ticket[] = [];
+    let startAt: number | undefined;
+    do {
+      const data = {
+        jql,
+        maxResults: maxResults ?? -1,
+        fields: [
+          'key',
+          'issuetype',
+          'summary',
+          'status',
+          'assignee',
+          'priority',
+          'parent',
+          'created',
+          'updated',
+          'project',
+        ],
+        startAt,
+      };
+      const request = await this.options.fetchApi.fetch(`${apiUrl}search`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+      if (!request.ok) {
+        throw new Error(`failed to fetch data, status ${request.status}: ${request.statusText}`);
+      }
+      const response: IssuesDataCenterResponse = await request.json();
+      const lastElement = response.startAt + response.maxResults;
+      startAt = response.total > lastElement ? lastElement : undefined;
+      issues = issues.concat(response.issues);
+    } while (startAt !== undefined);
+
+    return issues;
+  }
+}

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/index.ts
@@ -3,7 +3,11 @@ import { Ticket } from '../../../types';
 import { IssuesDataCenterResponse } from './types';
 
 export class JiraDataCenterStrategy extends JiraProductStrategy {
-  async pagedIssuesRequest(apiUrl: string, jql: string, maxResults?: number): Promise<Ticket[]> {
+  async pagedIssuesRequest(
+    apiUrl: string,
+    jql: string,
+    maxResults?: number,
+  ): Promise<Ticket[]> {
     let issues: Ticket[] = [];
     let startAt: number | undefined;
     do {
@@ -32,7 +36,9 @@ export class JiraDataCenterStrategy extends JiraProductStrategy {
         body: JSON.stringify(data),
       });
       if (!request.ok) {
-        throw new Error(`failed to fetch data, status ${request.status}: ${request.statusText}`);
+        throw new Error(
+          `failed to fetch data, status ${request.status}: ${request.statusText}`,
+        );
       }
       const response: IssuesDataCenterResponse = await request.json();
       const lastElement = response.startAt + response.maxResults;

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/index.ts
@@ -1,6 +1,6 @@
 import { JiraProductStrategy } from '../base';
 import { Ticket } from '../../../types';
-import { IssuesDataCenterResponse } from './types';
+import { SearchDataCenterResponse } from './types';
 
 export class JiraDataCenterStrategy extends JiraProductStrategy {
   async pagedIssuesRequest(
@@ -40,7 +40,7 @@ export class JiraDataCenterStrategy extends JiraProductStrategy {
           `failed to fetch data, status ${request.status}: ${request.statusText}`,
         );
       }
-      const response: IssuesDataCenterResponse = await request.json();
+      const response: SearchDataCenterResponse = await request.json();
       const lastElement = response.startAt + response.maxResults;
       startAt = response.total > lastElement ? lastElement : undefined;
       issues = issues.concat(response.issues);

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/types.ts
@@ -1,6 +1,6 @@
 import { Ticket } from '../../../types';
 
-export type IssuesDataCenterResponse = {
+export type SearchDataCenterResponse = {
   startAt: number;
   maxResults: number;
   total: number;

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/datacenter/types.ts
@@ -1,0 +1,8 @@
+import { Ticket } from '../../../types';
+
+export type IssuesDataCenterResponse = {
+  startAt: number;
+  maxResults: number;
+  total: number;
+  issues: Ticket[];
+};

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/factory.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/factory.ts
@@ -1,0 +1,14 @@
+import { JiraProductStrategy, JiraProductStrategyOptions } from './base';
+import { JiraCloudStrategy } from './cloud';
+import { JiraDataCenterStrategy } from './datacenter';
+
+export class JiraProductStrategyFactory {
+  static createStrategy(product: string, options: JiraProductStrategyOptions): JiraProductStrategy {
+    switch (product) {
+      case 'datacenter':
+        return new JiraDataCenterStrategy(options);
+      default:
+        return new JiraCloudStrategy(options);
+    }
+  }
+}

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/factory.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/factory.ts
@@ -3,7 +3,10 @@ import { JiraCloudStrategy } from './cloud';
 import { JiraDataCenterStrategy } from './datacenter';
 
 export class JiraProductStrategyFactory {
-  static createStrategy(product: string, options: JiraProductStrategyOptions): JiraProductStrategy {
+  static createStrategy(
+    product: string,
+    options: JiraProductStrategyOptions,
+  ): JiraProductStrategy {
     switch (product) {
       case 'datacenter':
         return new JiraDataCenterStrategy(options);

--- a/plugins/frontend/backstage-plugin-jira/src/api/strategies/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/api/strategies/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './factory';

--- a/plugins/frontend/backstage-plugin-jira/src/types.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/types.ts
@@ -118,13 +118,6 @@ export type Status = {
   statuses: Array<{ name: string; statusCategory: { name: string } }>;
 };
 
-export type IssuesResponse = {
-  nextPageToken: string;
-  maxResults: number;
-  total: number;
-  issues: Ticket[];
-};
-
 export type Ticket = {
   key: string;
   self: string;
@@ -190,11 +183,6 @@ export type User = {
   avatarUrls: {
     [key: string]: string;
   };
-};
-
-export type IssuesResult = {
-  nextPageToken: string | undefined;
-  issues: Ticket[];
 };
 
 export type UserSummary = {


### PR DESCRIPTION
This PR resolves #1935 by using a separate search endpoint for Data Center products, the one that was removed in #1893.

To support different implementations for different products, the `JiraAPI` was refactored to use strategies based on the product you supply in your config. If the config property is not set, the cloud strategy will be used as a default.

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Added or updated documentation (if applicable)
