### PR TITLE
Do not use strict mode after changeset release install

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "create-plugin": "backstage-cli create-plugin --scope roadiehq --no-private",
     "new": "backstage-cli new --scope roadiehq --no-private",
     "remove-plugin": "backstage-cli remove-plugin",
-    "release": "changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' && yarn install",
+    "release": "changeset version && yarn prettier --write '{packages,plugins}/*/{package.json,CHANGELOG.md}' && yarn install --no-immutable",
     "prepare": "husky install"
   },
   "resolutions": {


### PR DESCRIPTION
Yarn 4.0+ runs automatically in strict mode if it detects that the install is in a public github repo.
When the changeset workflow updates the repo the install fails in CI because it changes the lock file to update the packages to the new version.

This PR turns this off.