### PR TITLE
fix(argo-cd-backend): add Content-Type header to Azure AD OIDC token request for compliance with Microsoft identity platform

### DIFF
--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -237,6 +237,7 @@ export class ArgoService implements ArgoServiceApi {
     }
 
     if (oidcConfig?.provider === 'azure' && oidcConfig.providerConfigKey) {
+
       const azureCredentials = this.config.get<AzureConfig>(
         oidcConfig.providerConfigKey,
       );
@@ -245,6 +246,9 @@ export class ArgoService implements ArgoServiceApi {
         `${azureCredentials.loginUrl}/${azureCredentials.tenantId}/oauth2/v2.0/token`,
         {
           method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
           body: new URLSearchParams({
             grant_type: 'client_credentials',
             client_id: azureCredentials.clientId,

--- a/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-backend/src/service/argocd.service.ts
@@ -237,7 +237,6 @@ export class ArgoService implements ArgoServiceApi {
     }
 
     if (oidcConfig?.provider === 'azure' && oidcConfig.providerConfigKey) {
-
       const azureCredentials = this.config.get<AzureConfig>(
         oidcConfig.providerConfigKey,
       );
@@ -246,9 +245,6 @@ export class ArgoService implements ArgoServiceApi {
         `${azureCredentials.loginUrl}/${azureCredentials.tenantId}/oauth2/v2.0/token`,
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
           body: new URLSearchParams({
             grant_type: 'client_credentials',
             client_id: azureCredentials.clientId,


### PR DESCRIPTION
This PR fixes an issue where the Azure AD OIDC token request in the ArgoCD backend plugin was missing the required Content-Type header. This header is required by the Microsoft identity platform for client credentials flow.\n\n- Adds `Content-Type: application/x-www-form-urlencoded` to the Azure AD token request.\n- Fixes authentication failures in strict environments.\n\nCloses #<issue-if-any>.