### PR TITLE
move to community plugins

### DIFF
--- a/.changeset/violet-grapes-fetch.md
+++ b/.changeset/violet-grapes-fetch.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-bitbucket-pullrequest': patch
+---
+
+Deprecate plugin to move to the "backstage/community-plugins" repo

--- a/plugins/frontend/backstage-plugin-bitbucket-pullrequest/DEPRECATED.md
+++ b/plugins/frontend/backstage-plugin-bitbucket-pullrequest/DEPRECATED.md
@@ -1,0 +1,33 @@
+# Deprecation Notice
+
+This plugin has been deprecated in favor of the Backstage Community plugin: `@backstage-community/plugin-bitbucket-pull-requests`.
+
+## Migration Guide
+
+1. Uninstall this package:
+
+   ```bash
+   yarn remove @roadiehq/backstage-plugin-bitbucket-pullrequest
+   ```
+
+2. Install the community plugin:
+
+   ```bash
+   yarn add @backstage-community/plugin-bitbucket-pull-requests
+   ```
+
+3. Update your imports in `packages/app/src/components/catalog/EntityPage.tsx`:
+   ```diff
+   - import { EntityBitbucketPullRequestsContent } from '@roadiehq/backstage-plugin-bitbucket-pullrequest';
+   + import { EntityBitbucketPullRequestsContent } from '@backstage-community/plugin-bitbucket-pull-requests';
+   ```
+
+No other changes are needed.
+
+## Why was this deprecated?
+
+This plugin has been migrated to the Backstage Community Plugins repository to ensure better maintenance and broader community support. The community version offers the same functionality and is actively maintained by the Backstage community.
+
+## Need Help?
+
+For issues with the new plugin, please file an issue in the [Backstage Community Plugins repository](https://github.com/backstage/community-plugins).

--- a/plugins/frontend/backstage-plugin-bitbucket-pullrequest/README.md
+++ b/plugins/frontend/backstage-plugin-bitbucket-pullrequest/README.md
@@ -1,4 +1,35 @@
-# Bitbucket PullRequest Plugin for Backstage
+# ⚠️ Deprecated: Bitbucket PullRequest Plugin for Backstage
+
+> **This plugin is deprecated in favor of the Backstage Community plugin: `@backstage-community/plugin-bitbucket-pull-requests`**
+
+## Migration Guide
+
+To migrate from `@roadiehq/backstage-plugin-bitbucket-pullrequest` to `@backstage-community/plugin-bitbucket-pull-requests`:
+
+1. Uninstall the Roadie plugin:
+
+   ```bash
+   yarn remove @roadiehq/backstage-plugin-bitbucket-pullrequest
+   ```
+
+2. Install the Backstage Community plugin:
+
+   ```bash
+   yarn add @backstage-community/plugin-bitbucket-pull-requests
+   ```
+
+3. Update your imports in `packages/app/src/components/catalog/EntityPage.tsx`:
+
+   ```diff
+   - import { EntityBitbucketPullRequestsContent } from '@roadiehq/backstage-plugin-bitbucket-pullrequest';
+   + import { EntityBitbucketPullRequestsContent } from '@backstage-community/plugin-bitbucket-pull-requests';
+   ```
+
+   No other changes are needed.
+
+---
+
+## (Legacy) Bitbucket PullRequest Plugin for Backstage
 
 ![list of pull requests in the Bitbucket repo](./docs/bitbucketprimg.png)
 
@@ -72,4 +103,4 @@ metadata:
 
 ---
 
-Roadie gives you a hassle-free, fully customisable SaaS Backstage. Find out more here: [https://roadie.io](https://roadie.io).
+Roadie gives you a hassle-free, fully customizable SaaS Backstage. Find out more here: [https://roadie.io](https://roadie.io).

--- a/plugins/frontend/backstage-plugin-bitbucket-pullrequest/package.json
+++ b/plugins/frontend/backstage-plugin-bitbucket-pullrequest/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@roadiehq/backstage-plugin-bitbucket-pullrequest",
   "version": "2.1.0",
+  "deprecated": "This package has been deprecated in favor of @backstage-community/plugin-bitbucket-pull-requests. See README for migration instructions.",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
My coworker @smymoon added this plugin about a year ago: #1448

We've since realized this would be a better fit in the official Backstage Community Plugins repository. We're in the process of migrating it there to ensure better maintenance and broader community support.  I have added a pull request in community plugins here:
https://github.com/backstage/community-plugins/pull/5004

To prepare for this move, I've:
- Added a deprecation notice to the README
- Created a DEPRECATED.md with migration instructions
- Updated package.json to mark the package as deprecated

The migration is straightforward - users will just need to:
1. Uninstall this package
2. Install the community version
3. Update their imports

The new version is functionally identical and maintains backward compatibility with existing configurations.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
