### PR TITLE
Use first source if multiple are used

### DIFF
--- a/.changeset/plain-boats-crash.md
+++ b/.changeset/plain-boats-crash.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-argo-cd': minor
+---
+
+Added support for ArgoCD applications that use multiple sources (by using the first)

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/ArgoCDHistoryCard.tsx
@@ -56,6 +56,10 @@ const withRevisionDetails = async (
   url: string,
   row: any,
 ): Promise<ArgoCDHistoryTableRow> => {
+  if (row.sources) {
+    row.source = row.sources[0];
+    row.revision = row.revisions[0];
+  }
   if (isHelmChart(row)) {
     row.revisionDetails = { author: 'n/a', message: 'n/a', date: 'n/a' };
     return row;


### PR DESCRIPTION
ArgoCD applications can have either "source" or multiple "sources" this patch allows the creation of application history for apps with multiple sources by using the first defined source.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
