### PR TITLE
Fixes the error in the `weekly-check-versions` workflow

### DIFF
--- a/.github/workflows/weekly-check-versions.yml
+++ b/.github/workflows/weekly-check-versions.yml
@@ -23,6 +23,8 @@ jobs:
         run: |
           yarn install
           yarn backstage-cli versions:bump
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Get current time
         uses: 1466587594/get-current-time@v2


### PR DESCRIPTION
Currently the  `weekly-check-versions` workflow has been failing for the last little while with the following error: "YN0028: The lockfile would have been modified by this install, which is explicitly forbidden". We ran into similar issues on the Backstage Demo site and this PR add the same solution here.

Demo site code is here and has been in place for 2 years now: https://github.com/backstage/demo/blob/fd0ebec89c9eff4695db638e739c1be229c3a8ec/.github/workflows/version-bump.yml#L77

Note: if you'd like I'm more than happy to port over the full version bump workflow from the Demo site. It has the following advantages: generates a brand with the version number in it, supports running on `next` or `main` release lines, PR description includes links to the relevant change log and the upgrade helper. It's been pretty battle tested as well. We are also using a more complex version that uses a matrix for the Community Plugins. Example PR here: https://github.com/backstage/demo/pull/1117

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
