### PR TITLE
Updated the `backstage.pluginId` to match the `pluginId` set in the `createBackendModule`

### DIFF
--- a/.changeset/chilly-toys-turn.md
+++ b/.changeset/chilly-toys-turn.md
@@ -1,0 +1,9 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+'@roadiehq/scaffolder-backend-module-utils': patch
+'@roadiehq/scaffolder-backend-module-aws': patch
+'@roadiehq/scaffolder-backend-argocd': patch
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+Updated the `backstage.pluginId` to match the `pluginId` set in the `createBackendModule`

--- a/plugins/backend/catalog-backend-module-okta/package.json
+++ b/plugins/backend/catalog-backend-module-okta/package.json
@@ -31,7 +31,7 @@
   },
   "backstage": {
     "role": "backend-plugin-module",
-    "pluginId": "catalog-backend-module-okta",
+    "pluginId": "catalog",
     "pluginPackage": "@backstage/plugin-catalog-backend"
   },
   "homepage": "https://roadie.io",

--- a/plugins/scaffolder-actions/scaffolder-backend-argocd/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-argocd/package.json
@@ -11,7 +11,7 @@
   },
   "backstage": {
     "role": "backend-plugin-module",
-    "pluginId": "scaffolder-backend-argocd",
+    "pluginId": "scaffolder",
     "pluginPackage": "@backstage/plugin-scaffolder-backend"
   },
   "exports": {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-aws/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-aws/package.json
@@ -9,7 +9,7 @@
   },
   "backstage": {
     "role": "backend-plugin-module",
-    "pluginId": "scaffolder-backend-module-aws",
+    "pluginId": "scaffolder",
     "pluginPackage": "@backstage/plugin-scaffolder-backend"
   },
   "repository": {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/package.json
@@ -9,7 +9,7 @@
   },
   "backstage": {
     "role": "backend-plugin-module",
-    "pluginId": "scaffolder-backend-module-http-request",
+    "pluginId": "scaffolder",
     "pluginPackage": "@backstage/plugin-scaffolder-backend"
   },
   "exports": {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-utils/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "backstage": {
-    "role": "backend-plugin-module",
+    "role": "backend",
     "pluginId": "scaffolder-backend-module-utils",
     "pluginPackage": "@backstage/plugin-scaffolder-backend"
   },


### PR DESCRIPTION
Updated the `backstage.pluginId` to match the `pluginId` set in the `createBackendModule`. This follows the conventions for metadata documented here: https://backstage.io/docs/tooling/package-metadata#backstagepluginid. 🚀 

**Note:** running `yarn backstage-cli repo fix --publish` should have corrected this but some of the plugins have names that were set long before the plugin naming conventions were set. Renaming them did not make a lot of sense to me but this change gets us in the right state. We also may be doing additional linting or checks on these values in future Backstage versions, correcting this now avoids any impact from that change 👍 

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
