### PR TITLE
Fix casing bug for header parsing

### DIFF
--- a/.changeset/clean-insects-find.md
+++ b/.changeset/clean-insects-find.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': patch
+---
+
+Fix casing bug in automatic json serialisation

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -234,6 +234,40 @@ describe('http:backstage:request', () => {
           false,
         );
       });
+      it('should create a request and pass body parameter regardless of the header casing', async () => {
+        (http as jest.Mock).mockReturnValue({
+          code: 200,
+          headers: {},
+          body: {},
+        });
+        await action.handler({
+          ...mockContext,
+          input: {
+            path: '/api/proxy/foo',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify([
+              {
+                name: 'test',
+              },
+            ]),
+          },
+        });
+        expect(http).toHaveBeenCalledWith(
+          {
+            url: 'http://backstage.tests/api/proxy/foo',
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: '[{"name":"test"}]',
+          },
+          logger,
+          false,
+        );
+      });
     });
 
     describe('with authorization header', () => {

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -123,12 +123,17 @@ export function createHttpBackstageAction(options: {
 
       let inputBody: Body = undefined;
 
+      const inputHeaders: [string, any][] | undefined =
+        input.headers && Object.entries(input.headers);
       if (
         input.body &&
         typeof input.body !== 'string' &&
-        input.headers &&
-        input.headers['content-type'] &&
-        input.headers['content-type'].includes('application/json')
+        inputHeaders &&
+        inputHeaders.find(
+          kv =>
+            kv[0].toLowerCase() === 'content-type' &&
+            kv[1].toLowerCase() === 'application/json',
+        )
       ) {
         inputBody = JSON.stringify(input.body);
       } else {


### PR DESCRIPTION
When the header for this action is defined as `Content-Type` or `Content-type`, automatic json serialisation of the body does not happen resulting in an unhandled exception. This header should be case insensitive. 

#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
