### PR TITLE
Fix undefined issue and error handling in GitHub Pull Requests Statistics card if there is a PR without any commit

### DIFF
--- a/.changeset/heavy-experts-train.md
+++ b/.changeset/heavy-experts-train.md
@@ -1,0 +1,6 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+- Fix an issue that the GitHub Pull Requests Statistics ignores internal issues and shows undefined instead of an error message to the user.
+- Fix an issue that the GitHub Pull Requests Statistics card shows undefined (or an error) if a Pull Request without commits is consumed.

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsClient.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/api/GithubPullRequestsClient.ts
@@ -118,6 +118,11 @@ export class GithubPullRequestsClient implements GithubPullRequestsApi {
       repo: repo,
       pull_number: number,
     });
+    if (commits.length === 0) {
+      return {
+        firstCommitDate: null,
+      };
+    }
     const firstCommit = commits[0];
     return {
       firstCommitDate: new Date(firstCommit.commit.author!.date!),

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
@@ -15,21 +15,26 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { AnyApiRef, ConfigApi, configApiRef } from '@backstage/core-plugin-api';
 import {
+  AnyApiRef,
+  ConfigApi,
+  configApiRef,
+  errorApiRef,
+} from '@backstage/core-plugin-api';
+import { translationApiRef } from '@backstage/core-plugin-api/alpha';
+import { ScmAuthApi, scmAuthApiRef } from '@backstage/integration-react';
+import {
+  mockApis,
   setupRequestMockHandlers,
   TestApiProvider,
 } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
 import { githubPullRequestsApiRef } from '../..';
-import { GithubPullRequestsClient } from '../../api';
 import { entityMock } from '../../mocks/mocks';
 import PullRequestsStatsCard from './PullRequestsStatsCard';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { handlers } from '../../mocks/handlers';
-import { ScmAuthApi, scmAuthApiRef } from '@backstage/integration-react';
-import { ConfigReader } from '@backstage/core-app-api';
-import { defaultIntegrationsConfig } from '../../mocks/scmIntegrationsApiMock';
+import { GithubPullRequestsApiMock } from '../../mocks/githubPullRequestsApiMock';
 
 const mockScmAuth = {
   getCredentials: async () => ({ token: 'test-token', headers: {} }),
@@ -46,21 +51,14 @@ const config = {
   },
 } as ConfigApi;
 
+const errorApiMock = { post: jest.fn(), error$: jest.fn() };
+
 const apis: [AnyApiRef, Partial<unknown>][] = [
   [configApiRef, config],
+  [errorApiRef, errorApiMock],
   [scmAuthApiRef, mockScmAuth],
-  [
-    githubPullRequestsApiRef,
-    new GithubPullRequestsClient({
-      configApi: ConfigReader.fromConfigs([
-        {
-          context: 'unit-test',
-          data: defaultIntegrationsConfig,
-        },
-      ]),
-      scmAuthApi: mockScmAuth,
-    }),
-  ],
+  [githubPullRequestsApiRef, new GithubPullRequestsApiMock()],
+  [translationApiRef, mockApis.translation()],
 ];
 
 describe('PullRequestsCard', () => {

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/components/usePullRequestsStatistics.ts
@@ -44,7 +44,7 @@ export type PullRequestStatsCount = {
 };
 export type PullRequestStatsData = {
   createdAt: string;
-  firstCommitAt: string;
+  firstCommitAt: string | null;
   closedAt: string | null;
   pullRequest: {
     mergedAt: string | null;
@@ -60,10 +60,13 @@ function calculateStatistics(pullRequestsData: PullRequestStatsData[]) {
         ? new Date(curr.pullRequest.mergedAt).getTime() -
           new Date(curr.createdAt).getTime()
         : 0;
-      const avgCodingTime =
-        new Date(curr.createdAt).getTime() -
-        new Date(curr.firstCommitAt).getTime();
-      acc.avgCodingTime += avgCodingTime > 0 ? avgCodingTime : 0;
+      // Ignore PRs without any commit
+      if (curr.firstCommitAt) {
+        const avgCodingTime =
+          new Date(curr.createdAt).getTime() -
+          new Date(curr.firstCommitAt).getTime();
+        acc.avgCodingTime += avgCodingTime > 0 ? avgCodingTime : 0;
+      }
       acc.mergedCount += curr.pullRequest.mergedAt ? 1 : 0;
       acc.closedCount += curr.closedAt ? 1 : 0;
       acc.additions += curr.pullRequest.additions;
@@ -169,7 +172,7 @@ export function usePullRequestsStatistics({
           return {
             createdAt: pr.created_at,
             closedAt: pr.closed_at,
-            firstCommitAt: commitDate.firstCommitDate.toString(),
+            firstCommitAt: commitDate.firstCommitDate?.toString() ?? null,
             pullRequest: {
               mergedAt: pr.pull_request.merged_at,
               additions: repoData.additions,

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/mocks/githubPullRequestsApiMock.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/mocks/githubPullRequestsApiMock.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GithubPullRequestsApi } from '../api';
+import {
+  GithubFirstCommitDate,
+  GithubRepositoryData,
+  GithubSearchPullRequestsDataItem,
+  SearchPullRequestsResponseData,
+} from '../types';
+
+export class GithubPullRequestsApiMock implements GithubPullRequestsApi {
+  async listPullRequests(): Promise<{
+    pullRequestsData: SearchPullRequestsResponseData;
+  }> {
+    return {
+      pullRequestsData: {
+        total_count: 0,
+        incomplete_results: false,
+        items: [],
+      },
+    };
+  }
+
+  async getRepositoryData(): Promise<GithubRepositoryData> {
+    // Return mock repository data
+    return {
+      htmlUrl: '',
+      fullName: 'mock-owner/mock-repo',
+      additions: 10,
+      deletions: 5,
+      changedFiles: 3,
+    };
+  }
+
+  async getCommitDetailsData(): Promise<GithubFirstCommitDate> {
+    return {
+      firstCommitDate: new Date('2023-01-01T00:00:00Z'),
+    };
+  }
+
+  async searchPullRequest(): Promise<GithubSearchPullRequestsDataItem[]> {
+    return [];
+  }
+}

--- a/plugins/frontend/backstage-plugin-github-pull-requests/src/types.ts
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/src/types.ts
@@ -67,5 +67,5 @@ export type GithubRepositoryData = {
 };
 
 export type GithubFirstCommitDate = {
-  firstCommitDate: Date;
+  firstCommitDate: Date | null;
 };


### PR DESCRIPTION
This PR fixes two issues in the github-pull-requests plugin, esp. the card "GitHub Pull Requests Statistics" when it consumes a PR without any commit.

## Before

<img width="887" height="474" alt="image" src="https://github.com/user-attachments/assets/0578c5af-5bdc-49ac-981e-f60353674972" />

## Interim version

With the change in `PullRequestsStatsCard.tsx` it shows an ErrorPanel that shows the root cause:

<img width="850" height="766" alt="Screenshot From 2025-09-30 22-10-40" src="https://github.com/user-attachments/assets/938c587d-706a-4529-b641-33ce2d77c24b" />

## Final version

With the other small changes `getCommitDetailsData` and `calculateStatistics` doesn't crash anymore when there is a PR without any commit.

<img width="887" height="474" alt="image" src="https://github.com/user-attachments/assets/c4934758-901a-4b4e-8fb7-791b3da8c501" />

Yep, its an edge case but we actually found that in production. ;)

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
