### PR TITLE
Use scaffolder pluginId for http-request-field module

### DIFF
--- a/.changeset/silly-books-pull.md
+++ b/.changeset/silly-books-pull.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/plugin-scaffolder-frontend-module-http-request-field': patch
+---
+
+Add NFS metadata to package.json

--- a/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/package.json
+++ b/plugins/scaffolder-field-extensions/scaffolder-frontend-module-http-request-field/package.json
@@ -10,11 +10,9 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "frontend-plugin",
-    "pluginId": "plugin-scaffolder-frontend-module-http-request-field",
-    "pluginPackages": [
-      "@roadiehq/plugin-scaffolder-frontend-module-http-request-field"
-    ]
+    "role": "frontend-plugin-module",
+    "pluginId": "scaffolder",
+    "pluginPackage": "@backstage/plugin-scaffolder"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changes
- Map the `http-request-field` scaffolder module to the `scaffolder` plugin

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [ ] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
