### PR TITLE
feat(rag-ai): add property maxConcurrency to Bedrock embeddings config

### DIFF
--- a/.changeset/clever-seals-lie.md
+++ b/.changeset/clever-seals-lie.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend': patch
+---
+
+Added property maxConcurrency to example AWS Bedrock configuration

--- a/.changeset/tender-bobcats-sip.md
+++ b/.changeset/tender-bobcats-sip.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/rag-ai-backend-embeddings-aws': minor
+---
+
+Added property maxConcurrency to config to limit number of concurrent requests for AWS SDK client (defaults to 100)

--- a/plugins/backend/rag-ai-backend-embeddings-aws/README.md
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/README.md
@@ -51,6 +51,8 @@ ai:
       modelName: 'amazon.titan-embed-text-v1'
       # Maximum number of retries for the AWS SDK client
       maxRetries: 3
+      # Maximum number of concurrent requests for the AWS SDK client
+      maxConcurrency: 100
 ```
 
 ### AWS Credentials Configuration

--- a/plugins/backend/rag-ai-backend-embeddings-aws/config.d.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/config.d.ts
@@ -30,6 +30,10 @@ export interface Config {
          * Maximum number of retries for the AWS SDK client. Defaults to 3
          */
         maxRetries?: string;
+        /**
+         * Maximum number of concurrent requests for the AWS SDK client. Defaults to 100
+         */
+        maxConcurrency?: string;
       };
     };
   };

--- a/plugins/backend/rag-ai-backend-embeddings-aws/src/RoadieBedrockAugmenter.ts
+++ b/plugins/backend/rag-ai-backend-embeddings-aws/src/RoadieBedrockAugmenter.ts
@@ -24,6 +24,7 @@ import { BedrockCohereEmbeddings } from './BedrockCohereEmbeddings';
 export type BedrockConfig = {
   modelName: string;
   maxRetries?: number;
+  maxConcurrency?: number;
 };
 
 export class RoadieBedrockAugmenter extends DefaultVectorAugmentationIndexer {
@@ -45,10 +46,12 @@ export class RoadieBedrockAugmenter extends DefaultVectorAugmentationIndexer {
       ? new BedrockCohereEmbeddings({
           ...embeddingsConfig,
           maxRetries: config.bedrockConfig.maxRetries ?? 3,
+          maxConcurrency: config.bedrockConfig.maxConcurrency ?? 100,
         })
       : new BedrockEmbeddings({
           ...embeddingsConfig,
           maxRetries: config.bedrockConfig.maxRetries ?? 3,
+          maxConcurrency: config.bedrockConfig.maxConcurrency ?? 100,
         });
 
     super({ ...config, embeddings });

--- a/plugins/backend/rag-ai-backend/README.md
+++ b/plugins/backend/rag-ai-backend/README.md
@@ -78,6 +78,9 @@ ai:
       # (Optional) Maximum number of retries for the AWS SDK client
       maxRetries: 3
 
+      # (Optional) Maximum number of concurrent requests for the AWS SDK client
+      maxConcurrency: 100
+
       ## AWS Bedrock uses integration-aws-node package to configure credentials. See the package README for more info.
 
     # OpenAI Embeddings configuration


### PR DESCRIPTION
This PR adds the property `maxConcurrency` to the Bedrock embeddings config.

I tried experimenting with the default number, but as soon as I added another 0 (1000, 10000,...) I started getting Node.js errors like `ERR_HTTP2_STREAM_CANCEL`, so I assumed 100 would be a safe bet.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [x] Added or updated documentation (if applicable)
