### PR TITLE
fix(backstage-plugin-argo-cd): display source/destination for multi-source applications

### DIFF
--- a/.changeset/fix-multi-source-details.md
+++ b/.changeset/fix-multi-source-details.md
@@ -7,6 +7,7 @@ Fix: Display repository URL and path for ArgoCD applications with multiple sourc
 When ArgoCD applications use multiple sources via `spec.sources` array instead of `spec.source`, the DetailsDrawer component was unable to display source and path information. This fix adds a fallback to extract these values from the first source in the array when the singular source property is not available.
 
 **Changes:**
+
 - Updated `DetailsDrawer.tsx` to check `spec.source?.repoURL` first, then fallback to `spec.sources?.[0]?.repoURL`
 - Updated `DetailsDrawer.tsx` to check `spec.source?.path` first, then fallback to `spec.sources?.[0]?.path`
 

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
@@ -62,7 +62,8 @@ export const DetailsDrawerComponent = (
     };
   const tableContent: TableContent = {
     'Argo CD Instance': rowData.metadata?.instance?.name ?? '',
-    repoUrl: rowData.spec?.source?.repoURL || rowData.spec?.sources?.[0]?.repoURL,
+    repoUrl:
+      rowData.spec?.source?.repoURL || rowData.spec?.sources?.[0]?.repoURL,
     repoPath: rowData.spec?.source?.path || rowData.spec?.sources?.[0]?.path,
     destinationServer: rowData.spec?.destination?.server,
     destinationNamespace: rowData.spec?.destination?.namespace,


### PR DESCRIPTION
Display repo URL and path for ArgoCD multi-source applications by falling back to spec.sources[0] when spec.source is absent.

Files changed:
- .changeset/fix-multi-source-details.md
- plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx

- Relates to PR #2025 which applied a similar fix to the history card.