### PR TITLE
fix(backstage-plugin-argo-cd): display destination name when server is not available

### DIFF
--- a/.changeset/fix-destination-name.md
+++ b/.changeset/fix-destination-name.md
@@ -2,8 +2,8 @@
 '@roadiehq/backstage-plugin-argo-cd': patch
 ---
 
-Fix Destination Server field to display destination.name when destination.server is not available. 
-ArgoCD allows applications to be configured with either destination.server (Kubernetes API URL) 
-or destination.name (cluster name reference). This change adds fallback logic to show the cluster 
-name when the server URL is not present, ensuring the Destination Server field displays properly 
+Fix Destination Server field to display destination.name when destination.server is not available.
+ArgoCD allows applications to be configured with either destination.server (Kubernetes API URL)
+or destination.name (cluster name reference). This change adds fallback logic to show the cluster
+name when the server URL is not present, ensuring the Destination Server field displays properly
 for modern ArgoCD configurations.

--- a/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
+++ b/plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx
@@ -65,7 +65,8 @@ export const DetailsDrawerComponent = (
     repoUrl:
       rowData.spec?.source?.repoURL || rowData.spec?.sources?.[0]?.repoURL,
     repoPath: rowData.spec?.source?.path || rowData.spec?.sources?.[0]?.path,
-    destinationServer: rowData.spec?.destination?.server || rowData.spec?.destination?.name,
+    destinationServer:
+      rowData.spec?.destination?.server || rowData.spec?.destination?.name,
     destinationNamespace: rowData.spec?.destination?.namespace,
     syncStatus: rowData.status?.sync?.status,
     images: rowData.status?.summary?.images,


### PR DESCRIPTION
## Problem

ArgoCD supports two ways to configure application destinations:
- **destination.server** - Kubernetes API URL (e.g., `https://kubernetes.default.svc`)
- **destination.name** - Cluster name reference (e.g., `my-gke-cluster`)

Modern ArgoCD configurations often use `destination.name` instead of `destination.server`. The DetailsDrawer component was unable to display the Destination Server field when only `destination.name` was set.

## Solution

Added fallback logic to display `destination.name` when `destination.server` is not present, following the same pattern used for multi-source applications.

## Changes

- Updated `DetailsDrawer.tsx` to check `destination.server` first, then fallback to `destination.name`
- Added changeset for semantic versioning

## Related PRs

- Related to #2115 - fix(backstage-plugin-argo-cd): display source/destination for multi-source applications
- Relates to #2025 - Use first source if multiple are used (similar fix applied to history card)

## Files Changed

- `.changeset/fix-destination-name.md`
- `plugins/frontend/backstage-plugin-argo-cd/src/components/DetailsDrawer.tsx`