### PR TITLE
Apply correct array slicing

### DIFF
--- a/.changeset/rich-dogs-end.md
+++ b/.changeset/rich-dogs-end.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-glean-backend': patch
+---
+
+Apply correct slicing of documents into batches when indexing

--- a/plugins/backend/glean-backend/src/client/GleanIndexClient.ts
+++ b/plugins/backend/glean-backend/src/client/GleanIndexClient.ts
@@ -172,8 +172,9 @@ export class GleanIndexClient {
       const isLastPage = documents
         ? index >= documents.length - batchSize
         : false;
+      const batch = documents.slice(index, index + batchSize);
       const response = await this.indexDocuments(
-        documents,
+        batch,
         isFirstPage,
         isLastPage,
         uploadId,


### PR DESCRIPTION
Apply correct batches slicing when indexing documents for Glean plugin
