### PR TITLE
fix(prometheus): use fetchApi instead of native fetch for backend aut…

### DIFF
--- a/.changeset/fancy-baths-ask.md
+++ b/.changeset/fancy-baths-ask.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-prometheus': patch
+---
+
+Replace native fetch() with Backstage fetchApi in PrometheusApi to attach auth credentials to proxy requests. Fixes 401 Unauthorized errors when using the plugin with Backstage 1.24+ where backend auth is required by default.

--- a/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/api/index.ts
@@ -18,6 +18,7 @@ import {
   ConfigApi,
   createApiRef,
   DiscoveryApi,
+  FetchApi,
 } from '@backstage/core-plugin-api';
 import { DateTime, Duration } from 'luxon';
 
@@ -31,15 +32,18 @@ export const prometheusApiRef = createApiRef<PrometheusApi>({
 type Options = {
   discoveryApi: DiscoveryApi;
   configApi: ConfigApi;
+  fetchApi: FetchApi;
 };
 
 export class PrometheusApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly configApi: ConfigApi;
+  private readonly fetchApi: FetchApi;
 
   constructor(options: Options) {
     this.discoveryApi = options.discoveryApi;
     this.configApi = options.configApi;
+    this.fetchApi = options.fetchApi;
   }
 
   private async getApiUrl({ serviceName }: { serviceName?: string }) {
@@ -103,7 +107,7 @@ export class PrometheusApi {
 
     const end = DateTime.now().toSeconds();
     const start = DateTime.now().minus(Duration.fromObject(range)).toSeconds();
-    const response = await fetch(
+    const response = await this.fetchApi.fetch(
       `${apiUrl}/query_range?query=${query}&start=${start}&end=${end}&step=${step}`,
       {
         headers: {
@@ -121,7 +125,7 @@ export class PrometheusApi {
 
   async getAlerts({ serviceName }: { serviceName?: string }) {
     const apiUrl = await this.getApiUrl({ serviceName });
-    const response = await fetch(`${apiUrl}/rules?type=alert`, {
+    const response = await this.fetchApi.fetch(`${apiUrl}/rules?type=alert`, {
       headers: {
         [SERVICE_NAME_HEADER]: serviceName || '',
       },

--- a/plugins/frontend/backstage-plugin-prometheus/src/plugin.ts
+++ b/plugins/frontend/backstage-plugin-prometheus/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createRoutableExtension,
   createRouteRef,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { PrometheusApi, prometheusApiRef } from './api';
 
@@ -33,9 +34,13 @@ export const backstagePluginPrometheusPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: prometheusApiRef,
-      deps: { discoveryApi: discoveryApiRef, configApi: configApiRef },
-      factory: ({ discoveryApi, configApi }) =>
-        new PrometheusApi({ discoveryApi, configApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, configApi, fetchApi }) =>
+        new PrometheusApi({ discoveryApi, configApi, fetchApi }),
     }),
   ],
   routes: {


### PR DESCRIPTION
## Summary

Replace native `fetch()` with Backstage's `fetchApi` in `PrometheusApi` to fix 401 Unauthorized errors when using the plugin with Backstage 1.24+.

## Problem

Since Backstage 1.24, the backend requires valid auth tokens on all proxy requests by default. The Prometheus plugin uses the browser's native `fetch()` to make API calls, which bypasses Backstage's `FetchMiddlewares.injectIdentityAuth` middleware. This means no `Authorization: Bearer <token>` header is attached, and the backend proxy rejects requests with 401.

The only workaround is setting `credentials: 'dangerously-allow-unauthenticated'` on the proxy route, which disables auth entirely.

## Fix

- Added `FetchApi` to the `PrometheusApi` constructor options
- Replaced `fetch()` with `this.fetchApi.fetch()` in `query()` and `getAlerts()` methods
- Updated the API factory in `plugin.ts` to inject `fetchApiRef`

This allows users to use `credentials: 'forward'` or `credentials: 'require'` on their proxy config, consistent with how other Backstage plugins handle authentication.

## Files changed

- `plugins/frontend/backstage-plugin-prometheus/src/api/index.ts`
- `plugins/frontend/backstage-plugin-prometheus/src/plugin.ts`

## References
https://backstage.io/docs/releases/v1.24.0-changelog/ - Confirms incoming requests are rejected if not properly authenticated for users on the new backend system
https://backstage.io/docs/tutorials/auth-service-migration/ - Documents the auth service rework in 1.24 that made backend auth required by default
https://backstage.io/api/stable/classes/_backstage_core-app-api.FetchMiddlewares.html - Documents how fetchApi's injectIdentityAuth middleware automatically attaches Authorization Bearer tokens to requests

✔️ Checklist

- [ ]   Added tests for new functionality and regression tests for bug fixes
- [x]  Added changeset (run yarn changeset in the root)
- [ ]  Screenshots of before and after attached (for UI changes)
- [ ]  Added or updated documentation (if applicable)


