### PR TITLE
feat: @okta/okta-sdk-nodejs major version bumps

### DIFF
--- a/.changeset/twelve-houses-punch.md
+++ b/.changeset/twelve-houses-punch.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': minor
+---
+
+feat: @okta/okta-sdk-nodejs major version bump

--- a/plugins/backend/catalog-backend-module-okta/README.md
+++ b/plugins/backend/catalog-backend-module-okta/README.md
@@ -204,7 +204,7 @@ You may also choose to implement a custom naming strategy by providing a functio
 
 ```typescript jsx
 export const customUserNamingStrategy: UserNamingStrategy = user =>
-  user.profile.customField;
+  user?.profile?.customField || 'fallBack';
 ```
 
 #### Group naming strategies
@@ -219,7 +219,7 @@ You may also choose to implement a custom naming strategy by providing a functio
 
 ```typescript jsx
 export const customGroupNamingStrategy: GroupNamingStrategy = group =>
-  group.profile.customField;
+  group?.profile?.customField || 'fallBack';
 ```
 
 #### Hierarchy config
@@ -272,9 +272,9 @@ export const myGroupTransformer: OktaGroupEntityTransformer = function (
         ...options.annotations,
       },
       name: namingStrategy(group),
-      title: group.profile.name,
-      title: group.profile.description || group.profile.name,
-      description: group.profile.description || '',
+      title: group?.profile?.name || 'fallBack',
+      title: group?.profile?.description || group?.profile?.name || 'fallBack',
+      description: group?.profile?.description || '',
     },
     spec: {
       members: options.members,
@@ -447,7 +447,7 @@ You may also choose to implement a custom naming strategy by providing a functio
 
 ```typescript jsx
 export const customUserNamingStrategy: UserNamingStrategy = user =>
-  user.profile.customField;
+  user?.profile?.customField || 'fallBack';
 ```
 
 In case you want to customize the emitted entities, the provider allows to pass custom transformer by providing
@@ -473,12 +473,12 @@ export const myUserTransformer: OktaUserEntityTransformer = function (
     metadata: {
       annotations: { ...options.annotations },
       name: namingStrategy(user),
-      title: user.profile.email,
+      title: user?.profile?.email || 'fallBack',
     },
     spec: {
       profile: {
-        displayName: user.profile.displayName,
-        email: user.profile.email,
+        displayName: user?.profile?.displayName || 'fallBack',
+        email: user?.profile?.email || 'fallBack',
       },
       memberOf: [],
     },
@@ -542,7 +542,7 @@ You may also choose to implement a custom naming strategy by providing a functio
 
 ```typescript jsx
 export const customUserNamingStrategy: UserNamingStrategy = user =>
-  user.profile.customField;
+  user?.profile?.customField || 'fallBack';
 ```
 
 Group naming strategies:
@@ -557,7 +557,7 @@ You may also choose to implement a custom naming strategy by providing a functio
 
 ```typescript jsx
 export const customGroupNamingStrategy: GroupNamingStrategy = group =>
-  group.profile.customField;
+  group?.profile?.customField || 'fallBack';
 ```
 
 Make sure you use the OktaUserEntityProvider's naming strategy for the OktaGroupEntityProvider's user naming strategy.
@@ -594,9 +594,9 @@ export const myGroupTransformer: OktaGroupEntityTransformer = function (
         ...options.annotations,
       },
       name: namingStrategy(group),
-      title: group.profile.name,
-      title: group.profile.description || group.profile.name,
-      description: group.profile.description || '',
+      title: group?.profile?.name || 'fallBack',
+      title: group?.profile?.description || group?.profile?.name || 'fallBack',
+      description: group?.profile?.description || '',
     },
     spec: {
       members: options.members,

--- a/plugins/backend/catalog-backend-module-okta/package.json
+++ b/plugins/backend/catalog-backend-module-okta/package.json
@@ -63,7 +63,7 @@
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-catalog-backend": "backstage:^",
     "@backstage/plugin-catalog-node": "backstage:^",
-    "@okta/okta-sdk-nodejs": "^6.6.0",
+    "@okta/okta-sdk-nodejs": "^8.1.0",
     "lodash": "^4.17.21",
     "slugify": "^1.6.6"
   },

--- a/plugins/backend/catalog-backend-module-okta/src/__testUtils__/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/__testUtils__/index.ts
@@ -17,7 +17,7 @@
 import { createLogger } from 'winston';
 
 export class MockOktaCollection {
-  private items: Array<any>;
+  readonly items: Array<any>;
 
   constructor(items: Array<any>) {
     this.items = items;

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.ts
@@ -19,7 +19,8 @@ import {
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
 import { AccountConfig } from '../types';
-import { Client, User, Group } from '@okta/okta-sdk-nodejs';
+import { Client } from '@okta/okta-sdk-nodejs';
+import { OktaGroup, OktaUser } from './types';
 
 import {
   ANNOTATION_LOCATION,
@@ -84,12 +85,15 @@ export abstract class OktaEntityProvider implements EntityProvider {
     };
   }
 
-  protected getCustomAnnotations(member: User | Group, allowList: string[]) {
+  protected getCustomAnnotations(
+    member: OktaUser | OktaGroup,
+    allowList: string[],
+  ) {
     const profileAnnotations: Record<string, string> = {};
     if (allowList.length) {
-      for (const [key, value] of new Map(Object.entries(member.profile))) {
-        if (allowList.includes(key)) {
-          profileAnnotations[key] = value.toString();
+      for (const [key, value] of Object.entries(member.profile)) {
+        if (allowList.includes(key) && value !== undefined && value !== null) {
+          profileAnnotations[key] = String(value);
         }
       }
     }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
@@ -24,11 +24,19 @@ let listGroups: () => MockOktaCollection = () => {
   return new MockOktaCollection([]);
 };
 
+const listGroupUsers = ({ groupId }: { groupId: string }) => {
+  const group = listGroups().items.find((g: any) => g.id === groupId);
+  return group?.listUsers?.() ?? new MockOktaCollection([]);
+};
+
 jest.mock('@okta/okta-sdk-nodejs', () => {
   return {
     Client: jest.fn().mockImplementation(() => {
       return {
-        listGroups,
+        groupApi: {
+          listGroups,
+          listGroupUsers,
+        },
       };
     }),
   };
@@ -467,12 +475,14 @@ describe('OktaGroupProvider', () => {
           metadata: {
             annotations: { ...options.annotations },
             name: namingStrategy(group),
-            title: group.profile.name,
-            description: group.profile.description || '',
+            title: group?.profile?.name || 'fallBack',
+            description: group?.profile?.description || '',
           },
           spec: {
             profile: {
-              displayName: group.profile.displayName as string,
+              displayName:
+                ((group?.profile as { displayName?: string } | undefined)
+                  ?.displayName as string) || 'fallBack',
             },
             members: options.members,
             type: 'group',

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.ts
@@ -34,7 +34,7 @@ import { getAccountConfig } from './accountConfig';
 import { isError } from '@backstage/errors';
 import { getOktaGroups } from './getOktaGroups';
 import { getParentGroup } from './getParentGroup';
-import { OktaGroupEntityTransformer } from './types';
+import { OktaGroupEntityTransformer, asOktaUser } from './types';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 const DEFAULT_CHUNK_SIZE = 250;
@@ -141,7 +141,11 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
         entries.map(async ([_, group]) => {
           const members: string[] = [];
           try {
-            await group.listUsers().each(user => {
+            const groupUsers = await client.groupApi.listGroupUsers({
+              groupId: group.id,
+            });
+            await groupUsers.each(rawUser => {
+              const user = asOktaUser(rawUser);
               try {
                 const userName = this.userNamingStrategy(user);
                 members.push(userName);
@@ -169,12 +173,13 @@ export class OktaGroupEntityProvider extends OktaEntityProvider {
           });
           const profileAnnotations: Record<string, string> = {};
           if (this.customAttributesToAnnotationAllowlist.length) {
-            for (const [key, value] of new Map(Object.entries(group.profile))) {
-              const stringKey = key.toString();
+            for (const [key, value] of Object.entries(group.profile)) {
               if (
-                this.customAttributesToAnnotationAllowlist.includes(stringKey)
+                this.customAttributesToAnnotationAllowlist.includes(key) &&
+                value !== undefined &&
+                value !== null
               ) {
-                profileAnnotations[stringKey] = value.toString();
+                profileAnnotations[key] = String(value);
               }
             }
           }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
@@ -54,12 +54,22 @@ let listUsers: () => MockOktaCollection = () => {
   return new MockOktaCollection(allUsers);
 };
 
+const listGroupUsers = ({ groupId }: { groupId: string }) => {
+  const group = listGroups().items.find((g: any) => g.id === groupId);
+  return group?.listUsers?.() ?? new MockOktaCollection([]);
+};
+
 jest.mock('@okta/okta-sdk-nodejs', () => {
   return {
     Client: jest.fn().mockImplementation(() => {
       return {
-        listGroups,
-        listUsers,
+        userApi: {
+          listUsers,
+        },
+        groupApi: {
+          listGroups,
+          listGroupUsers,
+        },
       };
     }),
   };
@@ -410,7 +420,7 @@ describe('OktaOrgEntityProvider', () => {
       listGroups = () => {
         return new MockOktaCollection([
           {
-            id: 'asdfwefwefwef',
+            id: 'group-everyone',
             profile: {
               name: 'Everyone@the-company',
               description: 'Everyone in the company',
@@ -435,7 +445,7 @@ describe('OktaOrgEntityProvider', () => {
             },
           },
           {
-            id: 'asdfwefwefwef',
+            id: 'group-some',
             profile: {
               name: 'Some@the-company',
               description: 'Some in the company',
@@ -509,7 +519,7 @@ describe('OktaOrgEntityProvider', () => {
       listGroups = () => {
         return new MockOktaCollection([
           {
-            id: 'asdfwefwefwef',
+            id: 'group-everyone',
             profile: {
               name: 'Everyone@the-company',
               description: 'Everyone in the company',
@@ -534,7 +544,7 @@ describe('OktaOrgEntityProvider', () => {
             },
           },
           {
-            id: 'asdfwefwefwef',
+            id: 'group-some',
             profile: {
               name: 'Some@the-company',
               description: 'Some in the company',
@@ -572,12 +582,12 @@ describe('OktaOrgEntityProvider', () => {
             entity: expect.objectContaining({
               kind: 'Group',
               metadata: expect.objectContaining({
-                name: 'asdfwefwefwef',
+                name: 'group-everyone',
                 title: 'Everyone@the-company',
               }),
               spec: expect.objectContaining({
                 members: ['user-1', 'user-2'],
-                parent: 'asdfwefwefwef',
+                parent: 'group-everyone',
               }),
             }),
           }),
@@ -585,12 +595,12 @@ describe('OktaOrgEntityProvider', () => {
             entity: expect.objectContaining({
               kind: 'Group',
               metadata: expect.objectContaining({
-                name: 'asdfwefwefwef',
+                name: 'group-some',
                 title: 'Some@the-company',
               }),
               spec: expect.objectContaining({
                 members: ['user-1'],
-                parent: 'asdfwefwefwef',
+                parent: 'group-everyone',
               }),
             }),
           }),
@@ -700,12 +710,13 @@ describe('OktaOrgEntityProvider', () => {
           metadata: {
             annotations: { ...options.annotations },
             name: namingStrategy(group),
-            title: group.profile.name,
-            description: group.profile.description || '',
+            title: group.profile!.name,
+            description: group.profile!.description || '',
           },
           spec: {
             profile: {
-              displayName: group.profile.displayName as string,
+              displayName: (group.profile as { displayName?: string })
+                .displayName as string,
             },
             members: options.members,
             type: 'group',
@@ -780,12 +791,12 @@ describe('OktaOrgEntityProvider', () => {
           metadata: {
             annotations: { ...options.annotations },
             name: namingStrategy(user),
-            title: user.profile.email,
+            title: user.profile!.email,
           },
           spec: {
             profile: {
-              displayName: user.profile.displayName,
-              email: user.profile.email,
+              displayName: user.profile!.displayName ?? undefined,
+              email: user.profile!.email,
               picture: 'picture.com',
             },
             memberOf: [],

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.ts
@@ -35,7 +35,11 @@ import { isError } from '@backstage/errors';
 import { getOktaGroups } from './getOktaGroups';
 import { getParentGroup } from './getParentGroup';
 import { GroupTree } from './GroupTree';
-import { OktaGroupEntityTransformer, OktaUserEntityTransformer } from './types';
+import {
+  OktaGroupEntityTransformer,
+  OktaUserEntityTransformer,
+  asOktaUser,
+} from './types';
 import chunk from 'lodash/chunk';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
@@ -144,7 +148,11 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
 
     const defaultAnnotations = await this.buildDefaultAnnotations();
 
-    await client.listUsers({ search: this.account.userFilter }).each(user => {
+    const allUsers = await client.userApi.listUsers({
+      search: this.account.userFilter,
+    });
+    await allUsers.each(rawUser => {
+      const user = asOktaUser(rawUser);
       try {
         const userName = this.userNamingStrategy(user);
         userResources[userName] = this.userEntityFromOktaUser(
@@ -178,7 +186,11 @@ export class OktaOrgEntityProvider extends OktaEntityProvider {
       const promiseResults = await Promise.allSettled(
         chunkOfGroups.map(async group => {
           const members: string[] = [];
-          await group.listUsers().each(user => {
+          const groupUsers = await client.groupApi.listGroupUsers({
+            groupId: group.id,
+          });
+          await groupUsers.each(rawUser => {
+            const user = asOktaUser(rawUser);
             try {
               const userName = this.userNamingStrategy(user);
               if (userResources[userName]) {

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
@@ -26,7 +26,9 @@ jest.mock('@okta/okta-sdk-nodejs', () => {
   return {
     Client: jest.fn().mockImplementation(() => {
       return {
-        listUsers,
+        userApi: {
+          listUsers,
+        },
       };
     }),
   };
@@ -181,7 +183,7 @@ describe('OktaUserEntityProvider', () => {
       };
       const provider = OktaUserEntityProvider.fromConfig(config, {
         logger,
-        namingStrategy: user => user.id,
+        namingStrategy: user => user.id!,
       });
       provider.connect(entityProviderConnection);
       await provider.run();
@@ -261,12 +263,12 @@ describe('OktaUserEntityProvider', () => {
           metadata: {
             annotations: { ...options.annotations },
             name: namingStrategy(user),
-            title: user.profile.email,
+            title: user.profile!.email,
           },
           spec: {
             profile: {
-              displayName: user.profile.displayName,
-              email: user.profile.email,
+              displayName: user.profile!.displayName ?? undefined,
+              email: user.profile!.email,
               picture: 'picture.com',
             },
             memberOf: [],

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.ts
@@ -26,7 +26,7 @@ import { AccountConfig } from '../types';
 import { userEntityFromOktaUser as defaultUserEntityFromOktaUser } from './userEntityFromOktaUser';
 import { getAccountConfig } from './accountConfig';
 import { isError } from '@backstage/errors';
-import { OktaUserEntityTransformer } from './types';
+import { OktaUserEntityTransformer, asOktaUser } from './types';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
@@ -88,9 +88,12 @@ export class OktaUserEntityProvider extends OktaEntityProvider {
 
     const defaultAnnotations = await this.buildDefaultAnnotations();
 
-    const allUsers = await client.listUsers({ search: this.userFilter });
+    const allUsers = await client.userApi.listUsers({
+      search: this.userFilter,
+    });
 
-    await allUsers.each(user => {
+    await allUsers.each(rawUser => {
+      const user = asOktaUser(rawUser);
       const profileAnnotations = this.getCustomAnnotations(
         user,
         this.customAttributesToAnnotationAllowlist,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/getOktaGroups.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/getOktaGroups.ts
@@ -15,9 +15,10 @@
  */
 import get from 'lodash/get';
 import { isError } from '@backstage/errors';
-import { Group, Client } from '@okta/okta-sdk-nodejs';
+import { Client } from '@okta/okta-sdk-nodejs';
 import { GroupNamingStrategy } from './groupNamingStrategies';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { OktaGroup, asOktaGroup } from './types';
 
 type GetOktaGroupsOptions = {
   client: Client;
@@ -30,9 +31,11 @@ type GetOktaGroupsOptions = {
 export const getOktaGroups = async (opts: GetOktaGroupsOptions) => {
   const { client, groupFilter, key, groupNamingStrategy, logger } = opts;
 
-  const oktaGroups: Record<string, Group> = {};
+  const oktaGroups: Record<string, OktaGroup> = {};
 
-  await client.listGroups({ search: groupFilter }).each(group => {
+  const groups = await client.groupApi.listGroups({ search: groupFilter });
+  await groups.each(rawGroup => {
+    const group = asOktaGroup(rawGroup);
     if (key) {
       const id = get(group, key);
       if (typeof id === 'string') {

--- a/plugins/backend/catalog-backend-module-okta/src/providers/getParentGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/getParentGroup.ts
@@ -13,18 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Group } from '@okta/okta-sdk-nodejs';
 import get from 'lodash/get';
+import { OktaGroup } from './types';
 
 type GetParentGroupsOptions = {
   parentKey?: string;
-  group: Group;
-  oktaGroups: Record<string, Group>;
+  group: OktaGroup;
+  oktaGroups: Record<string, OktaGroup>;
 };
 
 export const getParentGroup = (opts: GetParentGroupsOptions) => {
   const { parentKey, group, oktaGroups } = opts;
-  let parentGroup: Group | undefined = undefined;
+  let parentGroup: OktaGroup | undefined = undefined;
 
   if (parentKey) {
     const parentId = get(group, parentKey);

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.test.ts
@@ -16,6 +16,7 @@
 
 import { groupEntityFromOktaGroup } from './groupEntityFromOktaGroup';
 import { Group } from '@okta/okta-sdk-nodejs';
+import { OktaGroup } from './types';
 import { ProfileFieldGroupNamingStrategy } from './groupNamingStrategies';
 
 describe('groupEntityFromOktaGroup', () => {
@@ -26,7 +27,7 @@ describe('groupEntityFromOktaGroup', () => {
         description: 'Group 1',
         parent_org_id: '',
         org_id: '1',
-      },
+      } as Group['profile'],
     };
     const parentGroup = undefined;
     const options = {
@@ -35,7 +36,7 @@ describe('groupEntityFromOktaGroup', () => {
     };
     expect(
       groupEntityFromOktaGroup(
-        group as Group,
+        group as OktaGroup,
         new ProfileFieldGroupNamingStrategy('org_id').nameForGroup,
         options,
         parentGroup,
@@ -60,14 +61,14 @@ describe('groupEntityFromOktaGroup', () => {
         description: 'Group 2',
         parent_org_id: '1',
         org_id: '2',
-      },
+      } as Group['profile'],
     };
     const parentGroup: Partial<Group> = {
       profile: {
         name: 'group-1',
         description: 'Group 1',
         org_id: '1',
-      },
+      } as Group['profile'],
     };
     const options = {
       annotations: {},
@@ -75,10 +76,10 @@ describe('groupEntityFromOktaGroup', () => {
     };
     expect(
       groupEntityFromOktaGroup(
-        group as Group,
+        group as OktaGroup,
         new ProfileFieldGroupNamingStrategy('org_id').nameForGroup,
         options,
-        parentGroup as Group,
+        parentGroup as OktaGroup,
       ),
     ).toEqual({
       apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupEntityFromOktaGroup.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 import { GroupEntity } from '@backstage/catalog-model';
-import { Group } from '@okta/okta-sdk-nodejs';
+import { OktaGroup } from './types';
 import { GroupNamingStrategy } from './groupNamingStrategies';
 
 export const groupEntityFromOktaGroup = (
-  group: Group,
+  group: OktaGroup,
   namingStrategy: GroupNamingStrategy,
   options: {
     annotations: Record<string, string>;
     members: string[];
   },
-  parentGroup?: Group,
+  parentGroup?: OktaGroup,
 ): GroupEntity => {
   const groupEntity: GroupEntity = {
     kind: 'Group',

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.test.ts
@@ -16,6 +16,7 @@
 
 import { ProfileFieldGroupNamingStrategy } from './ProfileFieldGroupNamingStrategy';
 import { Group } from '@okta/okta-sdk-nodejs';
+import { OktaGroup } from '../types';
 
 describe('ProfileFiledGroupNamingStrategy', () => {
   it('gets the right field from the group profile', async () => {
@@ -25,9 +26,9 @@ describe('ProfileFiledGroupNamingStrategy', () => {
         name: 'group-1',
         description: 'Group 1',
         org_id: '1234',
-      },
+      } as Group['profile'],
     };
-    expect(provider.nameForGroup(testGroup as Group)).toEqual('1234');
+    expect(provider.nameForGroup(testGroup as OktaGroup)).toEqual('1234');
   });
 
   it('fails if the field is not set', async () => {
@@ -38,7 +39,7 @@ describe('ProfileFiledGroupNamingStrategy', () => {
         description: 'Group 1',
       },
     };
-    expect(() => provider.nameForGroup(testGroup as Group)).toThrow(
+    expect(() => provider.nameForGroup(testGroup as OktaGroup)).toThrow(
       'Profile field org_id does not contain a string',
     );
   });
@@ -50,9 +51,9 @@ describe('ProfileFiledGroupNamingStrategy', () => {
         name: 'group-1',
         description: 'Group 1',
         org_id: ['wrong', 'type'],
-      },
+      } as Group['profile'],
     };
-    expect(() => provider.nameForGroup(testGroup as Group)).toThrow(
+    expect(() => provider.nameForGroup(testGroup as OktaGroup)).toThrow(
       'Profile field org_id does not contain a string',
     );
   });
@@ -64,8 +65,8 @@ describe('ProfileFiledGroupNamingStrategy', () => {
         name: 'group-1',
         description: 'Group 1',
         org_id: 1234,
-      },
+      } as Group['profile'],
     };
-    expect(provider.nameForGroup(testGroup as Group)).toEqual('1234');
+    expect(provider.nameForGroup(testGroup as OktaGroup)).toEqual('1234');
   });
 });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/ProfileFieldGroupNamingStrategy.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Group } from '@okta/okta-sdk-nodejs';
+import { OktaGroup } from '../types';
 import { GroupNamingStrategy } from './types';
 
 export class ProfileFieldGroupNamingStrategy {
@@ -22,13 +22,15 @@ export class ProfileFieldGroupNamingStrategy {
     this.fieldName = fieldName;
   }
 
-  nameForGroup: GroupNamingStrategy = (group: Group) => {
-    const groupName = group.profile[this.fieldName];
+  nameForGroup: GroupNamingStrategy = (group: OktaGroup) => {
+    const groupName = (group.profile as unknown as Record<string, unknown>)[
+      this.fieldName
+    ];
     if (!['number', 'string'].includes(typeof groupName)) {
       throw new Error(
         `Profile field ${this.fieldName} does not contain a string/number for ${group.profile.name}`,
       );
     }
-    return groupName.toString();
+    return (groupName as string | number).toString();
   };
 }

--- a/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/groupNamingStrategies/types.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Group } from '@okta/okta-sdk-nodejs';
+import { OktaGroup } from '../types';
 
-export type GroupNamingStrategy = (group: Group) => string;
+export type GroupNamingStrategy = (group: OktaGroup) => string;
 export type GroupNamingStrategies =
   | 'id'
   | 'kebab-case-name'

--- a/plugins/backend/catalog-backend-module-okta/src/providers/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/index.ts
@@ -20,6 +20,10 @@ export { OktaOrgEntityProvider } from './OktaOrgEntityProvider';
 export * from './groupNamingStrategies';
 export * from './userNamingStrategies';
 export type {
+  OktaGroup,
   OktaGroupEntityTransformer,
+  OktaGroupProfile,
+  OktaUser,
   OktaUserEntityTransformer,
+  OktaUserProfile,
 } from './types';

--- a/plugins/backend/catalog-backend-module-okta/src/providers/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/types.ts
@@ -16,11 +16,51 @@
 
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import type {
-  Group as OktaGroup,
-  User as OktaUser,
+  Group,
+  GroupProfile,
+  User,
+  UserProfile,
 } from '@okta/okta-sdk-nodejs';
 import { GroupNamingStrategy } from './groupNamingStrategies';
 import { UserNamingStrategy } from './userNamingStrategies';
+
+/**
+ * Stricter wrapper around the SDK `UserProfile`. The Okta API always returns
+ * an `email` for active users, but the generated SDK types mark it optional.
+ */
+export type OktaUserProfile = UserProfile & { email: string };
+
+/**
+ * Stricter wrapper around the SDK `User`. `id` and `profile.email` are always
+ * present at runtime on results returned by `listUsers` / `listGroupUsers`,
+ * even though the generated SDK types mark them optional.
+ */
+export type OktaUser = User & { id: string; profile: OktaUserProfile };
+
+/**
+ * Stricter wrapper around the SDK `GroupProfile`. The Okta API always returns
+ * a `name`, but the generated SDK types mark it optional.
+ */
+export type OktaGroupProfile = GroupProfile & { name: string };
+
+/**
+ * Stricter wrapper around the SDK `Group`. `id` and `profile.name` are always
+ * present at runtime on results returned by `listGroups`, even though the
+ * generated SDK types mark them optional.
+ */
+export type OktaGroup = Group & { id: string; profile: OktaGroupProfile };
+
+/**
+ * Narrow an SDK `User` to `OktaUser` at the SDK boundary. The cast is safe
+ * for results returned by `listUsers` and `listGroupUsers`.
+ */
+export const asOktaUser = (user: User): OktaUser => user as OktaUser;
+
+/**
+ * Narrow an SDK `Group` to `OktaGroup` at the SDK boundary. The cast is safe
+ * for results returned by `listGroups`.
+ */
+export const asOktaGroup = (group: Group): OktaGroup => group as OktaGroup;
 
 export type OktaGroupEntityTransformer = (
   group: OktaGroup,

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userEntityFromOktaUser.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userEntityFromOktaUser.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { UserEntity } from '@backstage/catalog-model';
-import { User } from '@okta/okta-sdk-nodejs';
+import { OktaUser } from './types';
 import { UserNamingStrategy } from './userNamingStrategies';
 
 export const userEntityFromOktaUser = (
-  user: User,
+  user: OktaUser,
   namingStrategy: UserNamingStrategy,
   options: { annotations: Record<string, string> },
 ): UserEntity => {
@@ -32,7 +32,7 @@ export const userEntityFromOktaUser = (
     },
     spec: {
       profile: {
-        displayName: user.profile.displayName,
+        displayName: user.profile.displayName ?? undefined,
         email: user.profile.email,
       },
       memberOf: [],

--- a/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/types.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/userNamingStrategies/types.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { User } from '@okta/okta-sdk-nodejs';
+import { OktaUser } from '../types';
 
-export type UserNamingStrategy = (user: User) => string;
+export type UserNamingStrategy = (user: OktaUser) => string;
 export type UserNamingStrategies =
   | 'id'
   | 'kebab-case-email'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9462,22 +9462,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@okta/okta-sdk-nodejs@npm:^6.6.0":
-  version: 6.6.0
-  resolution: "@okta/okta-sdk-nodejs@npm:6.6.0"
+"@okta/okta-sdk-nodejs@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@okta/okta-sdk-nodejs@npm:8.1.0"
   dependencies:
+    "@types/node-forge": "npm:^1.3.2"
     deep-copy: "npm:^1.4.2"
     eckles: "npm:^1.4.1"
-    form-data: "npm:^4.0.0"
+    form-data: "npm:^4.0.4"
     https-proxy-agent: "npm:^5.0.0"
     js-yaml: "npm:^4.1.0"
-    lodash: "npm:^4.17.20"
-    njwt: "npm:^1.0.0"
+    lodash: "npm:^4.17.23"
+    njwt: "npm:^2.0.1"
     node-fetch: "npm:^2.6.7"
+    node-jose: "npm:^2.2.0"
     parse-link-header: "npm:^2.0.0"
     rasha: "npm:^1.2.5"
     safe-flat: "npm:^2.0.2"
-  checksum: 10/464181f819f508004a741a3437438123f618da937611d4c8d1653be8a1f296a250f093ce3ca5d8b7af0292c15a785013348fb65ccb0f25c84ed59eb2f7fbccdd
+    url-parse: "npm:^1.5.10"
+    uuid: "npm:^11.1.0"
+  checksum: 10/8900300e395f96cb83f4918c334ce75e420d48f5835f09a12c6a25f429aa2d155e626e70710ac6d525dd9e1686c7d5ec97733c34aa2154c6679ab597af2fea48
   languageName: node
   linkType: hard
 
@@ -12879,7 +12883,7 @@ __metadata:
     "@backstage/errors": "backstage:^"
     "@backstage/plugin-catalog-backend": "backstage:^"
     "@backstage/plugin-catalog-node": "backstage:^"
-    "@okta/okta-sdk-nodejs": "npm:^6.6.0"
+    "@okta/okta-sdk-nodejs": "npm:^8.1.0"
     "@types/lodash": "npm:^4.14.151"
     lodash: "npm:^4.17.21"
     slugify: "npm:^1.6.6"
@@ -16244,6 +16248,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-forge@npm:^1.3.2":
+  version: 1.3.14
+  resolution: "@types/node-forge@npm:1.3.14"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/500ce72435285fca145837da079b49a09a5bdf8391b0effc3eb2455783dd81ab129e574a36e1a0374a4823d889d5328177ebfd6fe45b432c0c43d48d790fe39c
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^22.0.0":
   version: 22.9.1
   resolution: "@types/node@npm:22.9.1"
@@ -18346,7 +18359,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64url@npm:3.x.x":
+"base64url@npm:3.x.x, base64url@npm:^3.0.1":
   version: 3.0.1
   resolution: "base64url@npm:3.0.1"
   checksum: 10/a77b2a3a526b3343e25be424de3ae0aa937d78f6af7c813ef9020ef98001c0f4e2323afcd7d8b2d2978996bf8c42445c3e9f60c218c622593e5fdfd54a3d6e18
@@ -22109,6 +22122,13 @@ __metadata:
   version: 4.1.1
   resolution: "es6-error@npm:4.1.1"
   checksum: 10/48483c25701dc5a6376f39bbe2eaf5da0b505607ec5a98cd3ade472c1939242156660636e2e508b33211e48e88b132d245341595c067bd4a95ac79fa7134da06
+  languageName: node
+  linkType: hard
+
+"es6-promise@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "es6-promise@npm:4.2.8"
+  checksum: 10/b250c55523c496c43c9216c2646e58ec182b819e036fe5eb8d83fa16f044ecc6b8dcefc88ace2097be3d3c4d02b6aa8eeae1a66deeaf13e7bee905ebabb350a3
   languageName: node
   linkType: hard
 
@@ -28142,6 +28162,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.23":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -28203,6 +28230,13 @@ __metadata:
   version: 5.2.3
   resolution: "long@npm:5.2.3"
   checksum: 10/9167ec6947a825b827c30da169a7384eec6c0c9ec2f0b9c74da2e93d81159bbe39fb09c3f13dae9721d4b807ccfa09797a7dd1012f5d478e3e33ca3c78b608e6
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.2.0":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
   languageName: node
   linkType: hard
 
@@ -29952,14 +29986,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"njwt@npm:^1.0.0":
-  version: 1.2.0
-  resolution: "njwt@npm:1.2.0"
+"njwt@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "njwt@npm:2.0.1"
   dependencies:
     "@types/node": "npm:^15.0.1"
     ecdsa-sig-formatter: "npm:^1.0.5"
     uuid: "npm:^8.3.2"
-  checksum: 10/dd0dc82a2ed0e95c0d9ae5a035cb47e7c7be0ae0bc7d4b1b5b25573f02e9801b7f05e069b8a854ecd239f4fce1064f604f4475e75d6035493c8ab629d0b64168
+  checksum: 10/55e5aee498f308c4b922e62ff764e28ce3650d41d01d30e436cbdb7ae98822208c000333341bc4aec839f22082f3388104638d2a77eceb906688882ae679abaa
   languageName: node
   linkType: hard
 
@@ -30122,6 +30156,23 @@ __metadata:
   version: 0.4.0
   resolution: "node-int64@npm:0.4.0"
   checksum: 10/b7afc2b65e56f7035b1a2eec57ae0fbdee7d742b1cdcd0f4387562b6527a011ab1cbe9f64cc8b3cca61e3297c9637c8bf61cec2e6b8d3a711d4b5267dfafbe02
+  languageName: node
+  linkType: hard
+
+"node-jose@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "node-jose@npm:2.2.0"
+  dependencies:
+    base64url: "npm:^3.0.1"
+    buffer: "npm:^6.0.3"
+    es6-promise: "npm:^4.2.8"
+    lodash: "npm:^4.17.21"
+    long: "npm:^5.2.0"
+    node-forge: "npm:^1.2.1"
+    pako: "npm:^2.0.4"
+    process: "npm:^0.11.10"
+    uuid: "npm:^9.0.0"
+  checksum: 10/699f025ccc2f51370d3520af0e6268e9b8f103781e100f64efac82d14c33ab7c15907295bae7edc98d1e8a3d3e0f977f47aea03942a5b3d564185ac2213fb69f
   languageName: node
   linkType: hard
 
@@ -31006,6 +31057,13 @@ __metadata:
   version: 1.0.11
   resolution: "pako@npm:1.0.11"
   checksum: 10/1ad07210e894472685564c4d39a08717e84c2a68a70d3c1d9e657d32394ef1670e22972a433cbfe48976cb98b154ba06855dcd3fcfba77f60f1777634bec48c0
+  languageName: node
+  linkType: hard
+
+"pako@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 10/38a04991d0ec4f4b92794a68b8c92bf7340692c5d980255c92148da96eb3e550df7a86a7128b5ac0c65ecddfe5ef3bbe9c6dab13e1bc315086e759b18f7c1401
   languageName: node
   linkType: hard
 
@@ -37809,7 +37867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.0.0, uuid@npm:^11.0.2":
+"uuid@npm:^11.0.0, uuid@npm:^11.0.2, uuid@npm:^11.1.0":
   version: 11.1.0
   resolution: "uuid@npm:11.1.0"
   bin:


### PR DESCRIPTION
@okta/okta-sdk-nodejs v7 & v8 include breaking changes:
- API shape changed, e.g. client.listUsers => client.userApi.listUsers
- Model properties are optional

Reference: https://github.com/okta/okta-sdk-nodejs/blob/HEAD/MIGRATING.md#from-6x-to-70
Reference: https://github.com/okta/okta-sdk-nodejs/blob/HEAD/MIGRATING.md#from-7x-to-80

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [X] Added or updated documentation (if applicable)
