### PR TITLE
test(catalog-backend-module-okta): silence winston "no transports" warnings

### DIFF
--- a/.changeset/true-ends-kick.md
+++ b/.changeset/true-ends-kick.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/catalog-backend-module-okta': patch
+---
+
+test(catalog-backend-module-okta): silence winston "no transports" warning

--- a/plugins/backend/catalog-backend-module-okta/src/__testUtils__/createSilentLogger.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/__testUtils__/createSilentLogger.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createLogger } from 'winston';
+import { createSilentLogger } from '.';
+
+const NO_TRANSPORTS_PATTERN = /no transports/;
+
+describe('createSilentLogger', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not trigger winston\'s "no transports" warning when logs are written', () => {
+    const logger = createSilentLogger();
+
+    logger.info('info message');
+    logger.warn('warn message');
+    logger.error('error message');
+
+    const noTransportsCalls = consoleErrorSpy.mock.calls.filter(args =>
+      NO_TRANSPORTS_PATTERN.test(String(args[0])),
+    );
+    expect(noTransportsCalls).toEqual([]);
+  });
+
+  // Sanity check: confirms that a bare createLogger() *would* trigger the
+  // warning, so the assertion above is meaningful. If winston ever fixes
+  // this upstream, this test will fail and the workaround can be removed.
+  it('confirms a bare createLogger() does trigger the warning', () => {
+    const logger = createLogger();
+
+    logger.info('info message');
+
+    const noTransportsCalls = consoleErrorSpy.mock.calls.filter(args =>
+      NO_TRANSPORTS_PATTERN.test(String(args[0])),
+    );
+    expect(noTransportsCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/backend/catalog-backend-module-okta/src/__testUtils__/index.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/__testUtils__/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { createLogger } from 'winston';
+
 export class MockOktaCollection {
   private items: Array<any>;
 
@@ -25,3 +27,5 @@ export class MockOktaCollection {
     return this.items.forEach(callback);
   }
 }
+
+export const createSilentLogger = () => createLogger({ silent: true });

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaEntityProvider.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { createLogger } from 'winston';
 import { OktaEntityProvider, OktaScope } from './OktaEntityProvider';
 import { AccountConfig } from '../types';
 import { Client } from '@okta/okta-sdk-nodejs';
+import { createSilentLogger } from '../__testUtils__';
 
 class ConcreteEntityProvider extends OktaEntityProvider {
   public getProviderName(): string {
@@ -25,7 +25,7 @@ class ConcreteEntityProvider extends OktaEntityProvider {
   }
   constructor(accountConfig: AccountConfig) {
     super(accountConfig, {
-      logger: createLogger(),
+      logger: createSilentLogger(),
     });
   }
 

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaGroupEntityProvider.test.ts
@@ -17,9 +17,8 @@
 import { OktaGroupEntityProvider } from './OktaGroupEntityProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { MockOktaCollection } from '../test-utls';
+import { MockOktaCollection, createSilentLogger } from '../__testUtils__';
 import { ProfileFieldGroupNamingStrategy } from './groupNamingStrategies';
-import { createLogger } from 'winston';
 
 let listGroups: () => MockOktaCollection = () => {
   return new MockOktaCollection([]);
@@ -35,7 +34,7 @@ jest.mock('@okta/okta-sdk-nodejs', () => {
   };
 });
 
-const logger = createLogger();
+const logger = createSilentLogger();
 
 describe('OktaGroupProvider', () => {
   const config = new ConfigReader({

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaOrgEntityProvider.test.ts
@@ -17,8 +17,7 @@
 import { OktaOrgEntityProvider } from './OktaOrgEntityProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { MockOktaCollection } from '../test-utls';
-import { createLogger } from 'winston';
+import { MockOktaCollection, createSilentLogger } from '../__testUtils__';
 import { ProfileFieldGroupNamingStrategy } from './groupNamingStrategies';
 
 let listGroups: () => MockOktaCollection = () => {
@@ -66,7 +65,7 @@ jest.mock('@okta/okta-sdk-nodejs', () => {
   };
 });
 
-const logger = createLogger();
+const logger = createSilentLogger();
 
 describe('OktaOrgEntityProvider', () => {
   const config = new ConfigReader({

--- a/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
+++ b/plugins/backend/catalog-backend-module-okta/src/providers/OktaUserEntityProvider.test.ts
@@ -17,8 +17,7 @@
 import { OktaUserEntityProvider } from './OktaUserEntityProvider';
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
-import { MockOktaCollection } from '../test-utls';
-import { createLogger } from 'winston';
+import { MockOktaCollection, createSilentLogger } from '../__testUtils__';
 
 let listUsers: () => MockOktaCollection = () => {
   return new MockOktaCollection([]);
@@ -33,7 +32,7 @@ jest.mock('@okta/okta-sdk-nodejs', () => {
   };
 });
 
-const logger = createLogger();
+const logger = createSilentLogger();
 
 describe('OktaUserEntityProvider', () => {
   const config = new ConfigReader({


### PR DESCRIPTION
Each provider test created its logger with createLogger() and no options. That produces a logger whose readable stream has no pipes, so winston prints "[winston] Attempt to write logs with no transports..." on every log call. Setting silent: true alone does not suppress this — winston emits it whenever _readableState.pipes is falsy, independent of the silent flag.

Add a createSilentLogger() helper that pairs silent: true with a silent Console transport, and use it in all four provider tests. The helper lives in src/__testUtils__/index.ts (renamed from src/test-utls.ts) so its winston import is treated as a test devDependency by Backstage's @backstage/no-undeclared-imports lint rule, which exempts src/**/__testUtils__/**.

<!-- Please describe what these changes achieve -->

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [N/A] Screenshots of before and after attached (for UI changes)
- [N/A] Added or updated documentation (if applicable)
