### PR TITLE
feat: iframe srcFromAnnotation transforms

### DIFF
--- a/.changeset/iframe-annotation-transform-config-factory.md
+++ b/.changeset/iframe-annotation-transform-config-factory.md
@@ -1,0 +1,12 @@
+---
+'@roadiehq/backstage-plugin-iframe': minor
+---
+
+Add the `wrapAnnotationFromConfig(config, configKey, suffix?)` helper — a
+factory variant of `wrapAnnotation` that reads the URL prefix from a
+frontend-visible config key at call time. Useful when the iframe host
+should vary per environment (dev/staging/prod) without recompiling. Call
+it from a component that has `useApi(configApiRef)` available and pass
+the resulting transform to `EntityIFrameCard`. The configured key must be
+declared with `@visibility: frontend` in `config.d.ts` so the value
+reaches the browser bundle.

--- a/.changeset/iframe-annotation-transform.md
+++ b/.changeset/iframe-annotation-transform.md
@@ -1,0 +1,12 @@
+---
+'@roadiehq/backstage-plugin-iframe': minor
+---
+
+Add an optional `transform` prop for `EntityIFrameCard` / `IFrameCard` when
+using `srcFromAnnotation`. The function receives the raw annotation value
+plus the entity and returns the final iframe `src`, so annotations can
+store a bare identifier (e.g. a dashboard id) instead of a full URL. Two
+helper builders are exported: `wrapAnnotation(prefix, suffix?)` for
+prefix/suffix wrapping and `intoTemplate('https://host/foo/${value}/extra')`
+for embedding the value as a substring. The transformed URL still goes
+through the existing https-only and `iframe.allowList` checks.

--- a/plugins/frontend/backstage-plugin-iframe/README.md
+++ b/plugins/frontend/backstage-plugin-iframe/README.md
@@ -130,6 +130,81 @@ The transformed URL is still subject to the `iframe.allowList` check and
 the https-only protocol check, so the host you produce must be allowlisted
 just like a literal `src`.
 
+### Reading the prefix from frontend-visible config
+
+When the base URL should differ between environments (dev / staging / prod),
+hard-coding it in `EntityPage.tsx` is awkward. The factory helper
+`wrapAnnotationFromConfig` reads the prefix from `app-config.yaml` instead.
+The key must be marked `@visibility: frontend` (declare it in your plugin's
+or app's `config.d.ts`) or its value will be stripped before reaching the
+browser.
+
+```yaml
+# app-config.yaml
+iframe:
+  grafana:
+    baseUrl: https://grafana.example.com/d/ # @visibility: frontend
+```
+
+```tsx
+// packages/app/src/components/catalog/EntityPage.tsx
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import {
+  EntityIFrameCard,
+  wrapAnnotationFromConfig,
+} from '@roadiehq/backstage-plugin-iframe';
+import { useMemo } from 'react';
+
+export const GrafanaDashboardCard = () => {
+  const config = useApi(configApiRef);
+  // Memoize so the transform identity is stable across re-renders.
+  const transform = useMemo(
+    () => wrapAnnotationFromConfig(config, 'iframe.grafana.baseUrl'),
+    [config],
+  );
+  return (
+    <EntityIFrameCard
+      srcFromAnnotation="grafana/dashboard-id"
+      transform={transform}
+    />
+  );
+};
+```
+
+For anything more involved than a fixed prefix — appending query parameters,
+choosing between hosts, combining multiple annotations — write your own
+factory with the same shape:
+
+```tsx
+import type { Config } from '@backstage/config';
+import type { IFrameSrcTransform } from '@roadiehq/backstage-plugin-iframe';
+
+// Custom factory: reads both a base URL and a theme name from config, and
+// embeds them alongside the entity's namespace in the final URL.
+const grafanaDashboardTransform = (config: Config): IFrameSrcTransform => {
+  const baseUrl = config.getString('iframe.grafana.baseUrl');
+  const theme = config.getOptionalString('iframe.grafana.theme') ?? 'light';
+  return (dashboardId, entity) => {
+    const params = new URLSearchParams({
+      theme,
+      'var-namespace': entity.metadata.namespace ?? 'default',
+    });
+    return `${baseUrl}${dashboardId}?${params.toString()}`;
+  };
+};
+
+const GrafanaDashboardCard = () => {
+  const config = useApi(configApiRef);
+  const transform = useMemo(() => grafanaDashboardTransform(config), [config]);
+  return (
+    <EntityIFrameCard
+      srcFromAnnotation="grafana/dashboard-id"
+      transform={transform}
+    />
+  );
+};
+```
+
 ## Allowlisting
 
 This particular plugin supports allowlisting. What this means is you can add a domain to the plugin's configuration that will be verified during the creation of the plugins components.

--- a/plugins/frontend/backstage-plugin-iframe/README.md
+++ b/plugins/frontend/backstage-plugin-iframe/README.md
@@ -77,6 +77,59 @@ export const HomePage = () => {
 };
 ```
 
+## Building the src from an entity annotation
+
+`EntityIFrameCard` can read the `src` directly out of an entity annotation
+via `srcFromAnnotation`. By default the annotation value is used verbatim,
+which means each entity has to store the full URL.
+
+If you'd rather store only an identifier (a dashboard id, a project slug,
+etc.) and have the iframe assemble the URL, pass a `transform` function. It
+receives the raw annotation value and the entity, and returns the final
+`src`. Two helpers are exported for the common cases:
+
+```tsx
+// packages/app/src/components/catalog/EntityPage.tsx
+import {
+  EntityIFrameCard,
+  wrapAnnotation,
+  intoTemplate,
+} from '@roadiehq/backstage-plugin-iframe';
+
+// 1) Prefix only — https://host/prefix/${annotation_value}
+//    annotation "abc-123" => https://grafana.example.com/d/abc-123
+<EntityIFrameCard
+  srcFromAnnotation="grafana/dashboard-id"
+  transform={wrapAnnotation('https://grafana.example.com/d/')}
+/>
+
+// 2) Prefix + suffix — https://host/foo/${annotation_value}/extra
+<EntityIFrameCard
+  srcFromAnnotation="my-org/widget-id"
+  transform={wrapAnnotation('https://example.com/foo/', '/extra')}
+/>
+
+// 3) Free-form template — embed the value anywhere in the URL.
+//    Use single quotes so ${value} is not a JS template literal.
+<EntityIFrameCard
+  srcFromAnnotation="my-org/widget-id"
+  transform={intoTemplate('https://example.com/foo/${value}/extra')}
+/>
+
+// 4) Custom transform — the entity is the second argument, so you can mix
+//    the annotation value with other entity context.
+<EntityIFrameCard
+  srcFromAnnotation="grafana/dashboard-id"
+  transform={(value, entity) =>
+    `https://grafana.example.com/d/${value}?var-service=${entity.metadata.name}`
+  }
+/>
+```
+
+The transformed URL is still subject to the `iframe.allowList` check and
+the https-only protocol check, so the host you produce must be allowlisted
+just like a literal `src`.
+
 ## Allowlisting
 
 This particular plugin supports allowlisting. What this means is you can add a domain to the plugin's configuration that will be verified during the creation of the plugins components.

--- a/plugins/frontend/backstage-plugin-iframe/dev/index.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/dev/index.tsx
@@ -20,6 +20,8 @@ import {
   EntityIFrameCard,
   EntityIFrameContent,
   HomePageIFrameCard,
+  wrapAnnotation,
+  intoTemplate,
 } from '../src';
 import {
   IFrameContentProps,
@@ -37,6 +39,7 @@ const mockEntity: Entity = {
     description: 'backstage.io',
     annotations: {
       'roadie.io/example_domain': 'com',
+      'grafana/dashboard-id': 'abc-123',
     },
   },
   spec: {
@@ -82,6 +85,32 @@ createDevApp()
     ),
     title: 'Templated Iframe',
     path: 'iframe-page-templated',
+  })
+  .addPage({
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <EntityIFrameCard
+          srcFromAnnotation="grafana/dashboard-id"
+          transform={wrapAnnotation('https://example.com/d/', '/view')}
+          title="Annotation transform (prefix + suffix)"
+        />
+      </EntityProvider>
+    ),
+    title: 'Annotation transform: wrapAnnotation',
+    path: 'iframe-page-wrap-annotation',
+  })
+  .addPage({
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <EntityIFrameCard
+          srcFromAnnotation="grafana/dashboard-id"
+          transform={intoTemplate('https://example.com/foo/${value}/extra')}
+          title="Annotation transform (embedded substring)"
+        />
+      </EntityProvider>
+    ),
+    title: 'Annotation transform: intoTemplate',
+    path: 'iframe-page-into-template',
   })
   .addPage({
     element: <HomePageIFrameCard {...{ ...props, title: '1234' }} />,

--- a/plugins/frontend/backstage-plugin-iframe/dev/index.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/dev/index.tsx
@@ -22,6 +22,7 @@ import {
   HomePageIFrameCard,
   wrapAnnotation,
   intoTemplate,
+  wrapAnnotationFromConfig,
 } from '../src';
 import {
   IFrameContentProps,
@@ -30,6 +31,14 @@ import {
 } from '../src/components/types';
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { ConfigReader } from '@backstage/config';
+
+// In a real app the `Config` instance comes from `useApi(configApiRef)` — see
+// the README for that usage. The sandbox stubs one with `ConfigReader` so the
+// factory pattern works without touching the dev `app-config.yaml`.
+const sandboxConfig = new ConfigReader({
+  iframe: { grafana: { baseUrl: 'https://example.com/d/' } },
+});
 
 const mockEntity: Entity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -111,6 +120,22 @@ createDevApp()
     ),
     title: 'Annotation transform: intoTemplate',
     path: 'iframe-page-into-template',
+  })
+  .addPage({
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <EntityIFrameCard
+          srcFromAnnotation="grafana/dashboard-id"
+          transform={wrapAnnotationFromConfig(
+            sandboxConfig,
+            'iframe.grafana.baseUrl',
+          )}
+          title="Annotation transform (factory + config-driven prefix)"
+        />
+      </EntityProvider>
+    ),
+    title: 'Annotation transform: wrapAnnotationFromConfig',
+    path: 'iframe-page-wrap-annotation-from-config',
   })
   .addPage({
     element: <HomePageIFrameCard {...{ ...props, title: '1234' }} />,

--- a/plugins/frontend/backstage-plugin-iframe/package.json
+++ b/plugins/frontend/backstage-plugin-iframe/package.json
@@ -47,6 +47,7 @@
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
+    "@backstage/config": "backstage:^",
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/dev-utils": "backstage:^",

--- a/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.test.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.test.tsx
@@ -27,6 +27,7 @@ import {
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { IFrameCard } from './IFrameComponent';
 import { IFrameComponentProps } from './types';
+import { wrapAnnotation, intoTemplate } from '../transforms';
 
 const entityMock = {
   metadata: {
@@ -192,6 +193,104 @@ describe('IFrameCard', () => {
       expect(
         await rendered.findByText(
           'Src https://example-annotation.com for Iframe is not included in the allowlist hello.com.',
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('when transform is provided with srcFromAnnotation', () => {
+    it('applies the transform to build the final src (prefix only)', async () => {
+      mockConfig.mockImplementation(() => ['grafana.example.com']);
+      const rendered = render(
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={entityMock}>
+            <IFrameCard
+              srcFromAnnotation="iframeSrc"
+              transform={wrapAnnotation('https://grafana.example.com/d/')}
+              title="transformed title"
+            />
+          </EntityProvider>
+        </TestApiProvider>,
+      );
+      const iframe = rendered.container.querySelector('iframe');
+      expect(iframe?.getAttribute('src')).toBe(
+        'https://grafana.example.com/d/https://example-annotation.com',
+      );
+      expect(await rendered.findByText('transformed title')).toBeTruthy();
+    });
+
+    it('applies the transform to embed the value as a substring', async () => {
+      const entityWithId = {
+        ...entityMock,
+        metadata: {
+          ...entityMock.metadata,
+          annotations: { 'grafana/dashboard-id': 'abc-123' },
+        },
+      };
+      mockConfig.mockImplementation(() => ['example.com']);
+      const rendered = render(
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={entityWithId}>
+            <IFrameCard
+              srcFromAnnotation="grafana/dashboard-id"
+              transform={intoTemplate('https://example.com/foo/${value}/extra')}
+              title="embedded title"
+            />
+          </EntityProvider>
+        </TestApiProvider>,
+      );
+      const iframe = rendered.container.querySelector('iframe');
+      expect(iframe?.getAttribute('src')).toBe(
+        'https://example.com/foo/abc-123/extra',
+      );
+      expect(await rendered.findByText('embedded title')).toBeTruthy();
+    });
+
+    it('passes the entity to the transform', async () => {
+      const entityWithId = {
+        ...entityMock,
+        metadata: {
+          ...entityMock.metadata,
+          name: 'svc-42',
+          annotations: { 'grafana/dashboard-id': 'abc-123' },
+        },
+      };
+      mockConfig.mockImplementation(() => ['example.com']);
+      const rendered = render(
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={entityWithId}>
+            <IFrameCard
+              srcFromAnnotation="grafana/dashboard-id"
+              transform={(value, entity) =>
+                `https://example.com/${entity.metadata.name}/${value}`
+              }
+              title="entity-aware title"
+            />
+          </EntityProvider>
+        </TestApiProvider>,
+      );
+      const iframe = rendered.container.querySelector('iframe');
+      expect(iframe?.getAttribute('src')).toBe(
+        'https://example.com/svc-42/abc-123',
+      );
+    });
+
+    it('rejects a transformed url that violates the allowlist', async () => {
+      mockConfig.mockImplementation(() => ['some-other-host.com']);
+      const rendered = render(
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={entityMock}>
+            <IFrameCard
+              srcFromAnnotation="iframeSrc"
+              transform={wrapAnnotation('https://grafana.example.com/d/')}
+              title="rejected title"
+            />
+          </EntityProvider>
+        </TestApiProvider>,
+      );
+      expect(
+        await rendered.findByText(
+          /is not included in the allowlist some-other-host.com/,
         ),
       ).toBeTruthy();
     });

--- a/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/IFrameComponent.tsx
@@ -45,7 +45,7 @@ const IFrameComponentContent = (props: IFrameComponentContentProps) => {
 };
 
 const IFrameFromAnnotation = (props: IFrameFromAnnotationProps) => {
-  const { srcFromAnnotation, height, width } = props;
+  const { srcFromAnnotation, height, width, transform } = props;
   const title =
     props.title || 'Backstage IFrame (Note you can modify this with the props)';
   const configApi = useApi(configApiRef);
@@ -53,15 +53,17 @@ const IFrameFromAnnotation = (props: IFrameFromAnnotationProps) => {
   const { entity } = useEntity();
   let errorMessage = '';
 
-  const src = entity.metadata.annotations?.[srcFromAnnotation];
+  const annotationValue = entity.metadata.annotations?.[srcFromAnnotation];
 
-  if (!src) {
+  if (!annotationValue) {
     return (
       <ErrorComponent
         errorMessage={`Failed to get url src from the entity annotation ${srcFromAnnotation}`}
       />
     );
   }
+
+  const src = transform ? transform(annotationValue, entity) : annotationValue;
 
   errorMessage = determineError(src, allowList);
 
@@ -141,7 +143,15 @@ const IFrameFromSrc = (props: IFrameProps) => {
  * @public
  */
 export const IFrameCard = (props: IFrameComponentProps) => {
-  const { src, srcFromAnnotation, templatedSrc, height, width, title } = props;
+  const {
+    src,
+    srcFromAnnotation,
+    templatedSrc,
+    height,
+    width,
+    title,
+    transform,
+  } = props;
   if (src) {
     return (
       <IFrameFromSrc
@@ -174,6 +184,7 @@ export const IFrameCard = (props: IFrameComponentProps) => {
         height={height}
         width={width}
         title={title}
+        transform={transform}
       />
     );
   }

--- a/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
@@ -45,8 +45,8 @@ export type IFrameComponentProps = {
   /**
    * Optional transform applied to the annotation value (when `srcFromAnnotation`
    * is set) to build the final iframe `src`. Ignored otherwise. See
-   * {@link IFrameSrcTransform} and the `wrapAnnotation` / `intoTemplate`
-   * helpers exported from the package root.
+   * {@link IFrameSrcTransform} and the `wrapAnnotation`, `intoTemplate`, and
+   * `wrapAnnotationFromConfig` helpers exported from the package root.
    */
   transform?: IFrameSrcTransform;
 };
@@ -60,8 +60,8 @@ export type IFrameFromAnnotationProps = {
   /**
    * Optional transform applied to the annotation value (when `srcFromAnnotation`
    * is set) to build the final iframe `src`. Ignored otherwise. See
-   * {@link IFrameSrcTransform} and the `wrapAnnotation` / `intoTemplate`
-   * helpers exported from the package root.
+   * {@link IFrameSrcTransform} and the `wrapAnnotation`, `intoTemplate`, and
+   * `wrapAnnotationFromConfig` helpers exported from the package root.
    */
   transform?: IFrameSrcTransform;
 };

--- a/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/components/types.ts
@@ -1,3 +1,18 @@
+import type { Entity } from '@backstage/catalog-model';
+
+/**
+ * Transforms the raw value of an entity annotation into the final iframe `src`.
+ *
+ * The entity is also passed so callers can combine multiple annotations or
+ * incorporate other entity context (namespace, name, etc.) into the URL.
+ *
+ * @public
+ */
+export type IFrameSrcTransform = (
+  annotationValue: string,
+  entity: Entity,
+) => string;
+
 /**
  * Props for IFrame content component {@link Content}.
  *
@@ -27,6 +42,13 @@ export type IFrameComponentProps = {
   height?: string;
   width?: string;
   classes?: string;
+  /**
+   * Optional transform applied to the annotation value (when `srcFromAnnotation`
+   * is set) to build the final iframe `src`. Ignored otherwise. See
+   * {@link IFrameSrcTransform} and the `wrapAnnotation` / `intoTemplate`
+   * helpers exported from the package root.
+   */
+  transform?: IFrameSrcTransform;
 };
 
 export type IFrameFromAnnotationProps = {
@@ -35,6 +57,13 @@ export type IFrameFromAnnotationProps = {
   height?: string;
   width?: string;
   classes?: string;
+  /**
+   * Optional transform applied to the annotation value (when `srcFromAnnotation`
+   * is set) to build the final iframe `src`. Ignored otherwise. See
+   * {@link IFrameSrcTransform} and the `wrapAnnotation` / `intoTemplate`
+   * helpers exported from the package root.
+   */
+  transform?: IFrameSrcTransform;
 };
 
 export type IframeFromTemplatedSrcProps = {

--- a/plugins/frontend/backstage-plugin-iframe/src/index.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/index.ts
@@ -5,3 +5,5 @@ export {
   EntityIFrameContent,
   HomePageIFrameCard,
 } from './plugin';
+export type { IFrameSrcTransform } from './components/types';
+export { wrapAnnotation, intoTemplate } from './transforms';

--- a/plugins/frontend/backstage-plugin-iframe/src/index.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/index.ts
@@ -6,4 +6,8 @@ export {
   HomePageIFrameCard,
 } from './plugin';
 export type { IFrameSrcTransform } from './components/types';
-export { wrapAnnotation, intoTemplate } from './transforms';
+export {
+  wrapAnnotation,
+  intoTemplate,
+  wrapAnnotationFromConfig,
+} from './transforms';

--- a/plugins/frontend/backstage-plugin-iframe/src/transforms.test.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/transforms.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Entity } from '@backstage/catalog-model';
+import { intoTemplate, wrapAnnotation } from './transforms';
+
+const stubEntity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'svc', namespace: 'default' },
+} as Entity;
+
+describe('wrapAnnotation', () => {
+  it('prepends a prefix to the annotation value', () => {
+    const t = wrapAnnotation('https://grafana.example.com/d/');
+    expect(t('abc-123', stubEntity)).toBe(
+      'https://grafana.example.com/d/abc-123',
+    );
+  });
+
+  it('appends an optional suffix after the annotation value', () => {
+    const t = wrapAnnotation('https://example.com/foo/', '/extra');
+    expect(t('abc-123', stubEntity)).toBe(
+      'https://example.com/foo/abc-123/extra',
+    );
+  });
+});
+
+describe('intoTemplate', () => {
+  it('substitutes the value at the ${value} token', () => {
+    const t = intoTemplate('https://example.com/foo/${value}/extra');
+    expect(t('abc-123', stubEntity)).toBe(
+      'https://example.com/foo/abc-123/extra',
+    );
+  });
+
+  it('substitutes every occurrence of the token', () => {
+    const t = intoTemplate('https://${value}.example.com/d/${value}');
+    expect(t('abc', stubEntity)).toBe('https://abc.example.com/d/abc');
+  });
+
+  it('returns the template unchanged when the token is absent', () => {
+    const t = intoTemplate('https://example.com/static');
+    expect(t('abc', stubEntity)).toBe('https://example.com/static');
+  });
+});

--- a/plugins/frontend/backstage-plugin-iframe/src/transforms.test.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/transforms.test.ts
@@ -15,7 +15,12 @@
  */
 
 import type { Entity } from '@backstage/catalog-model';
-import { intoTemplate, wrapAnnotation } from './transforms';
+import { ConfigReader } from '@backstage/config';
+import {
+  intoTemplate,
+  wrapAnnotation,
+  wrapAnnotationFromConfig,
+} from './transforms';
 
 const stubEntity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -36,6 +41,39 @@ describe('wrapAnnotation', () => {
     expect(t('abc-123', stubEntity)).toBe(
       'https://example.com/foo/abc-123/extra',
     );
+  });
+});
+
+describe('wrapAnnotationFromConfig', () => {
+  it('reads the prefix from the configured key', () => {
+    const config = new ConfigReader({
+      iframe: { grafana: { baseUrl: 'https://grafana.example.com/d/' } },
+    });
+    const t = wrapAnnotationFromConfig(config, 'iframe.grafana.baseUrl');
+    expect(t('abc-123', stubEntity)).toBe(
+      'https://grafana.example.com/d/abc-123',
+    );
+  });
+
+  it('appends an optional suffix', () => {
+    const config = new ConfigReader({
+      iframe: { grafana: { baseUrl: 'https://grafana.example.com/d/' } },
+    });
+    const t = wrapAnnotationFromConfig(
+      config,
+      'iframe.grafana.baseUrl',
+      '?kiosk=tv',
+    );
+    expect(t('abc-123', stubEntity)).toBe(
+      'https://grafana.example.com/d/abc-123?kiosk=tv',
+    );
+  });
+
+  it('fails fast when the configured key is missing', () => {
+    const config = new ConfigReader({});
+    expect(() =>
+      wrapAnnotationFromConfig(config, 'iframe.grafana.baseUrl'),
+    ).toThrow(/iframe\.grafana\.baseUrl/);
   });
 });
 

--- a/plugins/frontend/backstage-plugin-iframe/src/transforms.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/transforms.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Config } from '@backstage/config';
 import type { IFrameSrcTransform } from './components/types';
 
 /**
@@ -62,3 +63,58 @@ export const intoTemplate =
   (template: string): IFrameSrcTransform =>
   value =>
     template.replace(/\$\{value\}/g, value);
+
+/**
+ * Factory variant of {@link wrapAnnotation} that reads the prefix (and an
+ * optional fixed suffix) from a frontend-visible configuration value at the
+ * time the factory is called.
+ *
+ * Use this when the URL should differ between environments (dev, staging,
+ * prod) without recompiling the app: put the host in `app-config.yaml` under
+ * a key marked `@visibility: frontend`, then call the factory from a
+ * component that has access to `configApiRef`.
+ *
+ * @example app-config.yaml — the key must be frontend-visible to reach the browser
+ * ```yaml
+ * iframe:
+ *   grafana:
+ *     baseUrl: https://grafana.example.com/d/   # @visibility: frontend
+ * ```
+ *
+ * @example component code — `useMemo` keeps the transform identity stable
+ * ```tsx
+ * import { configApiRef, useApi } from '@backstage/core-plugin-api';
+ * import {
+ *   EntityIFrameCard,
+ *   wrapAnnotationFromConfig,
+ * } from '@roadiehq/backstage-plugin-iframe';
+ * import { useMemo } from 'react';
+ *
+ * export const GrafanaDashboardCard = () => {
+ *   const config = useApi(configApiRef);
+ *   const transform = useMemo(
+ *     () => wrapAnnotationFromConfig(config, 'iframe.grafana.baseUrl'),
+ *     [config],
+ *   );
+ *   return (
+ *     <EntityIFrameCard
+ *       srcFromAnnotation="grafana/dashboard-id"
+ *       transform={transform}
+ *     />
+ *   );
+ * };
+ * ```
+ *
+ * Reads the key with `config.getString`, so a missing or non-string value
+ * fails fast at factory-call time rather than rendering a broken iframe.
+ *
+ * @public
+ */
+export const wrapAnnotationFromConfig = (
+  config: Config,
+  configKey: string,
+  suffix: string = '',
+): IFrameSrcTransform => {
+  const prefix = config.getString(configKey);
+  return value => `${prefix}${value}${suffix}`;
+};

--- a/plugins/frontend/backstage-plugin-iframe/src/transforms.ts
+++ b/plugins/frontend/backstage-plugin-iframe/src/transforms.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IFrameSrcTransform } from './components/types';
+
+/**
+ * Builds an iframe `src` by wrapping the annotation value with a fixed prefix
+ * and (optionally) a suffix.
+ *
+ * @example Prefix only — `https://host/prefix/${annotation_value}`
+ * ```tsx
+ * <EntityIFrameCard
+ *   srcFromAnnotation="my-org/dashboard-id"
+ *   transform={wrapAnnotation('https://grafana.example.com/d/')}
+ * />
+ * ```
+ *
+ * @example Prefix + suffix — `https://host/foo/${annotation_value}/extra`
+ * ```tsx
+ * <EntityIFrameCard
+ *   srcFromAnnotation="my-org/dashboard-id"
+ *   transform={wrapAnnotation('https://example.com/foo/', '/extra')}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const wrapAnnotation =
+  (prefix: string, suffix: string = ''): IFrameSrcTransform =>
+  value =>
+    `${prefix}${value}${suffix}`;
+
+/**
+ * Builds an iframe `src` by substituting the annotation value into the literal
+ * token `${value}` anywhere in a template string. Use single quotes so the
+ * token is not interpreted as a JavaScript template literal.
+ *
+ * @example
+ * ```tsx
+ * <EntityIFrameCard
+ *   srcFromAnnotation="my-org/dashboard-id"
+ *   transform={intoTemplate('https://example.com/foo/${value}/extra')}
+ * />
+ * ```
+ *
+ * @public
+ */
+export const intoTemplate =
+  (template: string): IFrameSrcTransform =>
+  value =>
+    template.replace(/\$\{value\}/g, value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12570,6 +12570,7 @@ __metadata:
   dependencies:
     "@backstage/catalog-model": "backstage:^"
     "@backstage/cli": "backstage:^"
+    "@backstage/config": "backstage:^"
     "@backstage/core-components": "backstage:^"
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/dev-utils": "backstage:^"


### PR DESCRIPTION
The IFrame plugin had the srcFromAnnotation, which took URLs directly from annotations; however there was no way to use an annotation value as part of an input. This functionality permits easy re-use of existing annotations in new ways, such as validating iframe behaviors against a different remote for staging/development rather than production.

#### :heavy_check_mark: Checklist

- [X] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [N/A] Screenshots of before and after attached (for UI changes)
- [X] Added or updated documentation (if applicable)
