### PR TITLE
feat(http-request): add opt-in idempotencyKey for checkpoint/task recovery

### DIFF
--- a/.changeset/http-request-idempotency-checkpoint.md
+++ b/.changeset/http-request-idempotency-checkpoint.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/scaffolder-backend-module-http-request': minor
+---
+
+Add an optional `idempotencyKey` input to the `http:backstage:request` action. When set and the scaffolder supports checkpoints (experimental task recovery), the request is wrapped in a checkpoint so it is executed at most once per task — on a task restart/recovery the cached response is returned instead of re-sending the request. This makes non-idempotent requests (e.g. creating Jira tickets) safe to use in templates that enable `EXPERIMENTAL_recovery`. Behaviour is unchanged when `idempotencyKey` is omitted.

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/README.md
@@ -166,6 +166,32 @@ Headers
 00000010  62 61 72 22 3a 22 66 6f  6f 22 7d                 |bar":"foo"}|
 ```
 
+### Idempotency and task recovery (experimental)
+
+When a template enables [experimental task recovery](https://backstage.io/docs/features/software-templates/experimental/#retries-and-recovery) (`spec.EXPERIMENTAL_recovery.EXPERIMENTAL_strategy: startOver`), a task that is interrupted (e.g. by a `scaffolder-backend` redeploy) is restarted from the beginning. By default that would re-send every `http:backstage:request` — duplicating non-idempotent side effects such as creating Jira tickets or other resources.
+
+To make a request safe under recovery, set an `idempotencyKey`. The request is then wrapped in a [checkpoint](https://backstage.io/docs/features/software-templates/writing-custom-actions/#using-checkpoints-in-custom-actions-experimental): it is executed at most once per task, and on a restart the cached response is returned instead of sending the request again. The key must be stable and unique within the template.
+
+```yaml
+steps:
+  - id: create_jira_ticket
+    name: Create Jira ticket
+    action: http:backstage:request
+    input:
+      method: 'POST'
+      path: '/proxy/jira/api/rest/api/latest/issue'
+      idempotencyKey: 'jira.create.parent'
+      headers:
+        content-type: 'application/json'
+      body:
+        fields:
+          project: { key: 'PROJ' }
+          summary: 'Created from Backstage'
+          issuetype: { name: 'Task' }
+```
+
+When `idempotencyKey` is omitted, or when the scaffolder does not provide a checkpoint API, behaviour is unchanged and the request is sent on every run.
+
 You can also visit the `/create/actions` route in your Backstage application to find out more about the parameters this action accepts when it's installed to configure how you like.
 
 ---

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.test.ts
@@ -603,4 +603,72 @@ describe('http:backstage:request', () => {
       });
     });
   });
+
+  describe('with idempotencyKey (checkpoint / task recovery)', () => {
+    const makeCheckpointContext = () => {
+      const checkpoint = jest.fn(
+        async ({ fn }: { key: string; fn: () => Promise<any> }) => fn(),
+      );
+      return { ...mockContext, checkpoint };
+    };
+
+    it('wraps the request in ctx.checkpoint when idempotencyKey is set and checkpoint is available', async () => {
+      (http as jest.Mock).mockResolvedValue({
+        code: 201,
+        headers: {},
+        body: { id: 'PROJ-1' },
+      });
+      const ctx: any = makeCheckpointContext();
+      await action.handler({
+        ...ctx,
+        input: {
+          path: '/api/proxy/jira/issue',
+          method: 'POST',
+          idempotencyKey: 'jira.create.parent',
+        },
+      });
+      expect(ctx.checkpoint).toHaveBeenCalledWith({
+        key: 'jira.create.parent',
+        fn: expect.any(Function),
+      });
+      expect(http).toHaveBeenCalledTimes(1);
+      expect(ctx.output).toHaveBeenCalledWith('code', 201);
+      expect(ctx.output).toHaveBeenCalledWith('body', { id: 'PROJ-1' });
+    });
+
+    it('falls back to sending the request directly when idempotencyKey is set but checkpoint is unavailable', async () => {
+      (http as jest.Mock).mockResolvedValue({
+        code: 200,
+        headers: {},
+        body: {},
+      });
+      await action.handler({
+        ...mockContext,
+        input: {
+          path: '/api/proxy/jira/issue',
+          method: 'POST',
+          idempotencyKey: 'jira.create.parent',
+        },
+      });
+      expect(http).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not use checkpoint when idempotencyKey is not provided', async () => {
+      (http as jest.Mock).mockResolvedValue({
+        code: 200,
+        headers: {},
+        body: {},
+      });
+      const ctx: any = makeCheckpointContext();
+      await action.handler({
+        ...ctx,
+        input: {
+          path: '/api/proxy/foo',
+          method: 'POST',
+        },
+      });
+      expect(ctx.checkpoint).not.toHaveBeenCalled();
+      expect(http).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
+++ b/plugins/scaffolder-actions/scaffolder-backend-module-http-request/src/actions/run/backstageRequest.ts
@@ -99,6 +99,12 @@ export function createHttpBackstageAction(options: {
             .describe(
               "When true, use the backstageToken from task secrets as the Authorization header instead of exchanging initiator credentials for a plugin token. Useful when the request needs to carry the caller's token directly.",
             ),
+          idempotencyKey: z
+            .string()
+            .optional()
+            .describe(
+              "When set and the scaffolder supports checkpoints (experimental task recovery), the request is wrapped in a checkpoint with this key. The HTTP request is then executed at most once per task: on a task restart/recovery the cached response is returned instead of sending the request again. Use a key that is stable and unique within the template (e.g. 'jira.create.parent'). This makes non-idempotent requests (creating tickets, issues, etc.) safe to use with recoverable templates. When omitted, behaviour is unchanged and the request is sent on every run.",
+            ),
         }),
       output: z =>
         z.object({
@@ -227,11 +233,21 @@ export function createHttpBackstageAction(options: {
         return;
       }
 
-      const { code, headers, body } = await http(
-        httpOptions,
-        ctx.logger,
-        continueOnBadResponse,
-      );
+      const sendRequest = () =>
+        http(httpOptions, ctx.logger, continueOnBadResponse);
+
+      // When an idempotencyKey is provided and the scaffolder supports
+      // checkpoints (experimental task recovery), wrap the request so it is
+      // executed at most once per task: on recovery the stored response is
+      // returned instead of re-sending the request. Otherwise behave exactly
+      // as before and send the request on every run.
+      const { code, headers, body } =
+        input.idempotencyKey && ctx.checkpoint
+          ? await ctx.checkpoint({
+              key: input.idempotencyKey,
+              fn: sendRequest,
+            })
+          : await sendRequest();
 
       ctx.output('code', code);
       ctx.output('headers', headers);


### PR DESCRIPTION
## Summary

Adds an optional `idempotencyKey` input to the `http:backstage:request` action so it can be used safely with Backstage's experimental scaffolder [task recovery](https://backstage.io/docs/features/software-templates/experimental/#retries-and-recovery).

## Motivation

When a template enables `spec.EXPERIMENTAL_recovery.EXPERIMENTAL_strategy: startOver`, an interrupted task (e.g. after a `scaffolder-backend` redeploy) is restarted **from the beginning**. Actions are expected to use [checkpoints](https://backstage.io/docs/features/software-templates/writing-custom-actions/#using-checkpoints-in-custom-actions-experimental) (scaffolder idempotency BEP-0004) to avoid repeating work.

`http:backstage:request` has no checkpoint support today, so on recovery it **re-sends every request**. For non-idempotent calls — most painfully **creating Jira tickets** via the proxy, but any resource-creating POST — this produces duplicates that must be cleaned up by hand, and in practice blocks enabling `EXPERIMENTAL_recovery` on templates that create resources through this action.

## What changed

- New optional input `idempotencyKey`. When set **and** the scaffolder provides `ctx.checkpoint`, the request is wrapped in a checkpoint with that key, so it executes at most once per task; on restart the cached response is returned instead of re-sending.
- Fully **backwards compatible**: when `idempotencyKey` is omitted, or the scaffolder offers no checkpoint API, behaviour is unchanged and the request is sent on every run. Opt-in by design so users who intentionally re-POST are unaffected.
- The change is isolated to `backstageRequest.ts` (~one wrapped call + one schema field).

```yaml
- action: http:backstage:request
  input:
    method: POST
    path: /proxy/jira/api/rest/api/latest/issue
    idempotencyKey: jira.create.parent
    body: { ... }
```

## Tests

Added unit tests covering: checkpoint path used when key + `ctx.checkpoint` present (request runs once, response output); fallback to a direct request when checkpoint is unavailable; and no checkpoint usage when the key is omitted.

## Docs / changeset

README section "Idempotency and task recovery" added; changeset included (`minor`).