### PR TITLE
feat(backstage-plugin-github-pull-requests): add missing alpha exports for NFS

### DIFF
--- a/.changeset/little-years-smash.md
+++ b/.changeset/little-years-smash.md
@@ -1,0 +1,5 @@
+---
+'@roadiehq/backstage-plugin-github-pull-requests': patch
+---
+
+Add missing alpha exports for new frontend system

--- a/plugins/frontend/backstage-plugin-github-pull-requests/package.json
+++ b/plugins/frontend/backstage-plugin-github-pull-requests/package.json
@@ -20,6 +20,21 @@
     "url": "github:RoadieHQ/roadie-backstage-plugins",
     "directory": "plugins/frontend/backstage-plugin-github-pull-requests"
   },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.tsx",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.tsx"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
The `alpha.tsx` file was added in https://github.com/RoadieHQ/roadie-backstage-plugins/pull/2209 but the corresponding `exports` and `typesVersions` fields were not added to `package.json`, making the new frontend system entrypoint unresolvable.

This adds the missing fields to match the pattern used by the other NFS-enabled plugins.

#### :heavy_check_mark: Checklist

- [ ] Added tests for new functionality and regression tests for bug fixes
- [X] Added changeset (run `yarn changeset` in the root)
- [ ] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
