### PR TITLE
feat(jira): add new frontend system support via an /alpha entry point

### DIFF
--- a/.changeset/lucky-tables-migrate.md
+++ b/.changeset/lucky-tables-migrate.md
@@ -1,0 +1,11 @@
+---
+'@roadiehq/backstage-plugin-jira': minor
+---
+
+Add new frontend system support via a new `/alpha` entry point, keeping the old frontend system exports untouched.
+
+The alpha plugin provides the Jira client as an `ApiBlueprint` extension, the three entity cards as `EntityCardBlueprint` extensions (`entity-card:jira/overview`, `entity-card:jira/activity-stream`, `entity-card:jira/query`), and a ready-made `/jira` tab as an `EntityContentBlueprint` extension (`entity-content:jira`). Cards carry the annotation filters that previously had to be wired up in the app with `EntitySwitch`, and the tab is shipped disabled so that installing the plugin never adds a tab an adopter did not ask for.
+
+`HomePageMyJiraTicketsCard` is not part of the alpha entry point yet: it needs `HomePageWidgetBlueprint`, which requires Backstage 1.48 or above.
+
+Note that this adds an `exports` field to the package, which stops deep imports into `dist/` from resolving.

--- a/plugins/frontend/backstage-plugin-jira/README.md
+++ b/plugins/frontend/backstage-plugin-jira/README.md
@@ -125,6 +125,50 @@ const overviewContent = (
 );
 ```
 
+## New Frontend System
+
+This plugin also ships an `/alpha` entry point for the [new frontend system](https://backstage.io/docs/frontend-system/). Steps 1 to 3 above (dependency, proxy config, CSP) are identical; only step 4 differs — instead of editing `EntityPage.tsx`, the extensions are discovered automatically and configured through `app-config.yaml`.
+
+If your app does not use package discovery, install the plugin explicitly:
+
+```tsx
+// packages/app/src/App.tsx
+import jiraPlugin from '@roadiehq/backstage-plugin-jira/alpha';
+
+const app = createApp({
+  features: [jiraPlugin],
+});
+```
+
+### Extensions
+
+| Extension ID                       | Default  | Description                                                      |
+| ---------------------------------- | -------- | ---------------------------------------------------------------- |
+| `entity-card:jira/overview`        | enabled  | Project details, issues and activity stream                      |
+| `entity-card:jira/activity-stream` | enabled  | Activity stream only                                             |
+| `entity-card:jira/query`           | enabled  | Results of the JQL query in the `jira/all-issues-jql` annotation |
+| `entity-content:jira`              | disabled | A ready-made `/jira` tab, combining the overview and query cards |
+| `api:jira`                         | enabled  | The Jira client                                                  |
+
+Cards are only rendered on entities carrying the annotations they need — `jira/project-key` for the overview and activity stream cards, `jira/all-issues-jql` for the query card — so no `EntitySwitch` is required.
+
+The `/jira` tab is shipped disabled so that installing the plugin never adds a tab you did not ask for. Enable it, and disable any card you do not want, under `app.extensions`:
+
+```yaml
+# app-config.yaml
+app:
+  extensions:
+    # Add the /jira tab
+    - entity-content:jira: true
+    # The tab already renders these two, so drop them from the entity page
+    - entity-card:jira/overview: false
+    - entity-card:jira/query: false
+```
+
+### Not yet supported
+
+`HomePageMyJiraTicketsCard` has no new frontend system equivalent yet: it needs `HomePageWidgetBlueprint`, which requires Backstage 1.48 or above, while this repository is on 1.44. Use the old frontend system export for the home page card in the meantime.
+
 ## How to get the Confluence Activity Filter key
 
 To filter the Confluence activities your instance needs to have the filter to select one or more types of activity from Confluence. You can check that out by executing the following command in your bash:

--- a/plugins/frontend/backstage-plugin-jira/package.json
+++ b/plugins/frontend/backstage-plugin-jira/package.json
@@ -31,6 +31,21 @@
       "@roadiehq/backstage-plugin-jira"
     ]
   },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.tsx",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.tsx"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "build": "backstage-cli package build",
@@ -47,6 +62,7 @@
     "@backstage/config": "backstage:^",
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
+    "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
     "@backstage/plugin-home-react": "backstage:^",
     "@material-ui/core": "^4.12.2",
@@ -72,6 +88,7 @@
     "@backstage/cli": "backstage:^",
     "@backstage/core-app-api": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
+    "@backstage/frontend-test-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/plugins/frontend/backstage-plugin-jira/src/alpha.test.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/alpha.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UrlPatternDiscovery } from '@backstage/core-app-api';
+import { AnyApiRef } from '@backstage/core-plugin-api';
+import { ConfigReader } from '@backstage/config';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import {
+  createExtensionTester,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+import { MockFetchApi, setupRequestMockHandlers } from '@backstage/test-utils';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { JiraAPI, jiraApiRef } from './api';
+import {
+  entityJiraActivityStreamCard,
+  entityJiraContent,
+  entityJiraOverviewCard,
+  entityJiraQueryCard,
+} from './alpha';
+import {
+  activityResponseStub,
+  entityStub,
+  projectResponseStub,
+  searchResponseStub,
+  statusesResponseStub,
+} from './responseStubs';
+
+const discoveryApi = UrlPatternDiscovery.compile('http://exampleapi.com');
+const fetchApi = new MockFetchApi();
+const configApi = new ConfigReader({});
+
+const apis: [AnyApiRef, Partial<unknown>][] = [
+  [jiraApiRef, new JiraAPI({ discoveryApi, configApi, fetchApi })],
+];
+
+const entityWithJqlStub = {
+  ...entityStub,
+  metadata: {
+    ...entityStub.metadata,
+    annotations: {
+      ...entityStub.metadata.annotations,
+      'jira/all-issues-jql': 'project = {{ projectKey }}',
+    },
+  },
+};
+
+const renderExtension = (
+  extension: Parameters<typeof createExtensionTester>[0],
+  entity: typeof entityStub = entityStub,
+) =>
+  renderInTestApp(
+    <TestApiProvider apis={apis}>
+      <EntityProvider entity={entity}>
+        {createExtensionTester(extension).reactElement()}
+      </EntityProvider>
+    </TestApiProvider>,
+  );
+
+describe('alpha extensions', () => {
+  const worker = setupServer();
+  setupRequestMockHandlers(worker);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    worker.use(
+      rest.get(
+        'http://exampleapi.com/jira/api/rest/api/latest/project/BT',
+        (_, res, ctx) => res(ctx.json(projectResponseStub)),
+      ),
+      rest.post(
+        'http://exampleapi.com/jira/api/rest/api/latest/search/jql',
+        (_, res, ctx) => res(ctx.json(searchResponseStub)),
+      ),
+      rest.get(
+        'http://exampleapi.com/jira/api/rest/api/latest/project/BT/statuses',
+        (_, res, ctx) => res(ctx.json(statusesResponseStub)),
+      ),
+      rest.get('http://exampleapi.com/jira/api/activity', (_, res, ctx) =>
+        res(ctx.xml(activityResponseStub)),
+      ),
+    );
+  });
+
+  it('renders the overview card', async () => {
+    const rendered = await renderExtension(entityJiraOverviewCard);
+
+    expect(await rendered.findByText(/backstage-test/)).toBeInTheDocument();
+  });
+
+  it('renders the activity stream card', async () => {
+    const rendered = await renderExtension(entityJiraActivityStreamCard);
+
+    expect(await rendered.findByText('Activity Stream')).toBeInTheDocument();
+    expect(
+      await rendered.findByText(
+        /changed the status to Selected for Development/,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the query card from the jira/all-issues-jql annotation', async () => {
+    const rendered = await renderExtension(
+      entityJiraQueryCard,
+      entityWithJqlStub,
+    );
+
+    expect(await rendered.findByText('Issues')).toBeInTheDocument();
+  });
+
+  it('renders the entity content with both the overview and the query card', async () => {
+    const rendered = await renderExtension(
+      entityJiraContent,
+      entityWithJqlStub,
+    );
+
+    expect(await rendered.findByText(/backstage-test/)).toBeInTheDocument();
+    expect(await rendered.findByText('Issues')).toBeInTheDocument();
+  });
+});

--- a/plugins/frontend/backstage-plugin-jira/src/alpha.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/alpha.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ApiBlueprint,
+  createFrontendPlugin,
+} from '@backstage/frontend-plugin-api';
+import {
+  configApiRef,
+  discoveryApiRef,
+  fetchApiRef,
+} from '@backstage/core-plugin-api';
+import {
+  EntityCardBlueprint,
+  EntityContentBlueprint,
+} from '@backstage/plugin-catalog-react/alpha';
+import { JiraAPI, jiraApiRef } from './api';
+import { hasJiraQuery, isJiraAvailable } from './components/Router';
+
+/**
+ * @alpha
+ */
+export const jiraApi = ApiBlueprint.make({
+  params: defineParams =>
+    defineParams({
+      api: jiraApiRef,
+      deps: {
+        discoveryApi: discoveryApiRef,
+        configApi: configApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, configApi, fetchApi }) =>
+        new JiraAPI({ discoveryApi, configApi, fetchApi }),
+    }),
+});
+
+/**
+ * @alpha
+ */
+export const entityJiraOverviewCard = EntityCardBlueprint.make({
+  name: 'overview',
+  params: {
+    type: 'content',
+    filter: isJiraAvailable,
+    loader: () =>
+      import('./components/JiraOverviewCard').then(m => <m.JiraOverviewCard />),
+  },
+});
+
+/**
+ * @alpha
+ */
+export const entityJiraActivityStreamCard = EntityCardBlueprint.make({
+  name: 'activity-stream',
+  params: {
+    type: 'content',
+    filter: isJiraAvailable,
+    loader: () =>
+      import('./components/EntityJiraActivityStreamCard').then(m => (
+        <m.EntityJiraActivityStreamCard />
+      )),
+  },
+});
+
+/**
+ * @alpha
+ */
+export const entityJiraQueryCard = EntityCardBlueprint.make({
+  name: 'query',
+  params: {
+    type: 'content',
+    filter: hasJiraQuery,
+    loader: () =>
+      import('./components/EntityJiraQueryCard').then(m => (
+        <m.EntityJiraQueryCard />
+      )),
+  },
+});
+
+/**
+ * A ready-made Jira tab, equivalent to the composition documented in the README
+ * for the old frontend system. Shipped disabled so that installing this plugin
+ * never adds a tab an adopter did not ask for: enable it with
+ * `entity-content:jira: true` under `app.extensions` in app-config.
+ *
+ * @alpha
+ */
+export const entityJiraContent = EntityContentBlueprint.make({
+  disabled: true,
+  params: {
+    path: '/jira',
+    title: 'Jira',
+    filter: isJiraAvailable,
+    loader: () =>
+      import('./components/EntityJiraContent').then(m => (
+        <m.EntityJiraContent />
+      )),
+  },
+});
+
+/**
+ * @alpha
+ */
+export default createFrontendPlugin({
+  pluginId: 'jira',
+  extensions: [
+    jiraApi,
+    entityJiraOverviewCard,
+    entityJiraActivityStreamCard,
+    entityJiraQueryCard,
+    entityJiraContent,
+  ],
+  // Same flag as the old frontend system plugin: shows the linked pull requests
+  // column in the Jira tickets table (Jira Data Center only).
+  featureFlags: [{ name: 'jira-show-linked-prs' }],
+});

--- a/plugins/frontend/backstage-plugin-jira/src/components/EntityJiraContent/EntityJiraContent.tsx
+++ b/plugins/frontend/backstage-plugin-jira/src/components/EntityJiraContent/EntityJiraContent.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Grid from '@material-ui/core/Grid';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { JiraOverviewCard } from '../JiraOverviewCard';
+import { EntityJiraQueryCard } from '../EntityJiraQueryCard';
+import { hasJiraQuery } from '../Router';
+
+/**
+ * Body of the Jira entity tab in the new frontend system. Deliberately renders no
+ * page shell (`Page`/`Header`/`PageWithHeader`) — the framework's page layout
+ * provides it.
+ */
+export const EntityJiraContent = () => {
+  const { entity } = useEntity();
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item md={12}>
+        <JiraOverviewCard />
+      </Grid>
+      {hasJiraQuery(entity) ? (
+        <Grid item md={12}>
+          <EntityJiraQueryCard />
+        </Grid>
+      ) : null}
+    </Grid>
+  );
+};

--- a/plugins/frontend/backstage-plugin-jira/src/components/EntityJiraContent/index.ts
+++ b/plugins/frontend/backstage-plugin-jira/src/components/EntityJiraContent/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Larder Software Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { EntityJiraContent } from './EntityJiraContent';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12605,6 +12605,8 @@ __metadata:
     "@backstage/core-components": "backstage:^"
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/dev-utils": "backstage:^"
+    "@backstage/frontend-plugin-api": "backstage:^"
+    "@backstage/frontend-test-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/plugin-home-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"


### PR DESCRIPTION
Adds new frontend system support to the Jira plugin through a new `/alpha` entry point, following the same pattern as `backstage-plugin-argo-cd`, `backstage-plugin-datadog` and `backstage-plugin-wiz` in this repo. The old frontend system exports are untouched, so adopters migrate when they are ready.

| Extension ID                       | Default  |                                                                  |
| ---------------------------------- | -------- | ---------------------------------------------------------------- |
| `api:jira`                         | enabled  | The Jira client, as an `ApiBlueprint` extension                   |
| `entity-card:jira/overview`        | enabled  | Project details, issues and activity stream                       |
| `entity-card:jira/activity-stream` | enabled  | Activity stream only                                             |
| `entity-card:jira/query`           | enabled  | Results of the `jira/all-issues-jql` annotation                   |
| `entity-content:jira`              | disabled | A ready-made `/jira` tab, combining the overview and query cards |

The cards carry the annotation filters that previously had to be wired up in the app with `EntitySwitch`. The tab is shipped disabled so installing the plugin never adds a tab an adopter did not ask for — enable it with `entity-content:jira: true` under `app.extensions`.

The plugin has no route refs, so there is no `convertLegacyRouteRefs`. `compatWrapper` also turned out to be unnecessary: the cards only use `useApi`, `useEntity` and `useAnalytics`.

`HomePageMyJiraTicketsCard` is left out — it needs `HomePageWidgetBlueprint`, which only exists from `@backstage/plugin-home-react@0.1.35` (Backstage 1.48+), while this repo is on 1.44. Card props are also not exposed as extension config yet; both would make good follow-ups.

Note that this adds an `exports` field to a package that had none, which stops deep imports into `dist/` from resolving — hence the `minor` changeset.

### Testing

`yarn tsc`, `yarn lint` and `yarn test` pass on the plugin (37 tests / 5 suites, including 4 new ones in `src/alpha.test.tsx` using `createExtensionTester`). `yarn build` produces `dist/alpha.esm.js` + `dist/alpha.d.ts`, and `prepack` correctly emits `"backstage": "@backstage/FrontendPlugin"` on the `./alpha` export so feature discovery picks it up.

Also verified end to end in a real Backstage 1.53 app on the new frontend system: the plugin is auto-discovered, the extension IDs resolve, and the `/jira` tab replaces the app's previous compat-layer JSX with no `API_FACTORY_CONFLICT`.

---

Written with [Claude Code](https://claude.com/claude-code). Review by me (brezinben)
