### PR TITLE
feat(@roadiehq/backstage-plugin-argo-cd-node): Add warning logs for unexpected HTML responses from Argo session api

### DIFF
--- a/.changeset/olive-teeth-hammer.md
+++ b/.changeset/olive-teeth-hammer.md
@@ -1,0 +1,14 @@
+---
+'@roadiehq/backstage-plugin-argo-cd-node': minor
+---
+
+New features:
+
+- Added debug logs when the Argo Session API returns an unexpected HTML response.
+- Purposefully throwing error when response contains html instead of the error thrown when attempting to parse a non json response.
+
+Reasoning: Depending on the deployment environment, traffic to the Argo API may pass through edge security, web application firewall (WAF), or content delivery network (CDN) services such as Akamai, F5, or Cloudflare. When routing failures occur, these services may return an HTML response instead of the expected API response.
+
+Previously, these responses were truncated in logs, making it difficult to access diagnostic information — such as reference IDs — that can help identify the source of the failure. This change improves observability by logging unexpected HTML responses, providing additional context for troubleshooting and root-cause analysis.
+
+Behavior: No functional behavior has changed. This change only adds additional warning-level logging for unexpected HTML responses to the session endpoint. Does not log when content type includes application/json

--- a/plugins/backend/backstage-plugin-argo-cd-node/src/service/argocd.service.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-node/src/service/argocd.service.ts
@@ -98,6 +98,20 @@ export class ArgoService implements ArgoServiceApi {
     return new ArgoService(argoUserName, argoPassword, config, logger);
   }
 
+  private async parseJson(response: Response, url: string) {
+    const contentType = response.headers.get('content-type');
+    if (
+      contentType?.includes('text/html') &&
+      !contentType?.includes('application/json')
+    ) {
+      this.logger.debug(await response.clone().text());
+      throw new Error(
+        `Received unexpected HTML response from ${url}. Enable debug logs to see full html response.`,
+      );
+    }
+    return await response.json();
+  }
+
   getArgoInstanceArray(): InstanceConfig[] {
     return this.getAppArray().map(instance => ({
       name: instance.getString('name'),
@@ -152,7 +166,6 @@ export class ArgoService implements ArgoServiceApi {
     const url = urlBuilder.toString();
 
     const resp = await fetch(url, requestOptions);
-
     if (!resp.ok) {
       throw new Error(`Request failed with ${resp.status} Error`);
     }
@@ -248,7 +261,8 @@ export class ArgoService implements ArgoServiceApi {
     if (token) return token;
 
     if ((username && password) || (this.username && this.password)) {
-      const resp = await fetch(buildArgoUrl(url, '/api/v1/session'), {
+      const sessionTokenUrl = buildArgoUrl(url, '/api/v1/session');
+      const resp = await fetch(sessionTokenUrl, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -258,13 +272,14 @@ export class ArgoService implements ArgoServiceApi {
           password: password || this.password,
         }),
       });
+
       if (!resp.ok) {
         this.logger.error(`failed to get argo token: ${url}`);
       }
       if (resp.status === 401) {
         throw new Error(`Getting unauthorized for Argo CD instance ${url}`);
       }
-      const data = await resp.json();
+      const data = await this.parseJson(resp, sessionTokenUrl);
       return data.token;
     }
 
@@ -342,7 +357,6 @@ export class ArgoService implements ArgoServiceApi {
       buildArgoUrl(baseUrl, `/api/v1/applications${urlSuffix}`),
       requestOptions,
     );
-
     if (!resp.ok) {
       throw new Error(`Request failed with ${resp.status} Error`);
     }
@@ -729,6 +743,7 @@ export class ArgoService implements ArgoServiceApi {
       options,
     );
     const respData = await resp.json();
+
     if (resp.status !== 200) {
       this.logger.error(
         `Error updating argo app ${appName}: ${respData.message}`,
@@ -762,6 +777,7 @@ export class ArgoService implements ArgoServiceApi {
         urlBuilder.toString(),
         options,
       )) as DeleteArgoAppFetchResponse;
+
       statusText = response.statusText;
       if (response.status === 200) {
         return { ...(await response.json()), statusCode: response.status };
@@ -1217,6 +1233,7 @@ export class ArgoService implements ArgoServiceApi {
         ),
         options,
       )) as TerminateArgoAppOperationFetchResponse;
+
       statusText = response.statusText;
 
       if (response.status === 200) {

--- a/plugins/backend/backstage-plugin-argo-cd-node/src/service/argocd.test.ts
+++ b/plugins/backend/backstage-plugin-argo-cd-node/src/service/argocd.test.ts
@@ -33,7 +33,6 @@ fetchMock.enableMocks();
 jest.mock('./timer.services', () => ({
   timer: jest.fn(),
 }));
-
 type GetConfigOptions = {
   clusterResourceBlacklist?: ResourceItem[];
   clusterResourceWhitelist?: ResourceItem[];
@@ -1154,1531 +1153,1650 @@ describe('ArgoCD service', () => {
         }),
       );
     });
+  });
 
-    describe('deleteAppandProject', () => {
-      let deleteAppMock: jest.SpyInstance<ReturnType<ArgoService['deleteApp']>>;
-      let deleteProjectMock: jest.SpyInstance<
-        ReturnType<ArgoService['deleteProject']>
-      >;
-      let getArgoApplicationInfoMock: jest.SpyInstance<
-        ReturnType<ArgoService['getArgoApplicationInfo']>
-      >;
-      let terminateArgoAppOperationMock: jest.SpyInstance<
-        ReturnType<ArgoService['terminateArgoAppOperation']>
-      >;
+  describe('deleteAppandProject', () => {
+    let deleteAppMock: jest.SpyInstance<ReturnType<ArgoService['deleteApp']>>;
+    let deleteProjectMock: jest.SpyInstance<
+      ReturnType<ArgoService['deleteProject']>
+    >;
+    let getArgoApplicationInfoMock: jest.SpyInstance<
+      ReturnType<ArgoService['getArgoApplicationInfo']>
+    >;
+    let terminateArgoAppOperationMock: jest.SpyInstance<
+      ReturnType<ArgoService['terminateArgoAppOperation']>
+    >;
 
-      beforeEach(() => {
-        deleteAppMock = jest.spyOn(ArgoService.prototype, 'deleteApp');
-        deleteProjectMock = jest.spyOn(ArgoService.prototype, 'deleteProject');
-        getArgoApplicationInfoMock = jest.spyOn(
-          ArgoService.prototype,
-          'getArgoApplicationInfo',
-        );
-        terminateArgoAppOperationMock = jest.spyOn(
-          ArgoService.prototype,
-          'terminateArgoAppOperation',
-        );
+    beforeEach(() => {
+      deleteAppMock = jest.spyOn(ArgoService.prototype, 'deleteApp');
+      deleteProjectMock = jest.spyOn(ArgoService.prototype, 'deleteProject');
+      getArgoApplicationInfoMock = jest.spyOn(
+        ArgoService.prototype,
+        'getArgoApplicationInfo',
+      );
+      terminateArgoAppOperationMock = jest.spyOn(
+        ArgoService.prototype,
+        'terminateArgoAppOperation',
+      );
+    });
+
+    it('deletes project after deletion of the application is successful due to the application not existing', async () => {
+      deleteAppMock.mockResolvedValueOnce({
+        message: 'application not found',
+        statusCode: 404,
+        code: 1,
+        error: 'error',
       });
 
-      it('deletes project after deletion of the application is successful due to the application not existing', async () => {
-        deleteAppMock.mockResolvedValueOnce({
-          message: 'application not found',
-          statusCode: 404,
-          code: 1,
-          error: 'error',
-        });
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
 
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
-            status: 'success',
-            message:
-              'application testApp does not exist and therefore does not need to be deleted',
-            argoResponse: {
-              message: 'application not found',
-              statusCode: 404,
-              code: 1,
-              error: 'error',
-            },
-          },
-          deleteProjectDetails: {
-            status: 'pending',
-            message: 'project testApp is pending deletion.',
-            argoResponse: {
-              statusCode: 200,
-            },
-          },
-        });
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
       });
 
-      it('skips project deletion when application deletion fails', async () => {
-        deleteAppMock.mockResolvedValueOnce({
-          code: 1,
-          error: 'some error occurred',
-          message: 'some error occurred',
-          statusCode: 500,
-        });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(getArgoApplicationInfoMock).not.toHaveBeenCalled();
-        expect(deleteProjectMock).not.toHaveBeenCalled();
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
-            status: 'failed',
-            message: 'failed to delete application testApp',
-            argoResponse: {
-              code: 1,
-              error: 'some error occurred',
-              message: 'some error occurred',
-              statusCode: 500,
-            },
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'success',
+          message:
+            'application testApp does not exist and therefore does not need to be deleted',
+          argoResponse: {
+            message: 'application not found',
+            statusCode: 404,
+            code: 1,
+            error: 'error',
           },
-          deleteProjectDetails: {
-            status: 'failed',
-            message:
-              'project testApp deletion skipped due to application still existing and pending deletion, or the application failed to delete.',
-            argoResponse: {},
+        },
+        deleteProjectDetails: {
+          status: 'pending',
+          message: 'project testApp is pending deletion.',
+          argoResponse: {
+            statusCode: 200,
           },
-        });
+        },
+      });
+    });
+
+    it('skips project deletion when application deletion fails', async () => {
+      deleteAppMock.mockResolvedValueOnce({
+        code: 1,
+        error: 'some error occurred',
+        message: 'some error occurred',
+        statusCode: 500,
       });
 
-      it('skips project deletion when application is pending to delete', async () => {
-        deleteAppMock.mockResolvedValueOnce({
-          statusCode: 200,
-        });
-
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          metadata: {
-            name: 'testAppName',
-            namespace: 'testNamespace',
-          },
-          statusCode: 200,
-        });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(deleteProjectMock).not.toHaveBeenCalled();
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
-            status: 'pending',
-            message:
-              'application testApp still pending deletion with the deletion timestamp of undefined',
-            argoResponse: {
-              metadata: {
-                name: 'testAppName',
-                namespace: 'testNamespace',
-              },
-              statusCode: 200,
-            },
-          },
-          deleteProjectDetails: {
-            status: 'failed',
-            message:
-              'project testApp deletion skipped due to application still existing and pending deletion, or the application failed to delete.',
-            argoResponse: {},
-          },
-        });
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
       });
 
-      it('skips project deletion when application deletion status is unknown', async () => {
-        deleteAppMock.mockResolvedValueOnce({
-          statusCode: 200,
-        });
+      expect(getArgoApplicationInfoMock).not.toHaveBeenCalled();
+      expect(deleteProjectMock).not.toHaveBeenCalled();
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'failed',
+          message: 'failed to delete application testApp',
+          argoResponse: {
+            code: 1,
+            error: 'some error occurred',
+            message: 'some error occurred',
+            statusCode: 500,
+          },
+        },
+        deleteProjectDetails: {
+          status: 'failed',
+          message:
+            'project testApp deletion skipped due to application still existing and pending deletion, or the application failed to delete.',
+          argoResponse: {},
+        },
+      });
+    });
 
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'something happened',
-          code: 1,
-          error: 'something happened',
-          statusCode: 500,
-        });
+    it('skips project deletion when application is pending to delete', async () => {
+      deleteAppMock.mockResolvedValueOnce({
+        statusCode: 200,
+      });
 
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        metadata: {
+          name: 'testAppName',
+          namespace: 'testNamespace',
+        },
+        statusCode: 200,
+      });
 
-        expect(deleteProjectMock).not.toHaveBeenCalled();
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(deleteProjectMock).not.toHaveBeenCalled();
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'pending',
+          message:
+            'application testApp still pending deletion with the deletion timestamp of undefined',
+          argoResponse: {
+            metadata: {
+              name: 'testAppName',
+              namespace: 'testNamespace',
+            },
+            statusCode: 200,
+          },
+        },
+        deleteProjectDetails: {
+          status: 'failed',
+          message:
+            'project testApp deletion skipped due to application still existing and pending deletion, or the application failed to delete.',
+          argoResponse: {},
+        },
+      });
+    });
+
+    it('skips project deletion when application deletion status is unknown', async () => {
+      deleteAppMock.mockResolvedValueOnce({
+        statusCode: 200,
+      });
+
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'something happened',
+        code: 1,
+        error: 'something happened',
+        statusCode: 500,
+      });
+
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(deleteProjectMock).not.toHaveBeenCalled();
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'failed',
+          message:
+            'a request was successfully sent to delete application testApp, but when getting your application information we received an error',
+          argoResponse: {
+            code: 1,
+            error: 'something happened',
+            message: 'something happened',
+            statusCode: 500,
+          },
+        },
+        deleteProjectDetails: {
+          status: 'failed',
+          message:
+            'project testApp deletion skipped due to application still existing and pending deletion, or the application failed to delete.',
+          argoResponse: {},
+        },
+      });
+    });
+
+    it('deletes app and project successfully', async () => {
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'application not found',
+        error: 'error',
+        code: 1,
+        statusCode: 404,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'success',
+          message:
+            'application testApp deletion verified (application no longer exists)',
+          argoResponse: {
+            code: 1,
+            error: 'error',
+            message: 'application not found',
+            statusCode: 404,
+          },
+        },
+        deleteProjectDetails: {
+          status: 'pending',
+          message: 'project testApp is pending deletion.',
+          argoResponse: { statusCode: 200 },
+        },
+      });
+    });
+    it('should successfully delete app and fail to delete project returning error message', async () => {
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'application not found',
+        error: 'error',
+        code: 1,
+        statusCode: 404,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({
+        error: 'something unexpected',
+        message: 'something unexpected',
+        code: 1,
+        statusCode: 500,
+      });
+
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'success',
+          message:
+            'application testApp deletion verified (application no longer exists)',
+          argoResponse: {
+            code: 1,
+            error: 'error',
+            message: 'application not found',
+            statusCode: 404,
+          },
+        },
+        deleteProjectDetails: {
+          status: 'failed',
+          message: 'failed to delete project testApp.',
+          argoResponse: {
+            error: 'something unexpected',
+            message: 'something unexpected',
+            code: 1,
+            statusCode: 500,
+          },
+        },
+      });
+    });
+    it('communicates when terminate operation is unsuccessful', async () => {
+      terminateArgoAppOperationMock.mockResolvedValueOnce({
+        message: 'something happened',
+        statusCode: 500,
+        code: 1,
+        error: 'error',
+      });
+
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'some error',
+        error: 'error',
+        code: 1,
+        statusCode: 500,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+        terminateOperation: true,
+      });
+
+      expect(resp).toEqual(
+        expect.objectContaining({
+          terminateOperationDetails: {
             status: 'failed',
-            message:
-              'a request was successfully sent to delete application testApp, but when getting your application information we received an error',
+            message: `failed to terminate testApp's operation for application`,
             argoResponse: {
-              code: 1,
-              error: 'something happened',
               message: 'something happened',
               statusCode: 500,
-            },
-          },
-          deleteProjectDetails: {
-            status: 'failed',
-            message:
-              'project testApp deletion skipped due to application still existing and pending deletion, or the application failed to delete.',
-            argoResponse: {},
-          },
-        });
-      });
-
-      it('deletes app and project successfully', async () => {
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'application not found',
-          error: 'error',
-          code: 1,
-          statusCode: 404,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
-            status: 'success',
-            message:
-              'application testApp deletion verified (application no longer exists)',
-            argoResponse: {
               code: 1,
               error: 'error',
-              message: 'application not found',
-              statusCode: 404,
             },
           },
-          deleteProjectDetails: {
-            status: 'pending',
-            message: 'project testApp is pending deletion.',
-            argoResponse: { statusCode: 200 },
-          },
-        });
+        }),
+      );
+    });
+    it('communicates when terminate operation cannot find application', async () => {
+      terminateArgoAppOperationMock.mockResolvedValueOnce({
+        message: 'not found',
+        statusCode: 404,
+        error: 'error',
+        code: 1,
       });
-      it('should successfully delete app and fail to delete project returning error message', async () => {
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
 
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'application not found',
-          error: 'error',
-          code: 1,
-          statusCode: 404,
-        });
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
 
-        deleteProjectMock.mockResolvedValueOnce({
-          error: 'something unexpected',
-          message: 'something unexpected',
-          code: 1,
-          statusCode: 500,
-        });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
-            status: 'success',
-            message:
-              'application testApp deletion verified (application no longer exists)',
-            argoResponse: {
-              code: 1,
-              error: 'error',
-              message: 'application not found',
-              statusCode: 404,
-            },
-          },
-          deleteProjectDetails: {
-            status: 'failed',
-            message: 'failed to delete project testApp.',
-            argoResponse: {
-              error: 'something unexpected',
-              message: 'something unexpected',
-              code: 1,
-              statusCode: 500,
-            },
-          },
-        });
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'some error',
+        error: 'error',
+        code: 1,
+        statusCode: 500,
       });
-      it('communicates when terminate operation is unsuccessful', async () => {
-        terminateArgoAppOperationMock.mockResolvedValueOnce({
-          message: 'something happened',
-          statusCode: 500,
-          code: 1,
-          error: 'error',
-        });
 
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
 
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'some error',
-          error: 'error',
-          code: 1,
-          statusCode: 500,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-          terminateOperation: true,
-        });
-
-        expect(resp).toEqual(
-          expect.objectContaining({
-            terminateOperationDetails: {
-              status: 'failed',
-              message: `failed to terminate testApp's operation for application`,
-              argoResponse: {
-                message: 'something happened',
-                statusCode: 500,
-                code: 1,
-                error: 'error',
-              },
-            },
-          }),
-        );
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+        terminateOperation: true,
       });
-      it('communicates when terminate operation cannot find application', async () => {
-        terminateArgoAppOperationMock.mockResolvedValueOnce({
-          message: 'not found',
-          statusCode: 404,
-          error: 'error',
-          code: 1,
-        });
 
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'some error',
-          error: 'error',
-          code: 1,
-          statusCode: 500,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-          terminateOperation: true,
-        });
-
-        expect(resp).toEqual(
-          expect.objectContaining({
-            terminateOperationDetails: {
-              status: 'failed',
-              message: 'application testApp not found',
-              argoResponse: {
-                message: 'not found',
-                statusCode: 404,
-                error: 'error',
-                code: 1,
-              },
-            },
-          }),
-        );
-      });
-      it('terminates operation when terminate set to true', async () => {
-        terminateArgoAppOperationMock.mockResolvedValueOnce({
-          statusCode: 200,
-        });
-
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'application not found',
-          error: 'error',
-          code: 1,
-          statusCode: 404,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-          terminateOperation: true,
-        });
-
-        expect(terminateArgoAppOperationMock).toHaveBeenCalled();
-        expect(resp).toStrictEqual({
-          deleteAppDetails: {
-            status: 'success',
-            message:
-              'application testApp deletion verified (application no longer exists)',
-            argoResponse: {
-              code: 1,
-              error: 'error',
-              message: 'application not found',
-              statusCode: 404,
-            },
-          },
-          deleteProjectDetails: {
-            status: 'pending',
-            message: 'project testApp is pending deletion.',
-            argoResponse: { statusCode: 200 },
-          },
+      expect(resp).toEqual(
+        expect.objectContaining({
           terminateOperationDetails: {
+            status: 'failed',
+            message: 'application testApp not found',
+            argoResponse: {
+              message: 'not found',
+              statusCode: 404,
+              error: 'error',
+              code: 1,
+            },
+          },
+        }),
+      );
+    });
+    it('terminates operation when terminate set to true', async () => {
+      terminateArgoAppOperationMock.mockResolvedValueOnce({
+        statusCode: 200,
+      });
+
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'application not found',
+        error: 'error',
+        code: 1,
+        statusCode: 404,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+        terminateOperation: true,
+      });
+
+      expect(terminateArgoAppOperationMock).toHaveBeenCalled();
+      expect(resp).toStrictEqual({
+        deleteAppDetails: {
+          status: 'success',
+          message:
+            'application testApp deletion verified (application no longer exists)',
+          argoResponse: {
+            code: 1,
+            error: 'error',
+            message: 'application not found',
+            statusCode: 404,
+          },
+        },
+        deleteProjectDetails: {
+          status: 'pending',
+          message: 'project testApp is pending deletion.',
+          argoResponse: { statusCode: 200 },
+        },
+        terminateOperationDetails: {
+          status: 'success',
+          message: `testApp's current operation terminated`,
+          argoResponse: { statusCode: 200 },
+        },
+      });
+    });
+
+    it('communicates when project was not found for deletion', async () => {
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValueOnce({
+        message: 'application not found',
+        code: 1,
+        error: 'error',
+        statusCode: 404,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({
+        code: 1,
+        message: 'not found',
+        error: 'error',
+        statusCode: 404,
+      });
+
+      const resp = await argoService.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(resp).toEqual(
+        expect.objectContaining({
+          deleteProjectDetails: {
             status: 'success',
-            message: `testApp's current operation terminated`,
-            argoResponse: { statusCode: 200 },
-          },
-        });
-      });
-
-      it('communicates when project was not found for deletion', async () => {
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValueOnce({
-          message: 'application not found',
-          code: 1,
-          error: 'error',
-          statusCode: 404,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({
-          code: 1,
-          message: 'not found',
-          error: 'error',
-          statusCode: 404,
-        });
-
-        const resp = await argoService.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toEqual(
-          expect.objectContaining({
-            deleteProjectDetails: {
-              status: 'success',
-              message:
-                'project testApp does not exist and therefore does not need to be deleted.',
-              argoResponse: {
-                code: 1,
-                message: 'not found',
-                error: 'error',
-                statusCode: 404,
-              },
+            message:
+              'project testApp does not exist and therefore does not need to be deleted.',
+            argoResponse: {
+              code: 1,
+              message: 'not found',
+              error: 'error',
+              statusCode: 404,
             },
-          }),
-        );
-      });
-
-      it('checks if app is deleted for two cycles', async () => {
-        const argoServiceWaitCycles = createService({
-          instanceCredentials: { token: 'token' },
-          waitCycles: 2,
-        });
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValue({
-          metadata: {
-            name: 'testApp',
           },
-          statusCode: 200,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        await argoServiceWaitCycles.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(2);
-        expect(mocked(timer)).toHaveBeenCalledTimes(1);
-      });
-
-      it('checks if app is deleted for more than 2 cycles', async () => {
-        const argoServiceWaitCycles = createService({
-          instanceCredentials: { token: 'token' },
-          waitCycles: 3,
-        });
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValue({
-          metadata: {
-            name: 'testApp',
-          },
-          statusCode: 200,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        await argoServiceWaitCycles.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(3);
-        expect(mocked(timer)).toHaveBeenCalledTimes(2);
-      });
-
-      it('waits the default amount of time when no interval time is provided', async () => {
-        const argoServiceWaitInterval = createService({
-          instanceCredentials: { token: 'token' },
-          waitCycles: 2,
-        });
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValue({
-          metadata: {
-            name: 'testApp',
-          },
-          statusCode: 200,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        await argoServiceWaitInterval.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(2);
-        expect(mocked(timer)).toHaveBeenCalledTimes(1);
-        expect(mocked(timer)).toHaveBeenCalledWith(5000);
-      });
-
-      it('waits the given amount of time configured when looping to check if application has been deleted', async () => {
-        const argoServiceWaitInterval = createService({
-          instanceCredentials: { token: 'token' },
-          waitCycles: 2,
-          waitInterval: 2000,
-        });
-        deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        getArgoApplicationInfoMock.mockResolvedValue({
-          metadata: {
-            name: 'testApp',
-          },
-          statusCode: 200,
-        });
-
-        deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
-
-        await argoServiceWaitInterval.deleteAppandProject({
-          argoAppName: 'testApp',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(2);
-        expect(mocked(timer)).toHaveBeenCalledTimes(1);
-        expect(mocked(timer)).toHaveBeenCalledWith(2000);
-      });
+        }),
+      );
     });
 
-    describe('findArgoApp', () => {
-      it('should return the argo instances an argo app is on', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            metadata: {
-              name: 'testApp-nonprod',
-              namespace: 'argocd',
-              status: {},
-            },
-          }),
-        );
-
-        const resp = await argoService.findArgoApp({ name: 'testApp-nonprod' });
-
-        expect(resp).toStrictEqual([
-          {
-            name: 'argoinstance1',
-            url: 'https://argoinstance1.com',
-            appName: ['testApp-nonprod'],
-          },
-        ]);
+    it('checks if app is deleted for two cycles', async () => {
+      const argoServiceWaitCycles = createService({
+        instanceCredentials: { token: 'token' },
+        waitCycles: 2,
       });
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
 
-      it('should return an empty array even when the request fails', async () => {
-        fetchMock.mockRejectOnce(new Error());
-        expect(
-          await argoService.findArgoApp({ name: 'test-app' }),
-        ).toStrictEqual([]);
-      });
-
-      it('should return the argo instances using the app selector', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            items: [
-              {
-                metadata: {
-                  name: 'testApp-nonprod',
-                  namespace: 'argocd',
-                  status: {},
-                },
-              },
-            ],
-          }),
-        );
-
-        const resp = await argoService.findArgoApp({
-          selector: 'name=testApp-nonprod',
-        });
-
-        expect(resp).toStrictEqual([
-          {
-            appName: ['testApp-nonprod'],
-            name: 'argoinstance1',
-            url: 'https://argoinstance1.com',
-          },
-        ]);
-      });
-
-      it('returns empty array when get token call fails', async () => {
-        fetchMock.mockRejectedValueOnce(new Error('FetchError'));
-
-        const resp = await argoServiceForNoToken.findArgoApp({
-          selector: 'name=testApp-nonprod',
-        });
-
-        expect(resp).toStrictEqual([]);
-      });
-
-      it('logs error when token call fails', async () => {
-        fetchMock.mockRejectedValueOnce(new Error('FetchError'));
-
-        await argoServiceForNoToken.findArgoApp({
-          selector: 'name=testApp-nonprod',
-        });
-
-        expect(logger.error).toHaveBeenCalledWith(
-          'Error getting token from Argo Instance argoinstance1: FetchError',
-        );
-      });
-    });
-
-    describe('updateArgoProjectAndApp', () => {
-      const data: UpdateArgoProjectAndAppProps = {
-        instanceConfig: {
-          name: 'argoInstanceName',
-          url: 'http://argoinstance.com',
-        },
-        argoToken: 'argoToken',
-        appName: 'appName',
-        projectName: 'projectName',
-        namespace: 'namespace',
-        sourceRepo: 'sourceRepo',
-        sourcePath: 'sourcePath',
-        labelValue: 'labelValue',
-      };
-      const getArgoAppDataResp = {
+      getArgoApplicationInfoMock.mockResolvedValue({
         metadata: {
-          name: 'argoInstanceName',
-          resourceVersion: 'resourceVersion',
+          name: 'testApp',
         },
-        spec: { source: { repoURL: 'sourceRepo' } },
-        status: {},
-        instance: 'instance',
-      };
-      const getArgoProjectResp = {
-        metadata: { resourceVersion: 'resourceVersion' },
-      };
-      it('should throw error when argo app not found', async () => {
-        fetchMock.mockResponseOnce('', { status: 404 }); // getArgoAppData
-        await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
-          'Request failed with 404 Error',
-        );
+        statusCode: 200,
       });
 
-      it('should throw error when source url undefined', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            ...getArgoAppDataResp,
-            spec: { source: { repoURL: '' } },
-          }),
-        ); // getArgoAppData
-        await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
-          'No repo URL found for argo app',
-        );
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      await argoServiceWaitCycles.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
       });
 
-      it('should throw error when app resourceVersion undefined', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({ ...getArgoAppDataResp, metadata: {} }),
-        ); // getArgoAppData
-        await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
-          'No resourceVersion found for argo app',
-        );
-      });
-
-      it('should throw error when project resourceVersion undefined', async () => {
-        fetchMock
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
-          .mockResponseOnce(JSON.stringify({ metadata: {} })); // getArgoProject
-        await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
-          'No resourceVersion found for argo project',
-        );
-      });
-
-      it('should throw error when argo project update fails', async () => {
-        fetchMock
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
-          .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
-          .mockResponseOnce(JSON.stringify({ message: 'ERROR' }), {
-            status: 500,
-          }); // updateArgoProject
-
-        await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
-          'Error updating argo project: ERROR',
-        );
-      });
-
-      it('should throw error when argo app update fails', async () => {
-        fetchMock
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
-          .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
-          .mockResponseOnce(JSON.stringify({ message: 'ERROR' }), {
-            status: 500,
-          }); // updateArgoApp
-
-        await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
-          'Error updating argo app: ERROR',
-        );
-      });
-
-      it('should send correct project payload', async () => {
-        fetchMock
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
-          .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoApp
-
-        await argoService.updateArgoProjectAndApp(data);
-
-        const fetchBody = JSON.parse(
-          fetchMock.mock.calls[2][1]?.body as string,
-        );
-
-        expect(fetchBody).toStrictEqual(
-          expect.objectContaining({
-            project: {
-              metadata: expect.objectContaining({
-                name: 'projectName',
-              }),
-              spec: expect.objectContaining({
-                destinations: [
-                  {
-                    name: 'local',
-                    namespace: 'namespace',
-                    server: 'https://kubernetes.default.svc',
-                  },
-                ],
-                sourceRepos: ['sourceRepo'],
-              }),
-            },
-          }),
-        );
-      });
-
-      it('should return true when app and project update succeeds', async () => {
-        fetchMock
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
-          .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoApp
-
-        const resp = await argoService.updateArgoProjectAndApp(data);
-
-        expect(resp).toBe(true);
-      });
-
-      it('should return true when app and project update succeeds and source repo changes', async () => {
-        fetchMock
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
-          .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoApp
-          .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
-          .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoProject
-
-        const newData = { ...data, sourceRepo: 'newRepo' };
-
-        const resp = await argoService.updateArgoProjectAndApp(newData);
-
-        expect(resp).toBe(true);
-      });
+      expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(2);
+      expect(mocked(timer)).toHaveBeenCalledTimes(1);
     });
 
-    describe('getArgoProject', () => {
-      const projectData = { metadata: { resourceVersion: 'resourceVersion' } };
-      const argoProjectReq = {
+    it('checks if app is deleted for more than 2 cycles', async () => {
+      const argoServiceWaitCycles = createService({
+        instanceCredentials: { token: 'token' },
+        waitCycles: 3,
+      });
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValue({
+        metadata: {
+          name: 'testApp',
+        },
+        statusCode: 200,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      await argoServiceWaitCycles.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(3);
+      expect(mocked(timer)).toHaveBeenCalledTimes(2);
+    });
+
+    it('waits the default amount of time when no interval time is provided', async () => {
+      const argoServiceWaitInterval = createService({
+        instanceCredentials: { token: 'token' },
+        waitCycles: 2,
+      });
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValue({
+        metadata: {
+          name: 'testApp',
+        },
+        statusCode: 200,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      await argoServiceWaitInterval.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(2);
+      expect(mocked(timer)).toHaveBeenCalledTimes(1);
+      expect(mocked(timer)).toHaveBeenCalledWith(5000);
+    });
+
+    it('waits the given amount of time configured when looping to check if application has been deleted', async () => {
+      const argoServiceWaitInterval = createService({
+        instanceCredentials: { token: 'token' },
+        waitCycles: 2,
+        waitInterval: 2000,
+      });
+      deleteAppMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      getArgoApplicationInfoMock.mockResolvedValue({
+        metadata: {
+          name: 'testApp',
+        },
+        statusCode: 200,
+      });
+
+      deleteProjectMock.mockResolvedValueOnce({ statusCode: 200 });
+
+      await argoServiceWaitInterval.deleteAppandProject({
+        argoAppName: 'testApp',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(getArgoApplicationInfoMock).toHaveBeenCalledTimes(2);
+      expect(mocked(timer)).toHaveBeenCalledTimes(1);
+      expect(mocked(timer)).toHaveBeenCalledWith(2000);
+    });
+  });
+
+  describe('findArgoApp', () => {
+    it('should return the argo instances an argo app is on', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          metadata: {
+            name: 'testApp-nonprod',
+            namespace: 'argocd',
+            status: {},
+          },
+        }),
+      );
+
+      const resp = await argoService.findArgoApp({ name: 'testApp-nonprod' });
+
+      expect(resp).toStrictEqual([
+        {
+          name: 'argoinstance1',
+          url: 'https://argoinstance1.com',
+          appName: ['testApp-nonprod'],
+        },
+      ]);
+    });
+
+    it('should return an empty array even when the request fails', async () => {
+      fetchMock.mockRejectOnce(new Error());
+      expect(await argoService.findArgoApp({ name: 'test-app' })).toStrictEqual(
+        [],
+      );
+    });
+
+    it('should return the argo instances using the app selector', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          items: [
+            {
+              metadata: {
+                name: 'testApp-nonprod',
+                namespace: 'argocd',
+                status: {},
+              },
+            },
+          ],
+        }),
+      );
+
+      const resp = await argoService.findArgoApp({
+        selector: 'name=testApp-nonprod',
+      });
+
+      expect(resp).toStrictEqual([
+        {
+          appName: ['testApp-nonprod'],
+          name: 'argoinstance1',
+          url: 'https://argoinstance1.com',
+        },
+      ]);
+    });
+
+    it('returns empty array when get token call fails', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('FetchError'));
+
+      const resp = await argoServiceForNoToken.findArgoApp({
+        selector: 'name=testApp-nonprod',
+      });
+
+      expect(resp).toStrictEqual([]);
+    });
+
+    it('logs error when token call fails', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('FetchError'));
+
+      await argoServiceForNoToken.findArgoApp({
+        selector: 'name=testApp-nonprod',
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error getting token from Argo Instance argoinstance1: FetchError',
+      );
+    });
+  });
+
+  describe('updateArgoProjectAndApp', () => {
+    const data: UpdateArgoProjectAndAppProps = {
+      instanceConfig: {
+        name: 'argoInstanceName',
+        url: 'http://argoinstance.com',
+      },
+      argoToken: 'argoToken',
+      appName: 'appName',
+      projectName: 'projectName',
+      namespace: 'namespace',
+      sourceRepo: 'sourceRepo',
+      sourcePath: 'sourcePath',
+      labelValue: 'labelValue',
+    };
+    const getArgoAppDataResp = {
+      metadata: {
+        name: 'argoInstanceName',
+        resourceVersion: 'resourceVersion',
+      },
+      spec: { source: { repoURL: 'sourceRepo' } },
+      status: {},
+      instance: 'instance',
+    };
+    const getArgoProjectResp = {
+      metadata: { resourceVersion: 'resourceVersion' },
+    };
+    it('should throw error when argo app not found', async () => {
+      fetchMock.mockResponseOnce('', { status: 404 }); // getArgoAppData
+      await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
+        'Request failed with 404 Error',
+      );
+    });
+
+    it('should throw error when source url undefined', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          ...getArgoAppDataResp,
+          spec: { source: { repoURL: '' } },
+        }),
+      ); // getArgoAppData
+      await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
+        'No repo URL found for argo app',
+      );
+    });
+
+    it('should throw error when app resourceVersion undefined', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ ...getArgoAppDataResp, metadata: {} }),
+      ); // getArgoAppData
+      await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
+        'No resourceVersion found for argo app',
+      );
+    });
+
+    it('should throw error when project resourceVersion undefined', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify({ metadata: {} })); // getArgoProject
+      await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
+        'No resourceVersion found for argo project',
+      );
+    });
+
+    it('should throw error when argo project update fails', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify({ message: 'ERROR' }), {
+          status: 500,
+        }); // updateArgoProject
+
+      await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
+        'Error updating argo project: ERROR',
+      );
+    });
+
+    it('should throw error when argo app update fails', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
+        .mockResponseOnce(JSON.stringify({ message: 'ERROR' }), {
+          status: 500,
+        }); // updateArgoApp
+
+      await expect(argoService.updateArgoProjectAndApp(data)).rejects.toThrow(
+        'Error updating argo app: ERROR',
+      );
+    });
+
+    it('should send correct project payload', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoApp
+
+      await argoService.updateArgoProjectAndApp(data);
+
+      const fetchBody = JSON.parse(fetchMock.mock.calls[2][1]?.body as string);
+
+      expect(fetchBody).toStrictEqual(
+        expect.objectContaining({
+          project: {
+            metadata: expect.objectContaining({
+              name: 'projectName',
+            }),
+            spec: expect.objectContaining({
+              destinations: [
+                {
+                  name: 'local',
+                  namespace: 'namespace',
+                  server: 'https://kubernetes.default.svc',
+                },
+              ],
+              sourceRepos: ['sourceRepo'],
+            }),
+          },
+        }),
+      );
+    });
+
+    it('should return true when app and project update succeeds', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoApp
+
+      const resp = await argoService.updateArgoProjectAndApp(data);
+
+      expect(resp).toBe(true);
+    });
+
+    it('should return true when app and project update succeeds and source repo changes', async () => {
+      fetchMock
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // getArgoAppData
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)) // updateArgoApp
+        .mockResponseOnce(JSON.stringify(getArgoProjectResp)) // getArgoProject
+        .mockResponseOnce(JSON.stringify(getArgoAppDataResp)); // updateArgoProject
+
+      const newData = { ...data, sourceRepo: 'newRepo' };
+
+      const resp = await argoService.updateArgoProjectAndApp(newData);
+
+      expect(resp).toBe(true);
+    });
+  });
+
+  describe('getArgoProject', () => {
+    const projectData = { metadata: { resourceVersion: 'resourceVersion' } };
+    const argoProjectReq = {
+      baseUrl: 'http://baseurl.com',
+      argoToken: 'token',
+      projectName: 'projectName',
+    };
+
+    it('should get project data', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(projectData));
+
+      const resp = await argoService.getArgoProject(argoProjectReq);
+
+      expect(resp).toStrictEqual(projectData);
+    });
+
+    it('should throw an error when fail to get project', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ message: 'ERROR' }), {
+        status: 500,
+      });
+
+      await expect(argoService.getArgoProject(argoProjectReq)).rejects.toThrow(
+        'Failed to get argo project: ERROR',
+      );
+    });
+  });
+
+  describe('getArgoApplicationInfo', () => {
+    it('returns argo application data by calling argo api', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          metadata: { name: 'application' },
+        }),
+      );
+
+      const resp = await argoService.getArgoApplicationInfo({
+        argoApplicationName: 'application',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(resp).toEqual(
+        expect.objectContaining({
+          metadata: { name: 'application' },
+          statusCode: 200,
+        }),
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://argoinstance1.com/api/v1/applications/application',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+    });
+
+    it('fails to find argo application data because application of arbitrary argo error', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'some error',
+          message: 'some error',
+        }),
+        { status: 1 },
+      );
+
+      const resp = await argoService.getArgoApplicationInfo({
+        argoApplicationName: 'application',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(resp).toEqual(
+        expect.objectContaining({
+          error: 'some error',
+          message: 'some error',
+          statusCode: 1,
+        }),
+      );
+    });
+
+    it('fails because argo cluster is not found', async () => {
+      await expect(
+        argoService.getArgoApplicationInfo({
+          argoApplicationName: 'application',
+          argoInstanceName: 'cluster',
+        }),
+      ).rejects.toThrow(/does not have argo information/i);
+    });
+
+    it('fails because credentials are incorrect', async () => {
+      const mockGetArgoToken = jest
+        .spyOn(ArgoService.prototype, 'getArgoToken')
+        .mockRejectedValueOnce('Unauthorized');
+
+      await expect(
+        argoServiceForNoToken.getArgoApplicationInfo({
+          argoApplicationName: 'application',
+          argoInstanceName: 'argoinstance1',
+        }),
+      ).rejects.toEqual('Unauthorized');
+
+      expect(mockGetArgoToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails to get argo application information for other reasons', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 });
+
+      await expect(
+        argoService.getArgoApplicationInfo({
+          argoApplicationName: 'application',
+          argoInstanceName: 'argoinstance1',
+        }),
+      ).rejects.toThrow(/invalid json/i);
+    });
+
+    it('gets application information when provided base url and token', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          metadata: { name: 'testApp' },
+        }),
+      );
+
+      const response = await argoService.getArgoApplicationInfo({
+        argoApplicationName: 'application',
+        baseUrl: 'https://argoinstance1.com',
+        argoToken: 'token',
+      });
+
+      expect(response).toEqual(
+        expect.objectContaining({
+          metadata: { name: 'testApp' },
+          statusCode: 200,
+        }),
+      );
+    });
+  });
+
+  describe('resource black and white lists', () => {
+    beforeEach(() => {
+      fetchMock.mockResponseOnce(JSON.stringify({}));
+    });
+
+    it('should include cluster and namespace white and black list if provided in the config', async () => {
+      const service = createService({
+        instanceCredentials: { token: 'token' },
+        clusterResourceWhitelist: [
+          { kind: 'clusterWhitelistKind', group: 'clusterWhitelistGroup' },
+        ],
+        clusterResourceBlacklist: [
+          { kind: 'clusterBlacklistKind', group: 'clusterBlacklistGroup' },
+        ],
+        namespaceResourceWhitelist: [
+          {
+            kind: 'namespaceWhitelistKind',
+            group: 'namespaceWhitelistGroup',
+          },
+        ],
+        namespaceResourceBlacklist: [
+          {
+            kind: 'namespaceBlacklistKind',
+            group: 'namespaceBlacklistGroup',
+          },
+        ],
+      });
+
+      await service.createArgoProject({
         baseUrl: 'http://baseurl.com',
         argoToken: 'token',
         projectName: 'projectName',
-      };
-
-      it('should get project data', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify(projectData));
-
-        const resp = await argoService.getArgoProject(argoProjectReq);
-
-        expect(resp).toStrictEqual(projectData);
+        namespace: 'namespace',
+        sourceRepo: 'repo',
       });
 
-      it('should throw an error when fail to get project', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify({ message: 'ERROR' }), {
-          status: 500,
-        });
-
-        await expect(
-          argoService.getArgoProject(argoProjectReq),
-        ).rejects.toThrow('Failed to get argo project: ERROR');
-      });
+      expect(fetchMock.mock.calls[0][1]?.body).toContain(
+        JSON.stringify([
+          {
+            kind: 'clusterBlacklistKind',
+            group: 'clusterBlacklistGroup',
+          },
+        ]),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).toContain(
+        JSON.stringify([
+          {
+            kind: 'clusterWhitelistKind',
+            group: 'clusterWhitelistGroup',
+          },
+        ]),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).toContain(
+        JSON.stringify([
+          {
+            kind: 'namespaceBlacklistKind',
+            group: 'namespaceBlacklistGroup',
+          },
+        ]),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).toContain(
+        JSON.stringify([
+          {
+            kind: 'namespaceWhitelistKind',
+            group: 'namespaceWhitelistGroup',
+          },
+        ]),
+      );
     });
 
-    describe('getApplicationData', () => {
-      it('returns argo application data by calling argo api', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            metadata: { name: 'application' },
-          }),
-        );
-
-        const resp = await argoService.getArgoApplicationInfo({
-          argoApplicationName: 'application',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toEqual(
-          expect.objectContaining({
-            metadata: { name: 'application' },
-            statusCode: 200,
-          }),
-        );
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          'https://argoinstance1.com/api/v1/applications/application',
-          expect.objectContaining({
-            headers: {
-              Authorization: 'Bearer token',
-              'Content-Type': 'application/json',
-            },
-          }),
-        );
+    it('should not include namespace white or black lists', async () => {
+      const service = createService({
+        instanceCredentials: { token: 'token' },
+        clusterResourceWhitelist: [
+          { kind: 'clusterWhitelistKind', group: 'clusterWhitelistGroup' },
+        ],
+        clusterResourceBlacklist: [
+          { kind: 'clusterBlacklistKind', group: 'clusterBlacklistGroup' },
+        ],
       });
 
-      it('fails to find argo application data because application of arbitrary argo error', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            error: 'some error',
-            message: 'some error',
-          }),
-          { status: 1 },
-        );
-
-        const resp = await argoService.getArgoApplicationInfo({
-          argoApplicationName: 'application',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toEqual(
-          expect.objectContaining({
-            error: 'some error',
-            message: 'some error',
-            statusCode: 1,
-          }),
-        );
+      await service.createArgoProject({
+        baseUrl: 'http://baseurl.com',
+        argoToken: 'token',
+        projectName: 'projectName',
+        namespace: 'namespace',
+        sourceRepo: 'repo',
       });
 
-      it('fails because argo cluster is not found', async () => {
-        await expect(
-          argoService.getArgoApplicationInfo({
-            argoApplicationName: 'application',
-            argoInstanceName: 'cluster',
-          }),
-        ).rejects.toThrow(/does not have argo information/i);
-      });
-
-      it('fails because credentials are incorrect', async () => {
-        const mockGetArgoToken = jest
-          .spyOn(ArgoService.prototype, 'getArgoToken')
-          .mockRejectedValueOnce('Unauthorized');
-
-        await expect(
-          argoServiceForNoToken.getArgoApplicationInfo({
-            argoApplicationName: 'application',
-            argoInstanceName: 'argoinstance1',
-          }),
-        ).rejects.toEqual('Unauthorized');
-
-        expect(mockGetArgoToken).toHaveBeenCalledTimes(1);
-      });
-
-      it('fails to get argo application information for other reasons', async () => {
-        fetchMock.mockResponseOnce('', { status: 500 });
-
-        await expect(
-          argoService.getArgoApplicationInfo({
-            argoApplicationName: 'application',
-            argoInstanceName: 'argoinstance1',
-          }),
-        ).rejects.toThrow(/invalid json/i);
-      });
-
-      it('gets application information when provided base url and token', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            metadata: { name: 'testApp' },
-          }),
-        );
-
-        const response = await argoService.getArgoApplicationInfo({
-          argoApplicationName: 'application',
-          baseUrl: 'https://argoinstance1.com',
-          argoToken: 'token',
-        });
-
-        expect(response).toEqual(
-          expect.objectContaining({
-            metadata: { name: 'testApp' },
-            statusCode: 200,
-          }),
-        );
-      });
+      expect(fetchMock.mock.calls[0][1]?.body).toContain(
+        JSON.stringify([
+          {
+            kind: 'clusterBlacklistKind',
+            group: 'clusterBlacklistGroup',
+          },
+        ]),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).toContain(
+        JSON.stringify([
+          {
+            kind: 'clusterWhitelistKind',
+            group: 'clusterWhitelistGroup',
+          },
+        ]),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
+        JSON.stringify([
+          {
+            kind: 'namespaceBlacklistKind',
+            group: 'namespaceBlacklistGroup',
+          },
+        ]),
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
+        JSON.stringify([
+          {
+            kind: 'namespaceWhitelistKind',
+            group: 'namespaceWhitelistGroup',
+          },
+        ]),
+      );
     });
 
-    describe('resource black and white lists', () => {
-      beforeEach(() => {
-        fetchMock.mockResponseOnce(JSON.stringify({}));
+    it('should not include any black or white lists', async () => {
+      const service = createService({
+        instanceCredentials: { token: 'token' },
       });
 
-      it('should include cluster and namespace white and black list if provided in the config', async () => {
-        const service = createService({
-          instanceCredentials: { token: 'token' },
-          clusterResourceWhitelist: [
-            { kind: 'clusterWhitelistKind', group: 'clusterWhitelistGroup' },
-          ],
-          clusterResourceBlacklist: [
-            { kind: 'clusterBlacklistKind', group: 'clusterBlacklistGroup' },
-          ],
-          namespaceResourceWhitelist: [
-            {
-              kind: 'namespaceWhitelistKind',
-              group: 'namespaceWhitelistGroup',
-            },
-          ],
-          namespaceResourceBlacklist: [
-            {
-              kind: 'namespaceBlacklistKind',
-              group: 'namespaceBlacklistGroup',
-            },
-          ],
-        });
+      await service.createArgoProject({
+        baseUrl: 'http://baseurl.com',
+        argoToken: 'token',
+        projectName: 'projectName',
+        namespace: 'namespace',
+        sourceRepo: 'repo',
+      });
+      expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
+        'clusterResourceWhitelist',
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
+        'clusterResourceBlacklist',
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
+        'namespaceResourceWhitelist',
+      );
+      expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
+        'namespaceResourceBlacklist',
+      );
+    });
+  });
 
-        await service.createArgoProject({
-          baseUrl: 'http://baseurl.com',
-          argoToken: 'token',
-          projectName: 'projectName',
-          namespace: 'namespace',
-          sourceRepo: 'repo',
-        });
+  describe('terminateArgoAppOperation', () => {
+    it('terminates argo application operation by calling argo api with app name and instance provided', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
 
-        expect(fetchMock.mock.calls[0][1]?.body).toContain(
-          JSON.stringify([
-            {
-              kind: 'clusterBlacklistKind',
-              group: 'clusterBlacklistGroup',
-            },
-          ]),
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).toContain(
-          JSON.stringify([
-            {
-              kind: 'clusterWhitelistKind',
-              group: 'clusterWhitelistGroup',
-            },
-          ]),
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).toContain(
-          JSON.stringify([
-            {
-              kind: 'namespaceBlacklistKind',
-              group: 'namespaceBlacklistGroup',
-            },
-          ]),
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).toContain(
-          JSON.stringify([
-            {
-              kind: 'namespaceWhitelistKind',
-              group: 'namespaceWhitelistGroup',
-            },
-          ]),
-        );
+      const resp = await argoService.terminateArgoAppOperation({
+        argoAppName: 'application',
+        argoInstanceName: 'argoinstance1',
       });
 
-      it('should not include namespace white or black lists', async () => {
-        const service = createService({
-          instanceCredentials: { token: 'token' },
-          clusterResourceWhitelist: [
-            { kind: 'clusterWhitelistKind', group: 'clusterWhitelistGroup' },
-          ],
-          clusterResourceBlacklist: [
-            { kind: 'clusterBlacklistKind', group: 'clusterBlacklistGroup' },
-          ],
-        });
+      expect(resp).toEqual(expect.objectContaining({ statusCode: 200 }));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://argoinstance1.com/api/v1/applications/application/operation',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer token',
+            'Content-Type': 'application/json',
+          },
+          method: 'DELETE',
+        }),
+      );
+    });
+    it('terminates argo application operation by calling argo api with app name, baseurl, and token provided', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
 
-        await service.createArgoProject({
-          baseUrl: 'http://baseurl.com',
-          argoToken: 'token',
-          projectName: 'projectName',
-          namespace: 'namespace',
-          sourceRepo: 'repo',
-        });
-
-        expect(fetchMock.mock.calls[0][1]?.body).toContain(
-          JSON.stringify([
-            {
-              kind: 'clusterBlacklistKind',
-              group: 'clusterBlacklistGroup',
-            },
-          ]),
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).toContain(
-          JSON.stringify([
-            {
-              kind: 'clusterWhitelistKind',
-              group: 'clusterWhitelistGroup',
-            },
-          ]),
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
-          JSON.stringify([
-            {
-              kind: 'namespaceBlacklistKind',
-              group: 'namespaceBlacklistGroup',
-            },
-          ]),
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
-          JSON.stringify([
-            {
-              kind: 'namespaceWhitelistKind',
-              group: 'namespaceWhitelistGroup',
-            },
-          ]),
-        );
+      const resp = await argoService.terminateArgoAppOperation({
+        argoAppName: 'application',
+        baseUrl: 'https://passedArgoinstance1.com',
+        argoToken: 'passedToken',
       });
 
-      it('should not include any black or white lists', async () => {
-        const service = createService({
-          instanceCredentials: { token: 'token' },
-        });
-
-        await service.createArgoProject({
-          baseUrl: 'http://baseurl.com',
-          argoToken: 'token',
-          projectName: 'projectName',
-          namespace: 'namespace',
-          sourceRepo: 'repo',
-        });
-        expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
-          'clusterResourceWhitelist',
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
-          'clusterResourceBlacklist',
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
-          'namespaceResourceWhitelist',
-        );
-        expect(fetchMock.mock.calls[0][1]?.body).not.toContain(
-          'namespaceResourceBlacklist',
-        );
-      });
+      expect(resp).toEqual(expect.objectContaining({ statusCode: 200 }));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /https:\/\/passedargoinstance1\.com\/api\/v1\/applications\/application\/operation/i,
+        ),
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer passedToken',
+            'Content-Type': 'application/json',
+          },
+          method: 'DELETE',
+        }),
+      );
     });
 
-    describe('terminateArgoAppOperation', () => {
-      it('terminates argo application operation by calling argo api with app name and instance provided', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
+    it('fails to terminate operation because of some arbitrary argo api error', async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'some error',
+          message: 'some error',
+        }),
+        { status: 1 },
+      );
 
-        const resp = await argoService.terminateArgoAppOperation({
+      const resp = await argoService.terminateArgoAppOperation({
+        argoAppName: 'application',
+        argoInstanceName: 'argoinstance1',
+      });
+
+      expect(resp).toEqual(
+        expect.objectContaining({
+          error: 'some error',
+          message: 'some error',
+          statusCode: 1,
+        }),
+      );
+    });
+
+    it('fails because credentials are incorrect', async () => {
+      const mockGetArgoToken = jest
+        .spyOn(ArgoService.prototype, 'getArgoToken')
+        .mockRejectedValueOnce('Unauthorized');
+
+      await expect(
+        argoServiceForNoToken.terminateArgoAppOperation({
           argoAppName: 'application',
           argoInstanceName: 'argoinstance1',
-        });
+        }),
+      ).rejects.toEqual('Unauthorized');
 
-        expect(resp).toEqual(expect.objectContaining({ statusCode: 200 }));
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          'https://argoinstance1.com/api/v1/applications/application/operation',
-          expect.objectContaining({
-            headers: {
-              Authorization: 'Bearer token',
-              'Content-Type': 'application/json',
-            },
-            method: 'DELETE',
-          }),
-        );
-      });
-      it('terminates argo application operation by calling argo api with app name, baseurl, and token provided', async () => {
-        fetchMock.mockResponseOnce(JSON.stringify({}), { status: 200 });
-
-        const resp = await argoService.terminateArgoAppOperation({
-          argoAppName: 'application',
-          baseUrl: 'https://passedArgoinstance1.com',
-          argoToken: 'passedToken',
-        });
-
-        expect(resp).toEqual(expect.objectContaining({ statusCode: 200 }));
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          expect.stringMatching(
-            /https:\/\/passedargoinstance1\.com\/api\/v1\/applications\/application\/operation/i,
-          ),
-          expect.objectContaining({
-            headers: {
-              Authorization: 'Bearer passedToken',
-              'Content-Type': 'application/json',
-            },
-            method: 'DELETE',
-          }),
-        );
-      });
-
-      it('fails to terminate operation because of some arbitrary argo api error', async () => {
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            error: 'some error',
-            message: 'some error',
-          }),
-          { status: 1 },
-        );
-
-        const resp = await argoService.terminateArgoAppOperation({
-          argoAppName: 'application',
-          argoInstanceName: 'argoinstance1',
-        });
-
-        expect(resp).toEqual(
-          expect.objectContaining({
-            error: 'some error',
-            message: 'some error',
-            statusCode: 1,
-          }),
-        );
-      });
-
-      it('fails because credentials are incorrect', async () => {
-        const mockGetArgoToken = jest
-          .spyOn(ArgoService.prototype, 'getArgoToken')
-          .mockRejectedValueOnce('Unauthorized');
-
-        await expect(
-          argoServiceForNoToken.terminateArgoAppOperation({
-            argoAppName: 'application',
-            argoInstanceName: 'argoinstance1',
-          }),
-        ).rejects.toEqual('Unauthorized');
-
-        expect(mockGetArgoToken).toHaveBeenCalledTimes(1);
-      });
-
-      it('fails because argo cluster is not found', async () => {
-        await expect(
-          argoService.terminateArgoAppOperation({
-            argoAppName: 'application',
-            argoInstanceName: 'cluster',
-          }),
-        ).rejects.toThrow(/does not have argo information/i);
-      });
-
-      it('raises error if argo instance not included and either base url or token not included', async () => {
-        await expect(
-          argoService.terminateArgoAppOperation({
-            argoAppName: 'application',
-            argoToken: 'token',
-            baseUrl: '',
-          }),
-        ).rejects.toThrow(/argo instance must be defined/i);
-      });
-
-      it('fails to get argo application information for other reasons', async () => {
-        fetchMock.mockResponseOnce('', { status: 500 });
-
-        await expect(
-          argoService.terminateArgoAppOperation({
-            argoAppName: 'application',
-            argoInstanceName: 'argoinstance1',
-          }),
-        ).rejects.toThrow(/invalid json/i);
-      });
+      expect(mockGetArgoToken).toHaveBeenCalledTimes(1);
     });
 
-    describe('getArgoToken', () => {
-      it('uses token from argo instance when only token provided', async () => {
-        const argoCdService = createService({
-          instanceCredentials: { token: 'token' },
-        });
+    it('fails because argo cluster is not found', async () => {
+      await expect(
+        argoService.terminateArgoAppOperation({
+          argoAppName: 'application',
+          argoInstanceName: 'cluster',
+        }),
+      ).rejects.toThrow(/does not have argo information/i);
+    });
 
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
+    it('raises error if argo instance not included and either base url or token not included', async () => {
+      await expect(
+        argoService.terminateArgoAppOperation({
+          argoAppName: 'application',
+          argoToken: 'token',
+          baseUrl: '',
+        }),
+      ).rejects.toThrow(/argo instance must be defined/i);
+    });
 
-        expect(token).toEqual('token');
-        expect(fetchMock).not.toHaveBeenCalled();
+    it('fails to get argo application information for other reasons', async () => {
+      fetchMock.mockResponseOnce('', { status: 500 });
+
+      await expect(
+        argoService.terminateArgoAppOperation({
+          argoAppName: 'application',
+          argoInstanceName: 'argoinstance1',
+        }),
+      ).rejects.toThrow(/invalid json/i);
+    });
+  });
+
+  describe('getArgoToken', () => {
+    it('uses token from argo instance when only token provided', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { token: 'token' },
       });
 
-      it('prioritizes token from argo instance when token, username, and password provided', async () => {
-        const argoCdService = createService({
-          instanceCredentials: {
-            token: 'token',
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
+
+      expect(token).toEqual('token');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('prioritizes token from argo instance when token, username, and password provided', async () => {
+      const argoCdService = createService({
+        instanceCredentials: {
+          token: 'token',
+          username: 'username',
+          password: 'password',
+        },
+      });
+
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
+
+      expect(token).toEqual('token');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('retrieves argo token using instance level username and password when upper level username and password is not provided', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
+      });
+      fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
+
+      const token = await argoCdService.getArgoToken(
+        argoServiceForNoToken.instanceConfigs[0],
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
+        expect.objectContaining({
+          body: JSON.stringify({ username: 'user', password: 'pass' }),
+        }),
+      );
+      expect(token).toEqual('token');
+    });
+
+    it('uses instance level token when upper level username and password provided', async () => {
+      const argoConfig = getConfig({
+        instanceCredentials: { token: 'token' },
+      });
+      const argoCdService = new ArgoService(
+        'upper-level-username',
+        'upper-level-password',
+        argoConfig,
+        logger,
+      );
+
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
+
+      expect(token).toEqual('token');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('retrieves argo token using instance level username and password when upper level username and password provided', async () => {
+      const argoConfig = getConfig({
+        instanceCredentials: { username: 'username', password: 'password' },
+      });
+      const argoCdService = new ArgoService(
+        'upper-level-username',
+        'upper-level-password',
+        argoConfig,
+        logger,
+      );
+
+      fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
+
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
+        expect.objectContaining({
+          body: JSON.stringify({
             username: 'username',
             password: 'password',
-          },
-        });
-
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
-
-        expect(token).toEqual('token');
-        expect(fetchMock).not.toHaveBeenCalled();
-      });
-
-      it('retrieves argo token using instance level username and password when upper level username and password is not provided', async () => {
-        const argoCdService = createService({
-          instanceCredentials: { username: 'username', password: 'password' },
-        });
-        fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
-
-        const token = await argoCdService.getArgoToken(
-          argoServiceForNoToken.instanceConfigs[0],
-        );
-
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
-          expect.objectContaining({
-            body: JSON.stringify({ username: 'user', password: 'pass' }),
           }),
-        );
-        expect(token).toEqual('token');
-      });
+        }),
+      );
+      expect(token).toEqual('token');
+    });
 
-      it('uses instance level token when upper level username and password provided', async () => {
-        const argoConfig = getConfig({
-          instanceCredentials: { token: 'token' },
-        });
-        const argoCdService = new ArgoService(
-          'upper-level-username',
-          'upper-level-password',
-          argoConfig,
-          logger,
-        );
+    it('retrieves argo token using upper level username and password when no instance credentials provided', async () => {
+      const argoConfig = getConfig({});
+      const argoCdService = new ArgoService(
+        'upper-level-username',
+        'upper-level-password',
+        argoConfig,
+        logger,
+      );
 
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
+      fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
 
-        expect(token).toEqual('token');
-        expect(fetchMock).not.toHaveBeenCalled();
-      });
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
 
-      it('retrieves argo token using instance level username and password when upper level username and password provided', async () => {
-        const argoConfig = getConfig({
-          instanceCredentials: { username: 'username', password: 'password' },
-        });
-        const argoCdService = new ArgoService(
-          'upper-level-username',
-          'upper-level-password',
-          argoConfig,
-          logger,
-        );
-
-        fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
-
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
-
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
-          expect.objectContaining({
-            body: JSON.stringify({
-              username: 'username',
-              password: 'password',
-            }),
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            username: 'upper-level-username',
+            password: 'upper-level-password',
           }),
-        );
-        expect(token).toEqual('token');
+        }),
+      );
+      expect(token).toEqual('token');
+    });
+
+    it('retrieves argo token using azure credentials when no other credentials provided', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const argoConfig = getConfig({
+        otherRootConfigs: { azure: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
+      });
+      const argoCdService = new ArgoService('', '', argoConfig, logger);
+
+      fetchMock.mockResponseOnce(
+        JSON.stringify({ access_token: 'azure_token' }),
+      );
+
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${azureConfig.loginUrl}/${azureConfig.tenantId}/oauth2/v2.0/token`,
+        expect.objectContaining({
+          body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            client_id: azureConfig.clientId,
+            client_secret: azureConfig.clientSecret,
+            scope: `${azureConfig.clientId}/.default`,
+          }).toString(),
+        }),
+      );
+      expect(token).toEqual('azure_token');
+    });
+
+    it('throws when unable to get argo token from azure login', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const argoConfig = getConfig({
+        otherRootConfigs: { azure: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
+      });
+      const argoCdService = new ArgoService('', '', argoConfig, logger);
+
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          error: 'error',
+          error_description: 'error_description',
+          error_codes: [1],
+        }),
+        {
+          status: 2,
+        },
+      );
+
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow(
+        'Failed to get argo token through your azure config credentials: error_description (error, codes: [1], status code: 2)',
+      );
+    });
+
+    it('returns instance level token from argo instance when azure credentials provided', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const argoConfig = getConfig({
+        otherRootConfigs: { azure: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
+        instanceCredentials: { token: 'token' },
+      });
+      const argoCdService = ArgoService.fromConfig({
+        config: argoConfig,
+        logger,
       });
 
-      it('retrieves argo token using upper level username and password when no instance credentials provided', async () => {
-        const argoConfig = getConfig({});
-        const argoCdService = new ArgoService(
-          'upper-level-username',
-          'upper-level-password',
-          argoConfig,
-          logger,
-        );
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
 
-        fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(token).toBe('token');
+    });
 
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
+    it('retrieves argo token using instance level username and password when azure credentials provided', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const argoConfig = getConfig({
+        otherRootConfigs: { azure: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
+        instanceCredentials: { username: 'username', password: 'password' },
+      });
+      const argoCdService = ArgoService.fromConfig({
+        config: argoConfig,
+        logger,
+      });
+      fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
-          expect.objectContaining({
-            body: JSON.stringify({
-              username: 'upper-level-username',
-              password: 'upper-level-password',
-            }),
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            username: 'username',
+            password: 'password',
           }),
-        );
-        expect(token).toEqual('token');
+        }),
+      );
+      expect(token).toEqual('token');
+    });
+
+    it('retrieves argo token using upper level username and password when azure credentials provided', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const argoConfig = getConfig({
+        otherRootConfigs: { azure: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
       });
+      const argoCdService = new ArgoService(
+        'upper-level-username',
+        'upper-level-password',
+        argoConfig,
+        logger,
+      );
+      fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
+      const token = await argoCdService.getArgoToken(
+        argoCdService.instanceConfigs[0],
+      );
 
-      it('retrieves argo token using azure credentials when no other credentials provided', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const argoConfig = getConfig({
-          otherRootConfigs: { azure: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
-        });
-        const argoCdService = new ArgoService('', '', argoConfig, logger);
-
-        fetchMock.mockResponseOnce(
-          JSON.stringify({ access_token: 'azure_token' }),
-        );
-
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
-
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          `${azureConfig.loginUrl}/${azureConfig.tenantId}/oauth2/v2.0/token`,
-          expect.objectContaining({
-            body: new URLSearchParams({
-              grant_type: 'client_credentials',
-              client_id: azureConfig.clientId,
-              client_secret: azureConfig.clientSecret,
-              scope: `${azureConfig.clientId}/.default`,
-            }).toString(),
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
+        expect.objectContaining({
+          body: JSON.stringify({
+            username: 'upper-level-username',
+            password: 'upper-level-password',
           }),
-        );
-        expect(token).toEqual('azure_token');
+        }),
+      );
+      expect(token).toEqual('token');
+    });
+
+    it('throws when upper level username and password, argoInstanceConfig, and azureCredentials are undefined', async () => {
+      const argoConfig = getConfig({});
+      const argoCdService = new ArgoService('', '', argoConfig, logger);
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow('Missing credentials in config for Argo Instance.');
+    });
+
+    it('retreives azure credentials from config based on provider config key', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const argoConfigAzure = getConfig({
+        otherRootConfigs: { azure: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
+      });
+      const getSpy = jest.spyOn(argoConfigAzure, 'get');
+      fetchMock.mockResponse(JSON.stringify({ token: 'token' }));
+      const argoCdService = new ArgoService('', '', argoConfigAzure, logger);
+      await argoCdService.getArgoToken(argoCdService.instanceConfigs[0]);
+
+      expect(getSpy).toHaveBeenCalledWith('azure');
+
+      const argoConfigNotAzure = getConfig({
+        otherRootConfigs: { test: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey: 'test' },
+      });
+      const getSpyNotAzure = jest.spyOn(argoConfigNotAzure, 'get');
+      const argoCdServiceNotAzure = new ArgoService(
+        '',
+        '',
+        argoConfigNotAzure,
+        logger,
+      );
+      await argoCdServiceNotAzure.getArgoToken(
+        argoCdServiceNotAzure.instanceConfigs[0],
+      );
+
+      expect(getSpyNotAzure).toHaveBeenCalledWith('test');
+    });
+
+    it('throws when provider config key is not found in config', async () => {
+      const azureConfig = {
+        tenantId: 'tenantId',
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+        loginUrl: 'loginUrl',
+      };
+      const providerConfigKey = 'notHere';
+      const argoConfig = getConfig({
+        otherRootConfigs: { here: azureConfig },
+        oidcConfig: { provider: 'azure', providerConfigKey },
+      });
+      const argoCdService = new ArgoService('', '', argoConfig, logger);
+      const getSpy = jest.spyOn(argoConfig, 'get');
+
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow(
+        `Missing required config value at '${providerConfigKey}' in ''`,
+      );
+
+      expect(getSpy).toHaveBeenCalledWith(providerConfigKey);
+    });
+
+    it('throws when getting token returns an unexpected html response instead of json', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
       });
 
-      it('throws when unable to get argo token from azure login', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const argoConfig = getConfig({
-          otherRootConfigs: { azure: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
-        });
-        const argoCdService = new ArgoService('', '', argoConfig, logger);
-
-        fetchMock.mockResponseOnce(
-          JSON.stringify({
-            error: 'error',
-            error_description: 'error_description',
-            error_codes: [1],
-          }),
-          {
-            status: 2,
-          },
-        );
-
-        await expect(
-          argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
-        ).rejects.toThrow(
-          'Failed to get argo token through your azure config credentials: error_description (error, codes: [1], status code: 2)',
-        );
+      fetchMock.mockResponseOnce('<html>error page</html>', {
+        status: 1,
+        headers: {
+          'content-type': 'text/html',
+        },
       });
 
-      it('returns instance level token from argo instance when azure credentials provided', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const argoConfig = getConfig({
-          otherRootConfigs: { azure: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
-          instanceCredentials: { token: 'token' },
-        });
-        const argoCdService = ArgoService.fromConfig({
-          config: argoConfig,
-          logger,
-        });
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow(/unexpected HTML response/i);
+    });
+  });
 
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
-
-        expect(fetchMock).not.toHaveBeenCalled();
-        expect(token).toBe('token');
+  describe('parseJson', () => {
+    // private function tested indirectly through getArgoToken
+    it('throws when getting token returns an unexpected html response instead of json', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
       });
 
-      it('retrieves argo token using instance level username and password when azure credentials provided', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const argoConfig = getConfig({
-          otherRootConfigs: { azure: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
-          instanceCredentials: { username: 'username', password: 'password' },
-        });
-        const argoCdService = ArgoService.fromConfig({
-          config: argoConfig,
-          logger,
-        });
-        fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
-
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
-          expect.objectContaining({
-            body: JSON.stringify({
-              username: 'username',
-              password: 'password',
-            }),
-          }),
-        );
-        expect(token).toEqual('token');
+      fetchMock.mockResponseOnce('<html>error page</html>', {
+        status: 1,
+        headers: {
+          'content-type': 'text/html',
+        },
       });
 
-      it('retrieves argo token using upper level username and password when azure credentials provided', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const argoConfig = getConfig({
-          otherRootConfigs: { azure: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
-        });
-        const argoCdService = new ArgoService(
-          'upper-level-username',
-          'upper-level-password',
-          argoConfig,
-          logger,
-        );
-        fetchMock.mockResponseOnce(JSON.stringify({ token: 'token' }));
-        const token = await argoCdService.getArgoToken(
-          argoCdService.instanceConfigs[0],
-        );
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow(/unexpected HTML response/i);
+    });
 
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-        expect(fetchMock).toHaveBeenCalledWith(
-          `${argoCdService.instanceConfigs[0].url}/api/v1/session`,
-          expect.objectContaining({
-            body: JSON.stringify({
-              username: 'upper-level-username',
-              password: 'upper-level-password',
-            }),
-          }),
-        );
-        expect(token).toEqual('token');
+    it('includes url in thrown message when getting token returns an unexpected html response instead of json', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
       });
 
-      it('throws when upper level username and password, argoInstanceConfig, and azureCredentials are undefined', async () => {
-        const argoConfig = getConfig({});
-        const argoCdService = new ArgoService('', '', argoConfig, logger);
-        await expect(
-          argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
-        ).rejects.toThrow('Missing credentials in config for Argo Instance.');
+      fetchMock.mockResponseOnce('<html>error page</html>', {
+        status: 1,
+        headers: {
+          'content-type': 'text/html',
+        },
       });
 
-      it('retreives azure credentials from config based on provider config key', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const argoConfigAzure = getConfig({
-          otherRootConfigs: { azure: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'azure' },
-        });
-        const getSpy = jest.spyOn(argoConfigAzure, 'get');
-        fetchMock.mockResponse(JSON.stringify({ token: 'token' }));
-        const argoCdService = new ArgoService('', '', argoConfigAzure, logger);
-        await argoCdService.getArgoToken(argoCdService.instanceConfigs[0]);
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow(/\/api\/v1\/session/i);
+    });
 
-        expect(getSpy).toHaveBeenCalledWith('azure');
-
-        const argoConfigNotAzure = getConfig({
-          otherRootConfigs: { test: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey: 'test' },
-        });
-        const getSpyNotAzure = jest.spyOn(argoConfigNotAzure, 'get');
-        const argoCdServiceNotAzure = new ArgoService(
-          '',
-          '',
-          argoConfigNotAzure,
-          logger,
-        );
-        await argoCdServiceNotAzure.getArgoToken(
-          argoCdServiceNotAzure.instanceConfigs[0],
-        );
-
-        expect(getSpyNotAzure).toHaveBeenCalledWith('test');
+    it('logs html body when getting token returns an unexpected html response instead of json', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
       });
 
-      it('throws when provider config key is not found in config', async () => {
-        const azureConfig = {
-          tenantId: 'tenantId',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-          loginUrl: 'loginUrl',
-        };
-        const providerConfigKey = 'notHere';
-        const argoConfig = getConfig({
-          otherRootConfigs: { here: azureConfig },
-          oidcConfig: { provider: 'azure', providerConfigKey },
-        });
-        const argoCdService = new ArgoService('', '', argoConfig, logger);
-        const getSpy = jest.spyOn(argoConfig, 'get');
-
-        await expect(
-          argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
-        ).rejects.toThrow(
-          `Missing required config value at '${providerConfigKey}' in ''`,
-        );
-
-        expect(getSpy).toHaveBeenCalledWith(providerConfigKey);
+      fetchMock.mockResponseOnce('<html>error page</html>', {
+        status: 1,
+        headers: {
+          'content-type': 'text/html',
+        },
       });
+
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow();
+
+      expect(logger.debug).toHaveBeenCalledWith('<html>error page</html>');
+    });
+
+    it('does not log when response content type includes application json to prevent sensitive data logs', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
+      });
+
+      fetchMock.mockResponseOnce('<html>error page</html>', {
+        status: 1,
+        headers: {
+          'content-type': 'text/html; application/json',
+        },
+      });
+
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow();
+
+      expect(logger.debug).not.toHaveBeenCalled();
+    });
+
+    it('reads the response body safely without consuming the original response', async () => {
+      const argoCdService = createService({
+        instanceCredentials: { username: 'username', password: 'password' },
+      });
+
+      const response = new Response('<html>error page</html>', {
+        status: 1,
+        headers: { 'content-type': 'text/html' },
+      });
+      const textMock = jest.fn().mockResolvedValue('<html>error page</html>');
+      const cloneMock = jest.fn().mockReturnValue({
+        text: textMock,
+      });
+
+      Object.defineProperty(response, 'clone', {
+        value: cloneMock,
+        configurable: true,
+      });
+
+      fetchMock.mockResolvedValueOnce(response);
+
+      await expect(
+        argoCdService.getArgoToken(argoCdService.instanceConfigs[0]),
+      ).rejects.toThrow(/unexpected HTML response/i);
+
+      expect(cloneMock).toHaveBeenCalledTimes(1);
+      expect(textMock).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
We want to add two small new features:
- We added a debug level log when the Argo Session API returns an unexpected HTML response.
- We are now throwing intentionally when the response is an html, rather than the error thrown when we try to parse a non-json response.


Reasoning: Depending on the deployment environment, traffic to the Argo API may pass through edge security, web application firewall (WAF), or content delivery network (CDN) services such as Akamai, F5, or Cloudflare. When routing failures occur, these services may return an HTML response instead of the expected API response.

Previously, these responses were truncated in logs (see image below), making it difficult to access diagnostic information — such as reference IDs — that can help identify the source of the failure. This change improves observability by logging unexpected HTML responses, providing additional context for troubleshooting and root-cause analysis. For context, the truncation happens when [we try to parse the html as a json](https://github.com/AmericanAirlines/roadie-backstage-plugins/blob/main/plugins/backend/backstage-plugin-argo-cd-node/src/service/argocd.service.ts#L267).

<img width="797" height="150" alt="Screenshot 2026-08-13 at 5 38 33 PM" src="https://github.com/user-attachments/assets/697b6a0c-9a8a-43c8-a4c0-41cc797b71ab" />

Behavior: No functional behavior has changed. This change only adds additional warning-level logging for unexpected HTML responses to the session endpoint. Does not log when content type includes application/json

New Log - would include helpful troubleshooting information like reference ids:

<img width="503" height="93" alt="Screenshot 2026-08-13 at 5 37 23 PM" src="https://github.com/user-attachments/assets/db49f41d-ca08-4573-98f0-e1dc33a6ce5a" />

Additional Change to TESTS:

I noticed the unit tests were nested under the wrong "describe" so I moved it out just for organizational purposes. You can view the actual changes by **HIDING THE WHITE SPACE**



#### :heavy_check_mark: Checklist

- [x] Added tests for new functionality and regression tests for bug fixes
- [x] Added changeset (run `yarn changeset` in the root)
- [x] Screenshots of before and after attached (for UI changes)
- [ ] Added or updated documentation (if applicable)
